### PR TITLE
Fix: More Info doesn't work with non-images

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { omit } from "ramda";
 import config from "@/config";
 import {
   Asset,
@@ -62,7 +63,7 @@ async function fetchFileMetaData(fileId: string): Promise<FileMetaData> {
     `${BASE_URL}/fileManager/getMetadataForObject/${fileId}`
   );
 
-  return res.data;
+  return omit(["bulkMetadata"], res.data);
 }
 
 async function fetchFileDownloadInfo(

--- a/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
+++ b/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
@@ -64,6 +64,13 @@
           </Tuple>
         </Accordion>
       </section>
+      <section v-else>
+        <div v-for="(value, key) in fileMetaData" :key="key" class="my-6">
+          <Tuple :label="key">
+            {{ value }}
+          </Tuple>
+        </div>
+      </section>
     </div>
   </Modal>
 </template>

--- a/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
+++ b/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
@@ -15,7 +15,7 @@
     <div v-if="isFileMetaDataReady">
       <span v-if="!fileMetaData">No meta data found.</span>
 
-      <section v-if="fileMetaData" class="flex flex-col gap-6">
+      <section v-if="fileMetaData?.exif" class="flex flex-col gap-6">
         <Tuple label="File Type">
           {{ fileMetaData.exif.File.FileType }}
         </Tuple>
@@ -47,8 +47,7 @@
             </Map>
           </div>
         </Tuple>
-      </section>
-      <section v-if="fileMetaData?.exif">
+
         <h2 class="text-xl font-bold mt-6 border-t pt-6">EXIF Details</h2>
         <Accordion
           v-for="(exifSectionProps, exifSectionLabel) in fileMetaData.exif"


### PR DESCRIPTION
- This checks that `exif` exists on the meta data before rendering image specific More Info, which fixes an issue where the modal would break with non image metadata.

- For non-images, we just render generic tuples with Key-Value of metadata, which seems good enough for most cases.

Resolves #59 