### PR TITLE
Add components for rendering static pages like `/page/view/1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@vueuse/core": "^9.3.0",
     "autolink-js": "^1.0.2",
     "axios": "^0.27.2",
+    "dompurify": "^3.0.1",
     "geojson": "^0.5.0",
     "mapbox-gl-esri-sources": "^0.0.4",
     "maplibre-gl": "^2.4.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ import {
   SearchResultsResponse,
   ApiInterstitialResponse,
   ApiInstanceNavResponse,
+  ApiStaticPageResponse,
   FileDownloadNormalized,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
@@ -225,6 +226,11 @@ export default {
       [page]: searchResults,
     });
     return searchResults;
+  },
+
+  async getStaticPage(pageId: string): Promise<ApiStaticPageResponse> {
+    const res = await axios.get(`${BASE_URL}/page/view/${pageId}/true`);
+    return res.data;
   },
 
   async deleteAsset(assetId: string) {

--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -32,6 +32,8 @@
   </div>
 </template>
 <script setup lang="ts">
+import { watch } from "vue";
+import { useRoute } from "vue-router";
 import { storeToRefs } from "pinia";
 import { useInstanceStore } from "@/stores/instanceStore";
 import { useAssetStore } from "@/stores/assetStore";
@@ -43,7 +45,7 @@ import AdminNavSection from "./AdminNavSection.vue";
 import HelpNavSection from "./HelpNavSection.vue";
 import config from "@/config";
 
-defineEmits<{
+const emit = defineEmits<{
   (eventName: "close"): void;
 }>();
 
@@ -53,6 +55,13 @@ const assetStore = useAssetStore();
 
 const { currentUser, instance, pages } = storeToRefs(instanceStore);
 const { activeAssetId } = storeToRefs(assetStore);
+
+// if the route changes, close the menu
+const route = useRoute();
+watch(
+  () => route.path,
+  () => emit("close")
+);
 </script>
 <style scoped>
 .app-menu {

--- a/src/components/AppMenu/PagesNavSection.vue
+++ b/src/components/AppMenu/PagesNavSection.vue
@@ -1,7 +1,7 @@
 <template>
   <template v-for="item in pageNavItems" :key="item.id">
     <div v-if="!item.children">
-      <AppMenuItem :href="item.href ?? '#'" :isCurrentPage="item.isCurrentPage">
+      <AppMenuItem :to="item.href ?? '#'" :isCurrentPage="item.isCurrentPage">
         {{ item.name }}
       </AppMenuItem>
     </div>
@@ -10,7 +10,7 @@
       <AppMenuItem
         v-for="subItem in item.children"
         :key="subItem.name"
-        :href="subItem.href ?? '#'"
+        :to="subItem.href ?? '#'"
         :isCurrentPage="subItem.isCurrentPage"
       >
         {{ subItem.name }}
@@ -31,12 +31,8 @@ const props = defineProps<{
 
 const BASE_URL = config.instance.base.url;
 
-function getHrefForPage(page: Page): string {
-  return `${BASE_URL}/page/view/${page.id}`;
-}
-
 function isCurrentPage(page: Page): boolean {
-  return getHrefForPage(page) === window.location.href;
+  return `${BASE_URL}/page/view/${page.id}` === window.location.href;
 }
 
 /**
@@ -47,7 +43,7 @@ function toNavItem(page: Page): NavItem {
     id: page.id,
     name: page.title,
     isCurrentPage: isCurrentPage(page),
-    href: getHrefForPage(page),
+    href: `/page/view/${page.id}`,
   };
 }
 

--- a/src/components/AppMenu/PagesNavSection.vue
+++ b/src/components/AppMenu/PagesNavSection.vue
@@ -19,20 +19,22 @@
   </template>
 </template>
 <script setup lang="ts">
+import { ref, watch } from "vue";
+import { useRoute } from "vue-router";
 import { NavItem, Page } from "@/types";
 import AppMenuGroup from "./AppMenuGroup.vue";
 import AppMenuItem from "./AppMenuItem.vue";
 import config from "@/config";
-import { computed } from "vue";
 
 const props = defineProps<{
   pages: Page[];
 }>();
 
-const BASE_URL = config.instance.base.url;
-
 function isCurrentPage(page: Page): boolean {
-  return `${BASE_URL}/page/view/${page.id}` === window.location.href;
+  return (
+    `${config.instance.base.path}/page/view/${page.id}` ===
+    window.location.pathname
+  );
 }
 
 /**
@@ -67,8 +69,16 @@ function convertPagesToNavItems(pages: Page[]): NavItem[] {
   });
 }
 
-const pageNavItems = computed((): NavItem[] =>
-  convertPagesToNavItems(props.pages)
+// if pages or route change, recompute the nav items
+// so that isCurrentPage is updated
+const pageNavItems = ref<NavItem[]>([]);
+const route = useRoute();
+watch(
+  [() => props.pages, () => route.path],
+  () => {
+    pageNavItems.value = convertPagesToNavItems(props.pages);
+  },
+  { immediate: true }
 );
 </script>
 <style scoped></style>

--- a/src/components/SanitizedHTML/SanitizedHTML.vue
+++ b/src/components/SanitizedHTML/SanitizedHTML.vue
@@ -1,0 +1,25 @@
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <div v-html="sanitizedHtml" />
+</template>
+<script setup lang="ts">
+import DOMPurify from "dompurify";
+import { computed } from "vue";
+const props = withDefaults(
+  defineProps<{
+    html: string;
+    removeInlineStyles?: boolean;
+  }>(),
+  {
+    removeInlineStyles: false,
+  }
+);
+
+const sanitizeConfig = {
+  FORBID_ATTR: props.removeInlineStyles ? ["style"] : [],
+};
+
+const sanitizedHtml = computed(() =>
+  DOMPurify.sanitize(props.html, sanitizeConfig)
+);
+</script>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <div class="static-page-view max-w-full overflow-scroll">
+    <div class="static-page-view max-w-full">
       <article
         v-if="page"
         class="static-page-view__article m-auto sm:max-w-3xl p-4 sm:p-12 rounded shadow sm:px-12 sm:my-8"

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -1,14 +1,25 @@
 <template>
   <DefaultLayout>
-    <h1>Page {{ pageId }}</h1>
-    Static Content goes here
+    <div v-if="page" class="prose mx-auto pt-8">
+      <h1>{{ page.title }}</h1>
+      <div v-html="page.content"></div>
+    </div>
   </DefaultLayout>
 </template>
 <script setup lang="ts">
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import { onMounted, ref } from "vue";
+import { ApiStaticPageResponse } from "@/types";
+import api from "@/api";
 
-defineProps<{
+const props = defineProps<{
   pageId: string;
 }>();
+
+const page = ref<ApiStaticPageResponse | null>(null);
+
+onMounted(async () => {
+  page.value = await api.getStaticPage(props.pageId);
+});
 </script>
 <style scoped></style>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -1,0 +1,14 @@
+<template>
+  <DefaultLayout>
+    <h1>Page {{ pageId }}</h1>
+    Static Content goes here
+  </DefaultLayout>
+</template>
+<script setup lang="ts">
+import DefaultLayout from "@/layouts/DefaultLayout.vue";
+
+defineProps<{
+  pageId: string;
+}>();
+</script>
+<style scoped></style>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -17,7 +17,7 @@
 <script setup lang="ts">
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
-import { onMounted, ref } from "vue";
+import { ref, watch } from "vue";
 import { ApiStaticPageResponse } from "@/types";
 import api from "@/api";
 
@@ -27,9 +27,13 @@ const props = defineProps<{
 
 const page = ref<ApiStaticPageResponse | null>(null);
 
-onMounted(async () => {
-  page.value = await api.getStaticPage(props.pageId);
-});
+watch(
+  () => props.pageId,
+  async () => {
+    page.value = await api.getStaticPage(props.pageId);
+  },
+  { immediate: true }
+);
 </script>
 <style scoped>
 .static-page-view__article {

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -1,13 +1,22 @@
 <template>
   <DefaultLayout>
-    <div v-if="page" class="prose mx-auto pt-8">
-      <h1>{{ page.title }}</h1>
-      <div v-html="page.content"></div>
+    <div class="static-page-view max-w-full overflow-scroll">
+      <article
+        v-if="page"
+        class="static-page-view__article m-auto sm:max-w-3xl p-4 sm:p-12 rounded shadow sm:px-12 sm:my-8"
+      >
+        <h2 class="text-3xl mb-12 sm:text-5xl font-bold mt-4">
+          {{ page?.title }}
+        </h2>
+
+        <SanitizedHTML :html="page.content" class="prose prose-neutral" />
+      </article>
     </div>
   </DefaultLayout>
 </template>
 <script setup lang="ts">
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { onMounted, ref } from "vue";
 import { ApiStaticPageResponse } from "@/types";
 import api from "@/api";
@@ -22,4 +31,13 @@ onMounted(async () => {
   page.value = await api.getStaticPage(props.pageId);
 });
 </script>
-<style scoped></style>
+<style scoped>
+.static-page-view__article {
+  background: var(--app-metaDataOnlyView-contentViewer-backgroundColor);
+  color: var(--app-metaDataOnlyView-contentViewer-textColor);
+}
+
+.static-page-view__article h2:after {
+  background: var(--app-metaDataOnlyView-contentViewer-textColor);
+}
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -52,6 +52,13 @@ const router = createRouter({
       props: true,
     },
     {
+      name: "StaticContentPage",
+      path: "/page/view/:pageId",
+      component: () =>
+        import("@/pages/StaticContentPage/StaticContentPage.vue"),
+      props: true,
+    },
+    {
       name: "error",
       path: "/error/:errorCode",
       component: () => import("@/pages/ErrorPage/ErrorPage.vue"),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -411,6 +411,11 @@ export interface ApiInstanceNavResponse {
   collections: AssetCollection[];
 }
 
+export interface ApiStaticPageResponse {
+  title: string;
+  content: string; // raw HTML
+}
+
 export interface InstanceStoreState {
   fetchStatus: FetchStatus;
   pages: Page[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5167,6 +5167,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.1.tgz#a0933f38931b3238934dd632043b727e53004289"
+  integrity sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw==
+
 domutils@^2.0.0, domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"


### PR DESCRIPTION
This adds a new `StaticContentPage` component for rendering static page content in Elevator.

Page content is raw HTML, so this includes a `<SanitizeHTML>` component (lifted from another LATIS project) for cleaning up any markup that may be problematic. Under the hood, this component uses the `dompurify` library.

- The page has some very light formatting, which I'm not sold on – so we can (and probably should) tweak this.
- As is typical with user created content, I noticed a lot of inline styles and non-semantic markup in the HTML. There are pros and cons with stripping out these styles. I've chosen to leave them as-is. 

Currently up: <https://dev.elevator.umn.edu/defaultinstance/page/view/3>
<img width="500" alt="Screenshot 2023-03-28 at 6 00 07 PM" src="https://user-images.githubusercontent.com/980170/228385853-94133e85-adcb-4f73-8598-5c189d8ab480.png">

Corresponding Elevator PR: https://github.com/UMN-LATIS/elevator/pull/120