### PR TITLE
fix: `getInterstitialText()` api call should happen only we're embedding an asset

### DIFF
--- a/src/components/ObjectViewer/ObjectViewer.vue
+++ b/src/components/ObjectViewer/ObjectViewer.vue
@@ -1,7 +1,10 @@
 <template>
   <section class="object-viewer relative flex flex-col">
     <h2 class="sr-only">Object Viewer</h2>
-    <AddToEmbeddedPluginButton :fileHandlerId="fileHandlerId" />
+    <AddToEmbeddedPluginButton
+      v-if="isInEmbedMode"
+      :fileHandlerId="fileHandlerId"
+    />
     <iframe
       v-if="fileHandlerId"
       class="object-viewer__iframe w-full flex-1"
@@ -22,6 +25,9 @@
 <script setup lang="ts">
 import config from "@/config";
 import AddToEmbeddedPluginButton from "./AddToEmbeddedPluginButton.vue";
+import { useElevatorSessionStorage } from "@/helpers/useElevatorSessionStorage";
+
+const { isInEmbedMode } = useElevatorSessionStorage();
 
 defineProps<{
   fileHandlerId: string | null;

--- a/src/helpers/useElevatorSessionStorage.ts
+++ b/src/helpers/useElevatorSessionStorage.ts
@@ -1,3 +1,4 @@
+import { computed } from "vue";
 import { useSessionStorage } from "@vueuse/core";
 import { ElevatorPluginType, ElevatorCallbackType } from "@/types";
 
@@ -7,6 +8,8 @@ export function useElevatorSessionStorage() {
     "elevatorPlugin",
     null
   );
+  const isInEmbedMode = computed(() => !!elevatorPlugin.value);
+
   const elevatorCallbackType = useSessionStorage<ElevatorCallbackType | null>(
     "elevatorCallbackType",
     null
@@ -20,6 +23,7 @@ export function useElevatorSessionStorage() {
 
   return {
     returnUrl,
+    isInEmbedMode,
     elevatorPlugin,
     elevatorCallbackType,
     clear,


### PR DESCRIPTION
The api call to get interstitial text happens when when the EmbedButton is mounted. This adds a `v-if` to the EmbedButton within ObjectView to prevent it from mounting if we're not in embed mode.