### PR TITLE
Sort widget contents marked as `isPrimary` first

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.7",
     "@types/geojson": "^7946.0.10",
+    "@types/ramda": "^0.28.20",
     "@types/react": "^18.0.21",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",

--- a/src/components/Widget/TextAreaWidget/TextAreaWidget.vue
+++ b/src/components/Widget/TextAreaWidget/TextAreaWidget.vue
@@ -1,6 +1,6 @@
 <!-- todo: need to add text truncation, maybe with a show more modal -->
 <template>
-  <ul>
+  <ul class="text-area-widget flex flex-col gap-4">
     <li v-for="(content, key) in contents" :key="key">
       <TextAreaItem
         :widget="widget"

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -1,3 +1,4 @@
+import { partition } from "ramda";
 import { Asset, WidgetProps, WidgetContent, Template } from "@/types";
 import config from "@/config";
 
@@ -21,11 +22,24 @@ export const getThumbURL = (fileObjectId: string): string =>
 export const getAssetUrl = (assetId: string): string =>
   `/asset/viewAsset/${assetId}`;
 
+/**
+ * selects widget contents from an asset
+ * sorts so that primary is first
+ */
 export function getWidgetContents<
   T extends WidgetProps,
   U extends WidgetContent
->({ asset, widget }: { asset: Asset; widget: T }) {
-  return asset[widget.fieldTitle] as U[];
+>({ asset, widget }: { asset: Asset; widget: T }): U[] | null {
+  const widgetContents = asset[widget.fieldTitle] as U[] | undefined;
+
+  if (!widgetContents) return null;
+
+  const [primary, secondary] = partition<U>(
+    (content) => !!content.isPrimary,
+    widgetContents
+  );
+
+  return [...primary, ...secondary];
 }
 
 /**
@@ -51,7 +65,7 @@ export function widgetMatchesTitleWidget({
     !!titleWidget &&
     widget.type === "text" &&
     widget.fieldTitle === titleWidget.fieldTitle &&
-    widgetContents.length === 1
+    widgetContents?.length === 1
   );
 }
 

--- a/src/helpers/getMockWidgetStoryArgs.ts
+++ b/src/helpers/getMockWidgetStoryArgs.ts
@@ -15,7 +15,7 @@ export function getMockWidgetStoryArgs<
   fieldTitle: string;
   template: Template;
   asset: Asset;
-}): { widget: T; contents: U[]; asset: Asset } {
+}): { widget: T; contents: U[] | null; asset: Asset } {
   const widget = getWidgetPropsByFieldTitle<T>(template, fieldTitle);
 
   if (!widget) throw new Error("cannot find widget");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,7 +180,7 @@ export interface UploadWidgetProps extends WidgetProps {
  * `TextWidgetContents`.
  */
 export interface WidgetContent {
-  isPrimary: boolean;
+  isPrimary?: boolean;
   [key: string]: unknown;
 }
 export interface TextWidgetContent extends WidgetContent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,6 +2680,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/ramda@^0.28.20":
+  version "0.28.20"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.28.20.tgz#df93bb5674f0051464c075480ca3075d1c1361ba"
+  integrity sha512-MeUhzGSXQTRsY19JGn5LIBTLxVEnyF6HDNr08KSJqybsm4DlfLIgK1jBHjhpiSyk252tXYmp+UOe0UFg0UiFsA==
+  dependencies:
+    ts-toolbelt "^6.15.1"
+
 "@types/react@>=16", "@types/react@^18.0.21":
   version "18.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
@@ -10860,6 +10867,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+ts-toolbelt@^6.15.1:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
+  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
This updates the `getWidgetContents` function to always return the sorted list of widget contents. The function will content items into two sets based on `isPrimary` property: primary and secondary. The primary items will be first.

Also a few fixes:
- `asset[widget.fieldTitle]` might be undefined rather than an array of widget contents. The partition function will throw not passed an array. This types `asset[widget.fieldTitle]` as possibly undefined, and if undefined – `getWidgetContents` returns `null`.
- A text area widget with multiple contents needed extra spacing to tell distinct items apart. This adds a little gap.

<img src="https://user-images.githubusercontent.com/980170/206518241-fe312cfb-9f98-4b7f-8ab3-56873dcc8333.png" alt="screenshot of primary item first and gap" width=500 />


