### PR TITLE
Detect when asset has metadata only, and render in a Meta Only Page

### DIFF
--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -83,19 +83,4 @@ defineEmits<{
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
-
-.ticker {
-  animation: 8s ticker infinite linear;
-}
-
-@keyframes ticker {
-  0% {
-    transform: translate3d(0, 0, 0);
-    visibility: visible;
-  }
-
-  100% {
-    transform: translate3d(-100%, 0, 0);
-  }
-}
 </style>

--- a/src/pages/AssetViewPage.stories.ts
+++ b/src/pages/AssetViewPage.stories.ts
@@ -3,6 +3,9 @@ import AssetViewPage from "@/pages/AssetViewPage.vue";
 
 export default {
   component: AssetViewPage,
+  parameters: {
+    layout: "fullscreen",
+  },
 } as Meta<typeof AssetViewPage>;
 
 const Template: StoryFn<typeof AssetViewPage> = (args) => ({
@@ -20,23 +23,19 @@ export const Default = Template.bind({});
 Default.args = {
   assetId: "56a3bb007d58ae8a488b4657",
 };
-Default.parameters = {
-  layout: "fullscreen",
-};
 
 export const WithObjectId = Template.bind({});
 WithObjectId.args = {
   assetId: "56a3bb007d58ae8a488b4657",
   objectId: "632dfcc223e48b6a531c8832",
 };
-WithObjectId.parameters = {
-  layout: "fullscreen",
-};
 
 export const MockAssetPage = Template.bind({});
 MockAssetPage.args = {
   assetId: "623dee393392272653676222",
 };
-MockAssetPage.parameters = {
-  layout: "fullscreen",
+
+export const WithNoObjectView = Template.bind({});
+WithNoObjectView.args = {
+  assetId: "56a3bb007d58ae8a488b465c",
 };

--- a/src/pages/AssetViewPage.vue
+++ b/src/pages/AssetViewPage.vue
@@ -1,6 +1,9 @@
 <template>
   <div v-if="isPageLoaded">
-    <MetaDataOnlyPage v-if="isMetaDataOnly" :assetId="assetId" />
+    <MetaDataOnlyPage
+      v-if="isMetaDataOnly"
+      :assetId="assetStore.activeAssetId"
+    />
     <div
       v-else
       class="asset-view-page bg-neutral-300"

--- a/src/pages/AssetViewPage.vue
+++ b/src/pages/AssetViewPage.vue
@@ -1,5 +1,7 @@
 <template>
+  <MetaDataOnlyPage v-if="!hasObjectFileToView" :assetId="assetId" />
   <div
+    v-else
     class="asset-view-page bg-neutral-300"
     :class="{
       'is-asset-details-open': isAssetDetailsOpen,
@@ -25,11 +27,14 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import { useAssetStore } from "@/stores/assetStore";
 import ObjectViewer from "@/components/ObjectViewer/ObjectViewer.vue";
 import ObjectDetailsDrawer from "@/components/ObjectDetailsDrawer/ObjectDetailsDrawer.vue";
 import AssetDetailsDrawer from "@/components/AssetDetailsDrawer/AssetDetailsDrawer.vue";
+import type { Asset } from "@/types";
+import { getAssetTitle } from "@/helpers/displayUtils";
+import MetaDataOnlyPage from "./MetaDataOnlyPage.vue";
 
 const props = defineProps<{
   assetId: string;
@@ -42,8 +47,8 @@ const props = defineProps<{
 
 const isAssetDetailsOpen = ref(true);
 const isObjectDetailsOpen = ref(false);
-
 const assetStore = useAssetStore();
+const hasObjectFileToView = computed(() => assetStore.activeFileObjectId);
 
 watch(
   [() => props.assetId],
@@ -68,6 +73,17 @@ watch(
 
 .asset-view-page__object-details {
   grid-area: object-details;
+}
+
+.asset-view-page.has-no-object-file-to-view {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "asset-details"
+    "object-details";
+}
+
+.asset-view-page.has-no-object-file-to-view .asset-view-page__viewer {
+  display: none;
 }
 
 @media (max-width: 639px) {

--- a/src/pages/MetaDataOnlyPage.stories.ts
+++ b/src/pages/MetaDataOnlyPage.stories.ts
@@ -1,0 +1,22 @@
+import { Meta, StoryFn } from "@storybook/vue3";
+import MetaDataOnlyPage from "./MetaDataOnlyPage.vue";
+
+export default {
+  component: MetaDataOnlyPage,
+} as Meta<typeof MetaDataOnlyPage>;
+
+const Template: StoryFn<typeof MetaDataOnlyPage> = (args) => ({
+  components: { MetaDataOnlyPage },
+  setup() {
+    return { args };
+  },
+  template: `
+    <MetaDataOnlyPage v-bind="args">
+    </MetaDataOnlyPage>
+  `,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  assetId: "56a3bb007d58ae8a488b465c",
+};

--- a/src/pages/MetaDataOnlyPage.stories.ts
+++ b/src/pages/MetaDataOnlyPage.stories.ts
@@ -3,6 +3,9 @@ import MetaDataOnlyPage from "./MetaDataOnlyPage.vue";
 
 export default {
   component: MetaDataOnlyPage,
+  parameters: {
+    layout: "fullscreen",
+  },
 } as Meta<typeof MetaDataOnlyPage>;
 
 const Template: StoryFn<typeof MetaDataOnlyPage> = (args) => ({

--- a/src/pages/MetaDataOnlyPage.vue
+++ b/src/pages/MetaDataOnlyPage.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="h-screen bg-neutral-300 sm:p-8">
     <article
-      class="m-auto sm:max-w-xl bg-white h-full overflow-auto p-4 sm:p-12 rounded shadow sm:px-8"
+      class="m-auto sm:max-w-3xl bg-white h-full overflow-auto p-4 sm:p-12 rounded shadow sm:px-8"
     >
       <h2
-        class="text-3xl mb-12 md:text-5xl font-bold py-8 after:content-[''] after:w-8 after:bg-neutral-900 after:h-2 after:block relative after:absolute after:bottom-0 after:left-0"
+        class="text-3xl mb-12 sm:text-5xl font-bold py-8 after:content-[''] after:w-8 after:bg-neutral-900 after:h-2 after:block relative after:absolute after:bottom-0 after:left-0"
       >
         {{ assetTitle }}
       </h2>

--- a/src/pages/MetaDataOnlyPage.vue
+++ b/src/pages/MetaDataOnlyPage.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="h-screen bg-neutral-300 sm:p-8">
+    <article
+      class="m-auto sm:max-w-xl bg-white h-full overflow-auto p-4 sm:p-12 rounded shadow sm:px-8 sm:border"
+    >
+      <h2
+        class="text-3xl mb-12 md:text-5xl font-bold py-8 after:content-[''] after:w-8 after:bg-neutral-900 after:h-2 after:block relative after:absolute after:bottom-0 after:left-0"
+      >
+        {{ assetTitle }}
+      </h2>
+
+      <WidgetList :assetId="assetId" />
+    </article>
+  </div>
+</template>
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { useAssetStore } from "@/stores/assetStore";
+import type { Asset } from "@/types";
+import { getAssetTitle } from "@/helpers/displayUtils";
+import WidgetList from "@/components/WidgetList/WidgetList.vue";
+
+const props = defineProps<{
+  assetId: string;
+}>();
+
+const asset = ref<Asset | null>(null);
+const assetStore = useAssetStore();
+const assetTitle = computed(() =>
+  asset.value ? getAssetTitle(asset.value) : ""
+);
+
+watch(
+  () => props.assetId,
+  async () => {
+    if (!props.assetId) return;
+    asset.value = await assetStore.fetchAsset(props.assetId);
+  },
+  { immediate: true }
+);
+</script>
+<style scoped></style>

--- a/src/pages/MetaDataOnlyPage.vue
+++ b/src/pages/MetaDataOnlyPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-screen bg-neutral-300 sm:p-8">
     <article
-      class="m-auto sm:max-w-xl bg-white h-full overflow-auto p-4 sm:p-12 rounded shadow sm:px-8 sm:border"
+      class="m-auto sm:max-w-xl bg-white h-full overflow-auto p-4 sm:p-12 rounded shadow sm:px-8"
     >
       <h2
         class="text-3xl mb-12 md:text-5xl font-bold py-8 after:content-[''] after:w-8 after:bg-neutral-900 after:h-2 after:block relative after:absolute after:bottom-0 after:left-0"
@@ -39,4 +39,23 @@ watch(
   { immediate: true }
 );
 </script>
-<style scoped></style>
+<style scoped>
+::-webkit-scrollbar {
+  width: 0.5rem;
+}
+
+/* Track */
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 33%);
+}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  background: #aaa;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+</style>

--- a/src/pages/MetaDataOnlyPage.vue
+++ b/src/pages/MetaDataOnlyPage.vue
@@ -9,7 +9,7 @@
         {{ assetTitle }}
       </h2>
 
-      <WidgetList :assetId="assetId" />
+      <WidgetList v-if="assetId" :assetId="assetId" />
     </article>
   </div>
 </template>
@@ -21,13 +21,13 @@ import { getAssetTitle } from "@/helpers/displayUtils";
 import WidgetList from "@/components/WidgetList/WidgetList.vue";
 
 const props = defineProps<{
-  assetId: string;
+  assetId: string | null;
 }>();
 
 const asset = ref<Asset | null>(null);
 const assetStore = useAssetStore();
 const assetTitle = computed(() =>
-  asset.value ? getAssetTitle(asset.value) : ""
+  asset.value ? getAssetTitle(asset.value) : "Unknown"
 );
 
 watch(


### PR DESCRIPTION
This adds a story and view for metadata only assets. When an asset is loaded, if no `firstFileHandlerId` is present, the asset it determined to be "meta-data only", and renders the data without a viewer.

The view is minimal. (Once the share and download tools are implemented, we can add those to the bottom or side).

Large screen:
<img  width="800" alt="Screen Shot 2022-09-28 at 6 05 21 PM" src="https://user-images.githubusercontent.com/980170/192904189-cc438786-8afb-4081-bc25-3a95ccbf78b7.png">

Small screen:
<img width="200" alt="Screen Shot 2022-09-28 at 6 05 32 PM" src="https://user-images.githubusercontent.com/980170/192904212-b46acee6-b3d3-4ce9-b7f1-445b4a3f917a.png">

