### PR TITLE
Fix mobile safari controls overlapping menu

### DIFF
--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="h-full">
     <AppMenuPure
       :instance="instanceStore.instance"
       :currentUser="instanceStore.currentUser"

--- a/src/components/AppMenu/AppMenuPure.vue
+++ b/src/components/AppMenu/AppMenuPure.vue
@@ -3,7 +3,7 @@
     class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 p-4 h-full relative"
   >
     <XButton class="absolute right-4 top-4" @click="$emit('close')" />
-    <header class="flex mt-4 py-4">
+    <header class="app-menu__header flex mt-4 py-4">
       <h1 class="md:text-2xl text-lg font-bold">
         {{ instance.name }}
       </h1>
@@ -16,9 +16,11 @@
     <AppMenuAuthSection
       :instance="instance"
       :currentUser="currentUser"
-      class="py-4"
+      class="app-menu__auth-section py-4"
     />
-    <footer class="py-4 sm:flex flex-col items-center text-sm hidden">
+    <footer
+      class="app-menu__footer py-4 sm:flex flex-col items-center text-sm hidden"
+    >
       <p>
         Powered by <a href="https://umn-latis.github.io/elevator/">Elevator</a>
       </p>
@@ -46,4 +48,15 @@ defineEmits<{
   (eventName: "close"): void;
 }>();
 </script>
-<style scoped></style>
+<style scoped>
+@media (max-height: 640px) {
+  .app-menu__auth-section,
+  .app-menu__footer,
+  .app-menu__header {
+    display: none;
+  }
+  .app-menu__items {
+    border: none;
+  }
+}
+</style>

--- a/src/components/AppMenu/AppMenuPure.vue
+++ b/src/components/AppMenu/AppMenuPure.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 p-4 h-screen relative"
+    class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 p-4 h-full relative"
   >
     <XButton class="absolute right-4 top-4" @click="$emit('close')" />
     <header class="flex mt-4 py-4">


### PR DESCRIPTION
Good catch @cmcfadden. Probably some other mobile "easter eggs" in this UI – I haven't been testing mobile much. 😃 

This PR changes the app-menu height from `h-screen` (`height: 100vh`) to `h-full` (`height: 100%`) so that the browser controls don't overlap the menu. 

I also added a media query to hide any secondary menu content (like footer, header) when the screen height is small (a phone is horizontal) so we can maximize space for the menu.

Resolves #51.

<img src="https://user-images.githubusercontent.com/980170/206074873-882e89d7-6e08-4ea1-9a48-e0534392e531.PNG" width="320" /> <img src="https://user-images.githubusercontent.com/980170/206075540-86f50541-7d90-4082-9f08-d4fb714ee382.jpeg" width="320" />

<img src="https://user-images.githubusercontent.com/980170/206075717-f1c047ee-8493-4478-92d8-c6418e2867fe.jpeg" height="320" />

