### PR TITLE
Fix: correctly show derivatives available for download

### DIFF
--- a/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
+++ b/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
@@ -6,35 +6,20 @@
     <div v-if="isDownloadFileInfoReady">
       <span v-if="!downloadFileInfo">No Downloads available</span>
       <ul v-else class="list-disc list-inside">
-        <template
-          v-for="(downloadDetails, filetype) in downloadFileInfo"
-          :key="filetype"
-        >
-          <li v-if="downloadDetails.ready">
-            <a
-              :href="`${config.instance.base.url}/fileManager/getDerivativeById/${assetStore.activeFileObjectId}/${filetype}`"
-            >
-              Download {{ filetype }}
+        <template v-for="download in downloadFileInfo" :key="download.filetype">
+          <li v-if="download.isReady || download.filetype === 'original'">
+            <a :href="download.url">
+              Download {{ download.filetype }}
               <span
                 v-if="
-                  getExtensionFromFilename(downloadDetails.originalFilename) !==
-                  filetype.toLocaleLowerCase()
+                  download.extension !== download.filetype.toLocaleLowerCase()
                 "
               >
-                ({{
-                  getExtensionFromFilename(downloadDetails.originalFilename)
-                }})
+                ({{ download.extension }})
               </span>
             </a>
           </li>
         </template>
-        <li v-if="isLoggedIn">
-          <a
-            :href="`${config.instance.base.url}/fileManager/getOriginal/${assetStore.activeFileObjectId}`"
-          >
-            Download Original
-          </a>
-        </li>
       </ul>
     </div>
   </Modal>
@@ -43,28 +28,19 @@
 import { ref, computed } from "vue";
 import ActiveFileViewButton from "./ActiveFileViewButton.vue";
 import { useAssetStore } from "@/stores/assetStore";
-import { FileDownloadResponse } from "@/types/FileDownloadTypes";
+import { FileDownloadNormalized } from "@/types";
 import DownloadIcon from "@/icons/DownloadIcon.vue";
 import api from "@/api";
-import config from "@/config";
 import Modal from "../Modal/Modal.vue";
-import { useInstanceStore } from "@/stores/instanceStore";
-
-const { isLoggedIn } = useInstanceStore();
 
 const assetStore = useAssetStore();
 const isOpen = ref(false);
-const downloadFileInfo = ref<FileDownloadResponse | null | undefined>(
+const downloadFileInfo = ref<FileDownloadNormalized[] | null | undefined>(
   undefined
 );
 const isDownloadFileInfoReady = computed(
   () => downloadFileInfo.value !== undefined
 );
-
-const getExtensionFromFilename = (filename) => {
-  const parts = filename.split(".");
-  return parts[parts.length - 1]; // last extension
-};
 
 async function handleDownloadFileClick() {
   isOpen.value = true;

--- a/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
+++ b/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
@@ -2,23 +2,28 @@
   <ActiveFileViewButton @click="handleDownloadFileClick">
     <DownloadIcon />
   </ActiveFileViewButton>
-  <Modal label="File Downloads" :isOpen="isOpen" @close="isOpen = false">
+  <Modal
+    label="File Downloads"
+    :isOpen="isOpen"
+    class="max-w-sm"
+    @close="isOpen = false"
+  >
     <div v-if="isDownloadFileInfoReady">
       <span v-if="!downloadFileInfo">No Downloads available</span>
-      <ul v-else class="list-disc list-inside">
+      <ul v-else class="max-w-sm">
         <template v-for="download in downloadFileInfo" :key="download.filetype">
-          <li v-if="download.isReady || download.filetype === 'original'">
-            <a :href="download.url">
-              Download {{ download.filetype }}
-              <span
-                v-if="
-                  download.extension !== download.filetype.toLocaleLowerCase()
-                "
-              >
-                ({{ download.extension }})
-              </span>
-            </a>
-          </li>
+          <a
+            v-if="download.isReady || download.filetype === 'original'"
+            :href="download.url"
+            class="py-2 hover:bg-transparent-black-50 border-t last:border-b block hover:no-underline group"
+          >
+            <li class="flex justify-between">
+              <span class="group-hover:underline">{{ download.filetype }}</span>
+              <Chip class="group-hover:bg-blue-100 group-hover:text-blue-600">
+                {{ download.extension }}
+              </Chip>
+            </li>
+          </a>
         </template>
       </ul>
     </div>
@@ -31,7 +36,9 @@ import { useAssetStore } from "@/stores/assetStore";
 import { FileDownloadNormalized } from "@/types";
 import DownloadIcon from "@/icons/DownloadIcon.vue";
 import api from "@/api";
-import Modal from "../Modal/Modal.vue";
+import Modal from "@/components/Modal/Modal.vue";
+import Chip from "@/components/Chip/Chip.vue";
+import { getColorClassesForString } from "@/helpers/getColorClassesForString";
 
 const assetStore = useAssetStore();
 const isOpen = ref(false);

--- a/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
+++ b/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
@@ -5,16 +5,34 @@
   <Modal label="File Downloads" :isOpen="isOpen" @close="isOpen = false">
     <div v-if="isDownloadFileInfoReady">
       <span v-if="!downloadFileInfo">No Downloads available</span>
-      <ul v-if="downloadFileInfo">
-        <li v-if="downloadFileInfo.screen?.ready">
+      <ul v-else class="list-disc list-inside">
+        <template
+          v-for="(downloadDetails, filetype) in downloadFileInfo"
+          :key="filetype"
+        >
+          <li v-if="downloadDetails.ready">
+            <a
+              :href="`${config.instance.base.url}/fileManager/getDerivativeById/${assetStore.activeFileObjectId}/${filetype}`"
+            >
+              Download {{ filetype }}
+              <span
+                v-if="
+                  getExtensionFromFilename(downloadDetails.originalFilename) !==
+                  filetype.toLocaleLowerCase()
+                "
+              >
+                ({{
+                  getExtensionFromFilename(downloadDetails.originalFilename)
+                }})
+              </span>
+            </a>
+          </li>
+        </template>
+        <li v-if="isLoggedIn">
           <a
-            :href="`${config.instance.base.url}/fileManager/getDerivativeById/${assetStore.activeFileObjectId}/screen`"
+            :href="`${config.instance.base.url}/fileManager/getOriginal/${assetStore.activeFileObjectId}`"
           >
-            Download Derivative ({{
-              getExtensionFromFilename(
-                downloadFileInfo.screen.originalFilename
-              )
-            }})
+            Download Original
           </a>
         </li>
       </ul>
@@ -30,6 +48,9 @@ import DownloadIcon from "@/icons/DownloadIcon.vue";
 import api from "@/api";
 import config from "@/config";
 import Modal from "../Modal/Modal.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
+
+const { isLoggedIn } = useInstanceStore();
 
 const assetStore = useAssetStore();
 const isOpen = ref(false);

--- a/src/helpers/getExtensionFromFilename.ts
+++ b/src/helpers/getExtensionFromFilename.ts
@@ -1,0 +1,4 @@
+export const getExtensionFromFilename = (filename: string) => {
+  const parts = filename.split(".");
+  return parts[parts.length - 1]; // last extension
+};

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import api from "@/api";
 import { selectCurrentUserFromResponse } from "@/helpers/selectCurrentUserFromResponse";
 import { selectInstanceFromResponse } from "@/helpers/selectInstanceFromResponse";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import {
   FetchStatus,
   Page,
@@ -54,6 +54,8 @@ export const useInstanceStore = defineStore("instance", () => {
     }
   }
 
+  const isLoggedIn = computed(() => !!currentUser.value);
+
   async function init() {
     // don't fetch if we already have data or are fetching
     if (["fetching", "success", "error"].includes(fetchStatus.value)) {
@@ -70,6 +72,7 @@ export const useInstanceStore = defineStore("instance", () => {
     pages,
     instance,
     currentUser,
+    isLoggedIn,
     collections,
     refresh,
   };

--- a/src/types/FileDownloadTypes.ts
+++ b/src/types/FileDownloadTypes.ts
@@ -1,12 +1,6 @@
-export interface FileDownloadResponse {
-  screen: Screen;
-  thumbnail: Screen;
-  thumbnail2x: Screen;
-  tiny: Screen;
-  tiny2x: Screen;
-}
+export type FileDownloadResponse = Record<string, FileDownloadDetails>;
 
-export interface Screen {
+export interface FileDownloadDetails {
   storageClass: string;
   originalFilename: string;
   path: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -455,3 +455,11 @@ export interface NavItem {
   isCurrentPage?: boolean;
   children?: NavItem[];
 }
+
+export interface FileDownloadNormalized {
+  filetype: string;
+  isReady: boolean;
+  url: string;
+  originalFilename: string;
+  extension: string;
+}


### PR DESCRIPTION
Resolves #67 

Download button will now correctly show derivatives available to the user, and the original (if available).

<img width="800" alt="Screenshot 2022-12-15 at 19 17 15@2x" src="https://user-images.githubusercontent.com/980170/207999852-4a49db35-2ce4-4aea-a73a-e97e21f611e4.png">
