### PR TITLE
Limit number of  inline results of More Like This section

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -20,7 +20,11 @@
         <header
           class="modal-contents__header flex justify-between items-start p-4 md:p-8"
         >
-          <h2 class="flex-1 font-bold text-2xl mr-12">{{ label }}</h2>
+          <h2 class="flex-1 font-bold text-2xl mr-12">
+            <slot name="label">
+              {{ label }}
+            </slot>
+          </h2>
         </header>
         <div class="modal-contents__body flex-1 overflow-auto p-4 md:p-8">
           <slot />

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -20,7 +20,7 @@
         <header
           class="modal-contents__header flex justify-between items-start p-4 md:p-8"
         >
-          <h2 class="flex-1 font-bold text-2xl mr-12">
+          <h2 class="flex-1 font-bold text-2xl mr-12 flex items-center">
             <slot name="label">
               {{ label }}
             </slot>

--- a/src/components/MoreLikeThis/ButtonWithCount.vue
+++ b/src/components/MoreLikeThis/ButtonWithCount.vue
@@ -1,0 +1,17 @@
+<template>
+  <Button variant="primary">
+    <slot />
+    <MoreLikeThisCountChip>
+      {{ count }}
+    </MoreLikeThisCountChip>
+  </Button>
+</template>
+<script setup lang="ts">
+import MoreLikeThisCountChip from "./CountChip.vue";
+import Button from "../Button/Button.vue";
+
+defineProps<{
+  count: number;
+}>();
+</script>
+<style scoped></style>

--- a/src/components/MoreLikeThis/ButtonWithCount.vue
+++ b/src/components/MoreLikeThis/ButtonWithCount.vue
@@ -1,5 +1,5 @@
 <template>
-  <Button variant="primary">
+  <Button>
     <slot />
     <MoreLikeThisCountChip>
       {{ count }}

--- a/src/components/MoreLikeThis/CountChip.vue
+++ b/src/components/MoreLikeThis/CountChip.vue
@@ -1,0 +1,15 @@
+<template>
+  <span
+    class="more-like-this__count inline-flex items-center px-2 py-1 text-xs font-bold rounded-full"
+  >
+    <slot />
+  </span>
+</template>
+<script setup lang="ts"></script>
+<style scoped>
+.more-like-this__count {
+  background-color: var(--app-mediaCard-backgroundColor);
+  border: var(--app-mediaCard-borderWidth) solid
+    var(--app-mediaCard-borderColor);
+}
+</style>

--- a/src/components/MoreLikeThis/CountChip.vue
+++ b/src/components/MoreLikeThis/CountChip.vue
@@ -11,5 +11,6 @@
   background-color: var(--app-mediaCard-backgroundColor);
   border: var(--app-mediaCard-borderWidth) solid
     var(--app-mediaCard-borderColor);
+  color: var(--app-mediaCard-title-textColor);
 }
 </style>

--- a/src/components/MoreLikeThis/MoreLikeThis.vue
+++ b/src/components/MoreLikeThis/MoreLikeThis.vue
@@ -32,6 +32,10 @@
       :isOpen="isShowingFullListOfResults"
       @close="isShowingFullListOfResults = false"
     >
+      <template #label>
+        <span>More Like This</span>
+        <CountChip class="ml-2">{{ items.length }}</CountChip>
+      </template>
       <div class="grid grid-cols-3 gap-2">
         <SearchResultCard
           v-for="searchMatch in items"

--- a/src/components/MoreLikeThis/MoreLikeThis.vue
+++ b/src/components/MoreLikeThis/MoreLikeThis.vue
@@ -1,39 +1,67 @@
 <template>
-  <div v-if="items.length" class="more-like-this pt-6 mt-6">
-    <h3
-      class="more-like-this__title flex flex-wrap items-center gap-2 mb-4 text-xl font-bold"
-    >
-      More Like This
-      <span
-        class="more-like-this__count inline-flex items-center px-2 py-1 text-xs font-normal rounded-full"
+  <section v-if="items.length" class="more-like-this pt-6 mt-6">
+    <div v-if="inlineResultsList.length">
+      <h3
+        class="more-like-this__title flex flex-wrap items-center gap-2 mb-4 text-xl font-bold"
       >
-        {{ items.length }}
-      </span>
-    </h3>
+        More Like This
+      </h3>
 
-    <SearchResultCard
-      v-for="searchMatch in items"
-      :key="searchMatch.objectId"
-      :searchMatch="searchMatch"
-    />
-  </div>
+      <SearchResultCard
+        v-for="searchMatch in inlineResultsList"
+        :key="searchMatch.objectId"
+        :searchMatch="searchMatch"
+      />
+    </div>
+    <ButtonWithCount
+      v-if="numOfSeeMoreResults"
+      :count="numOfSeeMoreResults"
+      @click="isShowingFullListOfResults = true"
+    >
+      {{
+        config.moreLikeThis.maxInlineResults ? "Show More" : "More Like This"
+      }}
+    </ButtonWithCount>
+
+    <Modal
+      label="More Like This"
+      :isOpen="isShowingFullListOfResults"
+      @close="isShowingFullListOfResults = false"
+    >
+      <div class="grid grid-cols-3">
+        <SearchResultCard
+          v-for="searchMatch in items"
+          :key="searchMatch.objectId"
+          :searchMatch="searchMatch"
+        />
+      </div>
+    </Modal>
+  </section>
 </template>
 <script setup lang="ts">
+import { computed, ref } from "vue";
 import { SearchResultMatch } from "@/types";
 import SearchResultCard from "../SearchResultCard/SearchResultCard.vue";
+import config from "@/config";
+import Modal from "../Modal/Modal.vue";
+import ButtonWithCount from "./ButtonWithCount.vue";
 
-defineProps<{
+const props = defineProps<{
   items: SearchResultMatch[];
 }>();
+
+const inlineResultsList = computed(() => {
+  return props.items.slice(0, config.moreLikeThis.maxInlineResults);
+});
+
+const numOfSeeMoreResults = computed(() => {
+  return props.items.length - inlineResultsList.value.length;
+});
+
+const isShowingFullListOfResults = ref(false);
 </script>
 <style scoped>
 .more-like-this__title {
   color: var(--app-mediaCard-title-textColor);
-}
-.more-like-this__count {
-  background-color: var(--app-mediaCard-backgroundColor);
-  border: var(--app-mediaCard-borderWidth) solid
-    var(--app-mediaCard-borderColor);
-  font-weight: bold;
 }
 </style>

--- a/src/components/MoreLikeThis/MoreLikeThis.vue
+++ b/src/components/MoreLikeThis/MoreLikeThis.vue
@@ -1,6 +1,6 @@
 <template>
-  <section v-if="items.length" class="more-like-this pt-6 mt-6">
-    <div v-if="inlineResultsList.length">
+  <section v-if="items.length" class="more-like-this">
+    <div v-if="inlineResultsList.length" class="pt-6 mt-6">
       <h3
         class="more-like-this__title flex flex-wrap items-center gap-2 mb-4 text-xl font-bold"
       >

--- a/src/components/MoreLikeThis/MoreLikeThis.vue
+++ b/src/components/MoreLikeThis/MoreLikeThis.vue
@@ -4,7 +4,8 @@
       <h3
         class="more-like-this__title flex flex-wrap items-center gap-2 mb-4 text-xl font-bold"
       >
-        More Like This
+        <span>More Like This</span>
+        <CountChip>{{ items.length }}</CountChip>
       </h3>
 
       <SearchResultCard
@@ -16,6 +17,7 @@
     <ButtonWithCount
       v-if="numOfSeeMoreResults"
       :count="numOfSeeMoreResults"
+      class="my-4"
       @click="isShowingFullListOfResults = true"
     >
       {{
@@ -28,7 +30,7 @@
       :isOpen="isShowingFullListOfResults"
       @close="isShowingFullListOfResults = false"
     >
-      <div class="grid grid-cols-3">
+      <div class="grid grid-cols-3 gap-2">
         <SearchResultCard
           v-for="searchMatch in items"
           :key="searchMatch.objectId"
@@ -45,6 +47,7 @@ import SearchResultCard from "../SearchResultCard/SearchResultCard.vue";
 import config from "@/config";
 import Modal from "../Modal/Modal.vue";
 import ButtonWithCount from "./ButtonWithCount.vue";
+import CountChip from "./CountChip.vue";
 
 const props = defineProps<{
   items: SearchResultMatch[];

--- a/src/components/MoreLikeThis/MoreLikeThis.vue
+++ b/src/components/MoreLikeThis/MoreLikeThis.vue
@@ -8,11 +8,13 @@
         <CountChip>{{ items.length }}</CountChip>
       </h3>
 
-      <SearchResultCard
-        v-for="searchMatch in inlineResultsList"
-        :key="searchMatch.objectId"
-        :searchMatch="searchMatch"
-      />
+      <div class="flex flex-col gap-2">
+        <SearchResultCard
+          v-for="searchMatch in inlineResultsList"
+          :key="searchMatch.objectId"
+          :searchMatch="searchMatch"
+        />
+      </div>
     </div>
     <ButtonWithCount
       v-if="numOfSeeMoreResults"

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,9 @@ const defaultConfig: AppConfig = {
   routes: {
     test: import.meta.env.VITE_TEST_ROUTE ?? null,
   },
+  moreLikeThis: {
+    maxInlineResults: 1,
+  },
 };
 
 // merge default config with anything on window.Elevator.config

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ const defaultConfig: AppConfig = {
     test: import.meta.env.VITE_TEST_ROUTE ?? null,
   },
   moreLikeThis: {
-    maxInlineResults: 1,
+    maxInlineResults: 3,
   },
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,15 @@ export interface AppConfig {
   routes: {
     test: string | null;
   };
+  moreLikeThis: {
+    /**
+     * Number of results to show in More Like This
+     * section before showing the "Show More" button.
+     * If set to 0, users won't see any preview results
+     * and will have to click a "More Like This" button.
+     */
+    maxInlineResults: number;
+  };
 }
 
 /**


### PR DESCRIPTION
This limits the number of results we show in the More Like This section of the asset panel to an instance configurable number (default 3). If there are more results, users can click "Show More" which will open a modal of all results.

If an instance is configured to with `config.moreLikeThis.maxInlineResults` to be 0, no inline results will be shown and instead the users will just have a button to open More Like This results as a modal.

<img width="181" alt="Screenshot 2022-11-18 at 10 27 12@2x" src="https://user-images.githubusercontent.com/980170/202754591-ebf27631-bfc4-4ac1-a661-e44f76ac4509.png">

<img width="500" alt="Screenshot 2022-11-18 at 10 27 32@2x" src="https://user-images.githubusercontent.com/980170/202754678-d4dccfdf-6e5f-4266-a3a9-ff0a18a28f53.png">

<img width="500" alt="Screenshot 2022-11-18 at 10 30 38@2x" src="https://user-images.githubusercontent.com/980170/202754703-b0373b4d-1156-4b45-ad41-492bb5aaf1c1.png">

As discussed, we can hone the design elements for the More Like This section once we work out the components on the search results page. (e.g. Maybe a flatter row style component might look better here than a card.)

