### PR TITLE
fix: persist search input between searches

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -7,7 +7,7 @@
         label="Search"
         :labelHidden="true"
         placeholder="Search"
-        :value="searchText"
+        :value="searchStore.query"
         @focus="handleInputGroupFocus"
         @blur="handleInputGroupBlur"
         @input="handleInput"
@@ -27,7 +27,7 @@
               v-if="searchStore.query.length"
               type="button"
               class="text-neutral-400 hover:text-neutral-900"
-              @click="searchText = ''"
+              @click="handleClearSearchInput"
             >
               <CircleXIcon />
             </button>
@@ -47,7 +47,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref, nextTick } from "vue";
+import { ref } from "vue";
 import { SearchIcon, CircleXIcon } from "@/icons";
 import KeyboardShortcut from "@/components/KeyboardShortcut/KeyboardShortcut.vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
@@ -65,11 +65,10 @@ const inputGroup = ref<InstanceType<typeof InputGroup> | null>(null);
 const searchInputHasFocus = ref(false);
 const isAdvancedSearchModalOpen = ref(false);
 const searchStore = useSearchStore();
-const searchText = ref("");
 const router = useRouter();
 
 function handleInput(event: InputEvent) {
-  searchText.value = (event.target as HTMLInputElement).value;
+  searchStore.query = (event.target as HTMLInputElement).value;
 }
 
 function handleInputGroupFocus(event) {
@@ -84,10 +83,7 @@ function handleInputGroupBlur(event) {
 
 async function handleSubmit(event: Event) {
   event.preventDefault();
-  const searchId = await searchStore.search(searchText.value);
-  nextTick(() => {
-    searchText.value = "";
-  });
+  const searchId = await searchStore.search();
   if (!searchId) {
     router.push({
       name: "error",
@@ -115,6 +111,10 @@ function removeFocusOnEscape(event: KeyboardEvent) {
   if (event.key === "Escape") {
     inputGroup.value.$el.querySelector("input")?.blur();
   }
+}
+
+function handleClearSearchInput() {
+  searchStore.query = "";
 }
 
 document.addEventListener("keydown", focusInputOnCommandK);

--- a/src/pages/SearchPage/SearchPage.vue
+++ b/src/pages/SearchPage/SearchPage.vue
@@ -5,8 +5,11 @@
         v-if="browsingCollectionId"
         :collectionId="browsingCollectionId"
       />
-      <h2 v-if="searchStore.query" class="text-4xl my-8 font-bold">
-        <q>{{ searchStore.query }}</q>
+      <h2
+        v-if="searchStore.searchEntry?.searchText"
+        class="text-4xl my-8 font-bold"
+      >
+        <q>{{ searchStore.searchEntry.searchText }}</q>
       </h2>
       <p v-if="searchStore.status === 'error'">Error loading search results.</p>
       <SearchResultsGrid

--- a/src/pages/SearchPage/SearchPage.vue
+++ b/src/pages/SearchPage/SearchPage.vue
@@ -11,6 +11,12 @@
       >
         <q>{{ searchStore.searchEntry.searchText }}</q>
       </h2>
+      <h2
+        v-if="!browsingCollectionId && !searchStore.searchEntry?.searchText"
+        class="text-4xl my-8 font-bold"
+      >
+        All Assets
+      </h2>
       <p v-if="searchStore.status === 'error'">Error loading search results.</p>
       <SearchResultsGrid
         :totalResults="searchStore.totalResults"

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -13,12 +13,19 @@ export const useSearchStore = defineStore("search", () => {
   const searchEntry = ref<SearchEntry | null>(null);
   const isReady = computed(() => status.value === "success");
 
-  async function search(searchText: string): Promise<string | void> {
-    reset();
-    query.value = searchText;
+  async function search(): Promise<string | void> {
+    // clear old search results
     status.value = "fetching";
+    searchId.value = undefined;
+    matches.value = [];
+    totalResults.value = undefined;
+    currentPage.value = 0;
+    searchEntry.value = null;
     try {
+      // first get the id of the search for this query
       searchId.value = await api.getSearchId(query.value);
+
+      // then use the id to get the actual results
       searchById(searchId.value);
       return searchId.value;
     } catch (error) {
@@ -69,7 +76,7 @@ export const useSearchStore = defineStore("search", () => {
 
     try {
       const res = await api.getSearchResultsById(id);
-      query.value = res.searchEntry.searchText ?? "";
+
       searchEntry.value = res.searchEntry;
       totalResults.value = res.totalResults;
       matches.value = res.matches;
@@ -80,22 +87,13 @@ export const useSearchStore = defineStore("search", () => {
     }
   }
 
-  function reset() {
-    query.value = "";
-    status.value = "idle";
-    searchId.value = undefined;
-    matches.value = [];
-    totalResults.value = undefined;
-    currentPage.value = 0;
-  }
-
   return {
     // expose refs as computed values to make readonly
     // readonly() was causing type issues for some reason
+    query,
     matches: computed(() => matches.value),
     status: computed(() => status.value),
     searchId: computed(() => searchId.value),
-    query: computed(() => query.value),
     totalResults: computed(() => totalResults.value),
     currentPage: computed(() => currentPage.value),
     searchEntry: computed(() => searchEntry.value),
@@ -108,7 +106,6 @@ export const useSearchStore = defineStore("search", () => {
     search,
     searchById,
     loadMore,
-    reset,
     isReady,
   };
 });


### PR DESCRIPTION
This resolves:
- #75 
- #76 

These issues were a biproduct of having two different "sources of truth" for the search query: the `searchText` input in the search component and `searchStore.query` in the search store.

This:
- uses `searchStore.query` as the "source of truth" for the search query input and removes the `searchText` ref intermediary
- no longer clears the search query once it's submitted
- switches the search result page header to use `searchEntry.searchText` rather than `searchStore.query` (since searchStoer.query is tied to the input, and not the current results a user may be viewing).
- Shows "All Assets" as a page header if the searchText is empty (and we're not browsing a collection)

Latest up on <http://dev.elevator.umn.edu/defaultinstance>
