### PR TITLE
Add navigation for prev/next search results within Asset Page

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="componentType"
-    class="button inline-flex items-center gap-1 no-underline hover:no-underline rounded justify-center leading-none transition-colors ease-in-out group"
+    class="button inline-flex items-center gap-1 no-underline hover:no-underline rounded justify-center leading-none transition-colors ease-in-out group cursor-pointer"
     :class="{
       'button--primary px-4 py-3': variant === 'primary',
       'button--secondary px-4 py-3': variant === 'secondary',

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="currentAssetIndex"
+    v-if="currentAssetIndex !== null"
     class="flex justify-between py-2 px-4 items-center gap-4"
   >
     <Button

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -8,7 +8,6 @@
         v-if="previousAssetId"
         variant="tertiary"
         :to="getAssetUrl(previousAssetId)"
-        class="!ml-0"
       >
         <ChevronLeftIcon class="h-3 w-3" />
         Prev

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="flex justify-between py-1 px-4">
+    <Button variant="tertiary">
+      <ChevronLeftIcon />
+      Previous
+    </Button>
+    <Button variant="tertiary"> Next <ChevronRightIcon /> </Button>
+  </div>
+</template>
+<script setup lang="ts">
+import Button from "@/components/Button/Button.vue";
+import { ChevronRightIcon, ChevronLeftIcon } from "@/icons";
+import { useAssetStore } from "@/stores/assetStore";
+import { useSearchStore } from "@/stores/searchStore";
+
+const assetStore = useAssetStore();
+const searchStore = useSearchStore();
+</script>
+<style scoped></style>

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -15,7 +15,12 @@
     </div>
 
     <div class="flex justify-center text-xs text-gray-500 leading-none p-2">
-      {{ currentAssetIndex + 1 }} of {{ searchStore.totalResults }}
+      <Button
+        :to="`/search/s/${searchStore.searchId}#object-${assetStore.activeAssetId}`"
+        variant="tertiary"
+      >
+        {{ currentAssetIndex + 1 }} of {{ searchStore.totalResults }}
+      </Button>
     </div>
 
     <div class="flex justify-end">

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -53,21 +53,11 @@ const currentAssetIndex = computed((): number | null => {
 const LOAD_MORE_THRESHOLD = 5;
 
 function shouldLoadMoreResults() {
-  // if there is no current asset index, we're done
-  if (currentAssetIndex.value === null) return false;
-
-  // if we're not within LOAD_MORE_THRESHOLD of the end of the searchStore.matches array, we're done
-  if (
-    searchStore.matches.length - currentAssetIndex.value >
-    LOAD_MORE_THRESHOLD
-  )
-    return false;
-
-  // if there's no more results to load, we're done
-  if (!searchStore.hasMoreResults) return false;
-
-  // otherwise, we should load more results
-  return true;
+  return (
+    currentAssetIndex.value !== null &&
+    searchStore.hasMoreResults &&
+    searchStore.matches.length - currentAssetIndex.value <= LOAD_MORE_THRESHOLD
+  );
 }
 
 watch([() => searchStore.matches, currentAssetIndex], () => {
@@ -86,16 +76,15 @@ const previousAssetId = computed(() => {
 
 const nextAssetId = computed(() => {
   const currentIndex = currentAssetIndex.value;
-  if (currentIndex === null || currentIndex + 1 >= searchStore.matches.length) {
+  if (
+    currentIndex === null || // no asset is active
+    currentIndex + 1 >= searchStore.matches.length || // end of results
+    searchStore.status == "fetching" // still loading more results
+  ) {
     return null;
   }
 
-  // if we're loading more, return null for now
-  // this will be recomputed once the
-  // searchStore.matches array is updated
-  if (searchStore.status == "fetching") return null;
-
-  return searchStore.matches[currentIndex + 1].objectId;
+  return searchStore.matches[currentIndex + 1]?.objectId ?? null;
 });
 </script>
 <style scoped></style>

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -1,32 +1,36 @@
 <template>
-  <div
+  <nav
     v-if="currentAssetIndex !== null"
-    class="flex justify-between py-2 px-4 items-center gap-4"
+    class="justify-between py-2 px-4 items-center gap-4 grid grid-cols-3"
   >
-    <Button
-      v-if="previousAssetId"
-      variant="tertiary"
-      :to="getAssetUrl(previousAssetId)"
-      class="!ml-0"
-    >
-      <ChevronLeftIcon class="h-3 w-3" />
-      Prev
-    </Button>
+    <div class="flex justify-start">
+      <Button
+        v-if="previousAssetId"
+        variant="tertiary"
+        :to="getAssetUrl(previousAssetId)"
+        class="!ml-0"
+      >
+        <ChevronLeftIcon class="h-3 w-3" />
+        Prev
+      </Button>
+    </div>
 
-    <div class="text-xs text-gray-500 leading-none p-2">
+    <div class="flex justify-center text-xs text-gray-500 leading-none p-2">
       {{ currentAssetIndex + 1 }} of {{ searchStore.totalResults }}
     </div>
 
-    <Button
-      v-if="nextAssetId"
-      variant="tertiary"
-      :to="getAssetUrl(nextAssetId)"
-      class="!ml-0"
-    >
-      Next
-      <ChevronRightIcon class="h-3 w-3" />
-    </Button>
-  </div>
+    <div class="flex justify-end">
+      <Button
+        v-if="nextAssetId"
+        variant="tertiary"
+        :to="getAssetUrl(nextAssetId)"
+        class="!ml-0"
+      >
+        Next
+        <ChevronRightIcon class="h-3 w-3" />
+      </Button>
+    </div>
+  </nav>
 </template>
 <script setup lang="ts">
 import { computed, watch } from "vue";
@@ -74,17 +78,25 @@ watch([() => searchStore.matches, currentAssetIndex], () => {
 });
 
 const previousAssetId = computed(() => {
-  if (currentAssetIndex.value === null) return null;
-  if (currentAssetIndex.value <= 0) return null;
-  return searchStore.matches[currentAssetIndex.value - 1].objectId;
+  const currentIndex = currentAssetIndex.value;
+  if (currentIndex === null || currentIndex <= 0) {
+    return null;
+  }
+  return searchStore.matches[currentIndex - 1].objectId;
 });
 
 const nextAssetId = computed(() => {
-  if (currentAssetIndex.value === null) return null;
-  if (currentAssetIndex.value >= searchStore.matches.length - 1) return null;
+  const currentIndex = currentAssetIndex.value;
+  if (currentIndex === null || currentIndex + 1 >= searchStore.matches.length) {
+    return null;
+  }
+
+  // if we're loading more, return null for now
+  // this will be recomputed once the
+  // searchStore.matches array is updated
   if (searchStore.status == "fetching") return null;
 
-  return searchStore.matches[currentAssetIndex.value + 1].objectId;
+  return searchStore.matches[currentIndex + 1].objectId;
 });
 </script>
 <style scoped></style>

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -1,19 +1,90 @@
 <template>
-  <div class="flex justify-between py-1 px-4">
-    <Button variant="tertiary">
-      <ChevronLeftIcon />
-      Previous
+  <div
+    v-if="currentAssetIndex"
+    class="flex justify-between py-2 px-4 items-center gap-4"
+  >
+    <Button
+      v-if="previousAssetId"
+      variant="tertiary"
+      :to="getAssetUrl(previousAssetId)"
+      class="!ml-0"
+    >
+      <ChevronLeftIcon class="h-3 w-3" />
+      Prev
     </Button>
-    <Button variant="tertiary"> Next <ChevronRightIcon /> </Button>
+
+    <div class="text-xs text-gray-500 leading-none p-2">
+      {{ currentAssetIndex + 1 }} of {{ searchStore.totalResults }}
+    </div>
+
+    <Button
+      v-if="nextAssetId"
+      variant="tertiary"
+      :to="getAssetUrl(nextAssetId)"
+      class="!ml-0"
+    >
+      Next
+      <ChevronRightIcon class="h-3 w-3" />
+    </Button>
   </div>
 </template>
 <script setup lang="ts">
+import { computed, watch } from "vue";
 import Button from "@/components/Button/Button.vue";
 import { ChevronRightIcon, ChevronLeftIcon } from "@/icons";
 import { useAssetStore } from "@/stores/assetStore";
 import { useSearchStore } from "@/stores/searchStore";
+import { getAssetUrl } from "@/helpers/displayUtils";
 
 const assetStore = useAssetStore();
 const searchStore = useSearchStore();
+const currentAssetIndex = computed((): number | null => {
+  const { activeAssetId } = assetStore;
+  if (!activeAssetId) return null;
+  const index = searchStore.matches.findIndex(
+    (match) => match.objectId === activeAssetId
+  );
+  return index === -1 ? null : index;
+});
+
+const LOAD_MORE_THRESHOLD = 5;
+
+function shouldLoadMoreResults() {
+  // if there is no current asset index, we're done
+  if (currentAssetIndex.value === null) return false;
+
+  // if we're not within LOAD_MORE_THRESHOLD of the end of the searchStore.matches array, we're done
+  if (
+    searchStore.matches.length - currentAssetIndex.value >
+    LOAD_MORE_THRESHOLD
+  )
+    return false;
+
+  // if there's no more results to load, we're done
+  if (!searchStore.hasMoreResults) return false;
+
+  // otherwise, we should load more results
+  return true;
+}
+
+watch([() => searchStore.matches, currentAssetIndex], () => {
+  if (shouldLoadMoreResults()) {
+    searchStore.loadMore();
+  }
+});
+
+const previousAssetId = computed(() => {
+  if (currentAssetIndex.value === null) return null;
+  if (currentAssetIndex.value <= 0) return null;
+  return searchStore.matches[currentAssetIndex.value - 1].objectId;
+});
+
+const nextAssetId = computed(() => {
+  if (currentAssetIndex.value === null) return null;
+  if (currentAssetIndex.value >= searchStore.matches.length - 1) return null;
+  if (searchStore.status == "fetching") return null;
+
+  return searchStore.matches[currentAssetIndex.value + 1].objectId;
+});
 </script>
 <style scoped></style>

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -4,6 +4,7 @@
     class="group hover:no-underline relative"
   >
     <MediaCard
+      :id="`object-${searchMatch.objectId}`"
       :imgSrc="thumbnailImgSrc"
       :imgAlt="title"
       class="search-result-card transition-all max-w-sm flex w-full h-full group-hover:outline outline-blue-600 group-hover:bg-blue-50 group-hover:text-blue-700 relative"

--- a/src/icons/ChevronLeftIcon.vue
+++ b/src/icons/ChevronLeftIcon.vue
@@ -1,0 +1,18 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="w-5 h-5"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15.75 19.5L8.25 12l7.5-7.5"
+    />
+  </svg>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/src/icons/ChevronRightIcon.vue
+++ b/src/icons/ChevronRightIcon.vue
@@ -1,0 +1,18 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="w-5 h-5"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M8.25 4.5l7.5 7.5-7.5 7.5"
+    />
+  </svg>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,6 +1,8 @@
 export { default as ArrowForwardIcon } from "./ArrowForwardIcon.vue";
 export { default as ChevronDownIcon } from "./ChevronDownIcon.vue";
 export { default as ChevronUpIcon } from "./ChevronUpIcon.vue";
+export { default as ChevronLeftIcon } from "./ChevronLeftIcon.vue";
+export { default as ChevronRightIcon } from "./ChevronRightIcon.vue";
 export { default as CircleCheckIcon } from "./CircleCheckIcon.vue";
 export { default as CircleIcon } from "./CircleIcon.vue";
 export { default as CircleXIcon } from "./CircleXIcon.vue";

--- a/src/layouts/NoScrollLayout.vue
+++ b/src/layouts/NoScrollLayout.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="h-screen flex flex-col">
     <AppHeader class="top-0 w-full z-20 backdrop-blur-sm" />
-    <PrevNextSearchResultNav
-      v-if="searchStore.searchId"
-      class="border-b sticky"
-    />
+    <PrevNextSearchResultNav />
     <div ref="contentContainer" class="flex-1 mt-18 md:mt-0 overflow-auto">
       <slot />
     </div>
@@ -13,8 +10,5 @@
 <script setup lang="ts">
 import AppHeader from "@/components/AppHeader/AppHeader.vue";
 import PrevNextSearchResultNav from "@/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
-import { useSearchStore } from "@/stores/searchStore";
-
-const searchStore = useSearchStore();
 </script>
 <style></style>

--- a/src/layouts/NoScrollLayout.vue
+++ b/src/layouts/NoScrollLayout.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="h-screen flex flex-col">
     <AppHeader class="top-0 w-full z-20 backdrop-blur-sm" />
+    <PrevNextSearchResultNav
+      v-if="searchStore.searchId"
+      class="border-b sticky"
+    />
     <div ref="contentContainer" class="flex-1 mt-18 md:mt-0 overflow-auto">
       <slot />
     </div>
@@ -8,5 +12,9 @@
 </template>
 <script setup lang="ts">
 import AppHeader from "@/components/AppHeader/AppHeader.vue";
+import PrevNextSearchResultNav from "@/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
+import { useSearchStore } from "@/stores/searchStore";
+
+const searchStore = useSearchStore();
 </script>
 <style></style>

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="asset-view relative flex flex-col border h-full">
-    <div v-if="searchStore.searchId" class="flex justify-between py-1 border">
-      <Button>Previous</Button>
-      <Button>Next</Button>
-    </div>
     <div class="relative border flex-1">
       <ObjectViewer
         class="asset-view__object-viewer h-[75vh] md:h-auto md:absolute md:top-0 border-t-0 border-b-asset-view"
@@ -65,7 +61,7 @@ import ObjectViewer from "@/components/ObjectViewer/ObjectViewer.vue";
 import ObjectDetailsDrawer from "@/components/ObjectDetailsDrawer/ObjectDetailsDrawer.vue";
 import AssetDetailsDrawer from "@/components/AssetDetailsDrawer/AssetDetailsDrawer.vue";
 import { useMediaQuery } from "@vueuse/core";
-import Button from "@/components/Button/Button.vue";
+import PrevNextSearchResultBar from "../../components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
 
 defineProps<{
   assetId: string | null;

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -1,72 +1,83 @@
 <template>
-  <div class="asset-view h-full relative">
-    <ObjectViewer
-      class="asset-view__object-viewer h-[75vh] md:h-auto md:absolute md:top-0 border-t-0 border-b-asset-view"
-      :class="{
-        'md:top-0 md:bottom-1/2 md:left-sm md:right-0 border-l-asset-view':
-          isAssetDetailsOpen && isObjectDetailsOpen, // both open
-        'md:top-0 md:bottom-16 md:left-sm md:right-0 border-l-asset-view':
-          isAssetDetailsOpen && !isObjectDetailsOpen, // just asset details
+  <div class="asset-view relative flex flex-col border h-full">
+    <div class="flex justify-between py-1 border">
+      <Button>Previous</Button>
+      <Button>Next</Button>
+    </div>
+    <div class="relative border flex-1">
+      <ObjectViewer
+        class="asset-view__object-viewer h-[75vh] md:h-auto md:absolute md:top-0 border-t-0 border-b-asset-view"
+        :class="{
+          'md:top-0 md:bottom-1/2 md:left-sm md:right-0 border-l-asset-view':
+            isAssetDetailsOpen && isObjectDetailsOpen, // both open
+          'md:top-0 md:bottom-16 md:left-sm md:right-0 border-l-asset-view':
+            isAssetDetailsOpen && !isObjectDetailsOpen, // just asset details
 
-        'md:top-0 md:bottom-16 md:left-0 md:right-sm border-r-asset-view':
-          !isAssetDetailsOpen && isObjectDetailsOpen, // just object details
-        'md:top-0 md:bottom-16 md:left-0 md:right-0':
-          !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
-      }"
-      :fileHandlerId="assetStore.activeFileObjectId"
-    />
-    <AssetDetailsDrawer
-      class="asset-view__asset-panel md:absolute"
-      :class="{
-        'asset-view__asset-panel--open': isAssetDetailsOpen,
-        'md:bottom-0 md:left-0 md:top-0 md:w-sm': isAssetDetailsOpen, // both open + asset details open
-        'md:bottom-0 md:left-0 md:h-16 md:right-sm border-r-asset-view':
-          !isAssetDetailsOpen && isObjectDetailsOpen, // just obj panel
-        'md:bottom-0 md:left-0 md:h-16 md:w-1/2':
-          !isAssetDetailsOpen && !isObjectDetailsOpen, //neither open
-      }"
-      :showToggle="permitDrawerToggle"
-      :assetId="assetStore.activeAssetId"
-      :isOpen="permitDrawerToggle ? isAssetDetailsOpen : true"
-      @toggle="isAssetDetailsOpen = !isAssetDetailsOpen"
-    />
-    <ObjectDetailsDrawer
-      class="asset-view__details-panel md:absolute"
-      :class="{
-        'asset-view__details-panel--open': isObjectDetailsOpen,
-        'border-l-asset-view': !isObjectDetailsOpen,
-        'md:bottom-0 md:right-0 md:h-16 md:left-sm':
-          !isObjectDetailsOpen && isAssetDetailsOpen, // just asset open
-        'md:bottom-0 md:right-0 md:h-1/2 md:left-sm border-l-asset-view':
-          isObjectDetailsOpen && isAssetDetailsOpen, // both panels open
-        'md:bottom-0 md:right-0 md:top-0 md:w-sm':
-          isObjectDetailsOpen && !isAssetDetailsOpen, // just object open
-        'md:bottom-0 md:right-0 md:h-16 md:w-1/2':
-          !isObjectDetailsOpen && !isAssetDetailsOpen, // neither panels open
-      }"
-      :showToggle="permitDrawerToggle"
-      :objectId="assetStore.activeObjectId"
-      :isOpen="permitDrawerToggle ? isObjectDetailsOpen : true"
-      @toggle="isObjectDetailsOpen = !isObjectDetailsOpen"
-    />
+          'md:top-0 md:bottom-16 md:left-0 md:right-sm border-r-asset-view':
+            !isAssetDetailsOpen && isObjectDetailsOpen, // just object details
+          'md:top-0 md:bottom-16 md:left-0 md:right-0':
+            !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
+        }"
+        :fileHandlerId="assetStore.activeFileObjectId"
+      />
+      <AssetDetailsDrawer
+        class="asset-view__asset-panel md:absolute"
+        :class="{
+          'asset-view__asset-panel--open': isAssetDetailsOpen,
+          'md:bottom-0 md:left-0 md:top-0 md:w-sm': isAssetDetailsOpen, // both open + asset details open
+          'md:bottom-0 md:left-0 md:h-16 md:right-sm border-r-asset-view':
+            !isAssetDetailsOpen && isObjectDetailsOpen, // just obj panel
+          'md:bottom-0 md:left-0 md:h-16 md:w-1/2':
+            !isAssetDetailsOpen && !isObjectDetailsOpen, //neither open
+        }"
+        :showToggle="permitDrawerToggle"
+        :assetId="assetStore.activeAssetId"
+        :isOpen="permitDrawerToggle ? isAssetDetailsOpen : true"
+        @toggle="isAssetDetailsOpen = !isAssetDetailsOpen"
+      />
+      <ObjectDetailsDrawer
+        class="asset-view__details-panel md:absolute"
+        :class="{
+          'asset-view__details-panel--open': isObjectDetailsOpen,
+          'border-l-asset-view': !isObjectDetailsOpen,
+          'md:bottom-0 md:right-0 md:h-16 md:left-sm':
+            !isObjectDetailsOpen && isAssetDetailsOpen, // just asset open
+          'md:bottom-0 md:right-0 md:h-1/2 md:left-sm border-l-asset-view':
+            isObjectDetailsOpen && isAssetDetailsOpen, // both panels open
+          'md:bottom-0 md:right-0 md:top-0 md:w-sm':
+            isObjectDetailsOpen && !isAssetDetailsOpen, // just object open
+          'md:bottom-0 md:right-0 md:h-16 md:w-1/2':
+            !isObjectDetailsOpen && !isAssetDetailsOpen, // neither panels open
+        }"
+        :showToggle="permitDrawerToggle"
+        :objectId="assetStore.activeObjectId"
+        :isOpen="permitDrawerToggle ? isObjectDetailsOpen : true"
+        @toggle="isObjectDetailsOpen = !isObjectDetailsOpen"
+      />
+    </div>
   </div>
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
 import { useAssetStore } from "@/stores/assetStore";
+import { useSearchStore } from "@/stores/searchStore";
 import ObjectViewer from "@/components/ObjectViewer/ObjectViewer.vue";
 import ObjectDetailsDrawer from "@/components/ObjectDetailsDrawer/ObjectDetailsDrawer.vue";
 import AssetDetailsDrawer from "@/components/AssetDetailsDrawer/AssetDetailsDrawer.vue";
 import { useMediaQuery } from "@vueuse/core";
+import Button from "@/components/Button/Button.vue";
 
 defineProps<{
   assetId: string | null;
   objectId?: string | null;
+  previousAssetId?: string | null;
+  nextAssetId?: string | null;
 }>();
 
 const isAssetDetailsOpen = ref(true);
 const isObjectDetailsOpen = ref(false);
 const assetStore = useAssetStore();
+const searchStore = useSearchStore();
 
 const permitDrawerToggle = useMediaQuery("(min-width: 768px)");
 </script>

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -1,79 +1,72 @@
 <template>
-  <div class="asset-view relative flex flex-col border h-full">
-    <div class="relative border flex-1">
-      <ObjectViewer
-        class="asset-view__object-viewer h-[75vh] md:h-auto md:absolute md:top-0 border-t-0 border-b-asset-view"
-        :class="{
-          'md:top-0 md:bottom-1/2 md:left-sm md:right-0 border-l-asset-view':
-            isAssetDetailsOpen && isObjectDetailsOpen, // both open
-          'md:top-0 md:bottom-16 md:left-sm md:right-0 border-l-asset-view':
-            isAssetDetailsOpen && !isObjectDetailsOpen, // just asset details
+  <div class="asset-view h-full relative">
+    <ObjectViewer
+      class="asset-view__object-viewer h-[75vh] md:h-auto md:absolute md:top-0 border-t-0 border-b-asset-view"
+      :class="{
+        'md:top-0 md:bottom-1/2 md:left-sm md:right-0 border-l-asset-view':
+          isAssetDetailsOpen && isObjectDetailsOpen, // both open
+        'md:top-0 md:bottom-16 md:left-sm md:right-0 border-l-asset-view':
+          isAssetDetailsOpen && !isObjectDetailsOpen, // just asset details
 
-          'md:top-0 md:bottom-16 md:left-0 md:right-sm border-r-asset-view':
-            !isAssetDetailsOpen && isObjectDetailsOpen, // just object details
-          'md:top-0 md:bottom-16 md:left-0 md:right-0':
-            !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
-        }"
-        :fileHandlerId="assetStore.activeFileObjectId"
-      />
-      <AssetDetailsDrawer
-        class="asset-view__asset-panel md:absolute"
-        :class="{
-          'asset-view__asset-panel--open': isAssetDetailsOpen,
-          'md:bottom-0 md:left-0 md:top-0 md:w-sm': isAssetDetailsOpen, // both open + asset details open
-          'md:bottom-0 md:left-0 md:h-16 md:right-sm border-r-asset-view':
-            !isAssetDetailsOpen && isObjectDetailsOpen, // just obj panel
-          'md:bottom-0 md:left-0 md:h-16 md:w-1/2':
-            !isAssetDetailsOpen && !isObjectDetailsOpen, //neither open
-        }"
-        :showToggle="permitDrawerToggle"
-        :assetId="assetStore.activeAssetId"
-        :isOpen="permitDrawerToggle ? isAssetDetailsOpen : true"
-        @toggle="isAssetDetailsOpen = !isAssetDetailsOpen"
-      />
-      <ObjectDetailsDrawer
-        class="asset-view__details-panel md:absolute"
-        :class="{
-          'asset-view__details-panel--open': isObjectDetailsOpen,
-          'border-l-asset-view': !isObjectDetailsOpen,
-          'md:bottom-0 md:right-0 md:h-16 md:left-sm':
-            !isObjectDetailsOpen && isAssetDetailsOpen, // just asset open
-          'md:bottom-0 md:right-0 md:h-1/2 md:left-sm border-l-asset-view':
-            isObjectDetailsOpen && isAssetDetailsOpen, // both panels open
-          'md:bottom-0 md:right-0 md:top-0 md:w-sm':
-            isObjectDetailsOpen && !isAssetDetailsOpen, // just object open
-          'md:bottom-0 md:right-0 md:h-16 md:w-1/2':
-            !isObjectDetailsOpen && !isAssetDetailsOpen, // neither panels open
-        }"
-        :showToggle="permitDrawerToggle"
-        :objectId="assetStore.activeObjectId"
-        :isOpen="permitDrawerToggle ? isObjectDetailsOpen : true"
-        @toggle="isObjectDetailsOpen = !isObjectDetailsOpen"
-      />
-    </div>
+        'md:top-0 md:bottom-16 md:left-0 md:right-sm border-r-asset-view':
+          !isAssetDetailsOpen && isObjectDetailsOpen, // just object details
+        'md:top-0 md:bottom-16 md:left-0 md:right-0':
+          !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
+      }"
+      :fileHandlerId="assetStore.activeFileObjectId"
+    />
+    <AssetDetailsDrawer
+      class="asset-view__asset-panel md:absolute"
+      :class="{
+        'asset-view__asset-panel--open': isAssetDetailsOpen,
+        'md:bottom-0 md:left-0 md:top-0 md:w-sm': isAssetDetailsOpen, // both open + asset details open
+        'md:bottom-0 md:left-0 md:h-16 md:right-sm border-r-asset-view':
+          !isAssetDetailsOpen && isObjectDetailsOpen, // just obj panel
+        'md:bottom-0 md:left-0 md:h-16 md:w-1/2':
+          !isAssetDetailsOpen && !isObjectDetailsOpen, //neither open
+      }"
+      :showToggle="permitDrawerToggle"
+      :assetId="assetStore.activeAssetId"
+      :isOpen="permitDrawerToggle ? isAssetDetailsOpen : true"
+      @toggle="isAssetDetailsOpen = !isAssetDetailsOpen"
+    />
+    <ObjectDetailsDrawer
+      class="asset-view__details-panel md:absolute"
+      :class="{
+        'asset-view__details-panel--open': isObjectDetailsOpen,
+        'border-l-asset-view': !isObjectDetailsOpen,
+        'md:bottom-0 md:right-0 md:h-16 md:left-sm':
+          !isObjectDetailsOpen && isAssetDetailsOpen, // just asset open
+        'md:bottom-0 md:right-0 md:h-1/2 md:left-sm border-l-asset-view':
+          isObjectDetailsOpen && isAssetDetailsOpen, // both panels open
+        'md:bottom-0 md:right-0 md:top-0 md:w-sm':
+          isObjectDetailsOpen && !isAssetDetailsOpen, // just object open
+        'md:bottom-0 md:right-0 md:h-16 md:w-1/2':
+          !isObjectDetailsOpen && !isAssetDetailsOpen, // neither panels open
+      }"
+      :showToggle="permitDrawerToggle"
+      :objectId="assetStore.activeObjectId"
+      :isOpen="permitDrawerToggle ? isObjectDetailsOpen : true"
+      @toggle="isObjectDetailsOpen = !isObjectDetailsOpen"
+    />
   </div>
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
 import { useAssetStore } from "@/stores/assetStore";
-import { useSearchStore } from "@/stores/searchStore";
 import ObjectViewer from "@/components/ObjectViewer/ObjectViewer.vue";
 import ObjectDetailsDrawer from "@/components/ObjectDetailsDrawer/ObjectDetailsDrawer.vue";
 import AssetDetailsDrawer from "@/components/AssetDetailsDrawer/AssetDetailsDrawer.vue";
 import { useMediaQuery } from "@vueuse/core";
-import PrevNextSearchResultBar from "../../components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
 
 defineProps<{
   assetId: string | null;
   objectId?: string | null;
-  previousAssetId?: string | null;
-  nextAssetId?: string | null;
 }>();
 
 const isAssetDetailsOpen = ref(true);
 const isObjectDetailsOpen = ref(false);
 const assetStore = useAssetStore();
-const searchStore = useSearchStore();
 
 const permitDrawerToggle = useMediaQuery("(min-width: 768px)");
 </script>

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="asset-view relative flex flex-col border h-full">
-    <div class="flex justify-between py-1 border">
+    <div v-if="searchStore.searchId" class="flex justify-between py-1 border">
       <Button>Previous</Button>
       <Button>Next</Button>
     </div>

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -1,14 +1,16 @@
 <template>
-  <NoScrollLayout v-if="isPageLoaded" class="overflow-x-hidden">
-    <MetaDataOnlyView
-      v-if="isMetaDataOnly"
-      :assetId="assetStore.activeAssetId"
-    />
-    <AssetView
-      v-else
-      :assetId="assetStore.activeAssetId"
-      :objectId="assetStore.activeObjectId"
-    />
+  <NoScrollLayout class="overflow-x-hidden">
+    <template v-if="isPageLoaded">
+      <MetaDataOnlyView
+        v-if="isMetaDataOnly"
+        :assetId="assetStore.activeAssetId"
+      />
+      <AssetView
+        v-else
+        :assetId="assetStore.activeAssetId"
+        :objectId="assetStore.activeObjectId"
+      />
+    </template>
   </NoScrollLayout>
 </template>
 <script setup lang="ts">

--- a/src/pages/SearchPage/SearchPage.vue
+++ b/src/pages/SearchPage/SearchPage.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <div v-if="searchStore.isReady" class="search-results-page px-4">
+    <div class="search-results-page px-4">
       <BrowseCollectionHeader
         v-if="browsingCollectionId"
         :collectionId="browsingCollectionId"

--- a/src/router.ts
+++ b/src/router.ts
@@ -38,9 +38,19 @@ const router = createRouter({
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
       return savedPosition;
-    } else {
-      return { top: 0 };
     }
+
+    // scroll to anchor if it exists on the page
+    if (to.hash && document.querySelector(to.hash)) {
+      return {
+        el: to.hash,
+        behavior: "smooth",
+        top: 100, // offset to account for app header
+      };
+    }
+
+    // otherwise scroll to top
+    return { top: 0 };
   },
   routes: [
     {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -21,7 +21,7 @@ const getters = (state: ReturnType<typeof createState>) => ({
   collectionIds: computed((): number[] | null => {
     if (!state.searchEntry.value?.collection) return null;
     // convert to numbers, as the api returns strings
-    return state.searchEntry.value.collection.map(Number.parseInt);
+    return state.searchEntry.value.collection.map((id) => Number.parseInt(id));
   }),
   matches: computed(() => state.matches.value),
   status: computed(() => state.status.value),

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -3,109 +3,112 @@ import api from "@/api";
 import { ref, computed } from "vue";
 import { FetchStatus, SearchResultMatch, SearchEntry } from "@/types";
 
-export const useSearchStore = defineStore("search", () => {
-  const searchId = ref<string | undefined>(undefined);
-  const status = ref<FetchStatus>("idle");
-  const query = ref("");
-  const matches = ref<SearchResultMatch[]>([]);
-  const totalResults = ref<number | undefined>(undefined);
-  const currentPage = ref(0);
-  const searchEntry = ref<SearchEntry | null>(null);
-  const isReady = computed(() => status.value === "success");
+const createState = () => ({
+  searchId: ref<string | undefined>(undefined),
+  status: ref<FetchStatus>("idle"),
+  query: ref(""),
+  matches: ref<SearchResultMatch[]>([]),
+  totalResults: ref<number | undefined>(undefined),
+  currentPage: ref(0),
+  searchEntry: ref<SearchEntry | null>(null),
+});
 
-  async function search(): Promise<string | void> {
+const getters = (state: ReturnType<typeof createState>) => ({
+  isReady: computed(() => state.status.value === "success"),
+  hasMoreResults: computed(() => {
+    return state.matches.value.length < (state.totalResults.value ?? 0);
+  }),
+  collectionIds: computed((): number[] | null => {
+    if (!state.searchEntry.value?.collection) return null;
+    // convert to numbers, as the api returns strings
+    return state.searchEntry.value.collection.map(Number.parseInt);
+  }),
+  matches: computed(() => state.matches.value),
+  status: computed(() => state.status.value),
+  searchId: computed(() => state.searchId.value),
+  totalResults: computed(() => state.totalResults.value),
+  currentPage: computed(() => state.currentPage.value),
+  searchEntry: computed(() => state.searchEntry.value),
+});
+
+const actions = (state: ReturnType<typeof createState>) => ({
+  async search(): Promise<string | void> {
     // clear old search results
-    status.value = "fetching";
-    searchId.value = undefined;
-    matches.value = [];
-    totalResults.value = undefined;
-    currentPage.value = 0;
-    searchEntry.value = null;
+    state.status.value = "fetching";
+    state.searchId.value = undefined;
+    state.matches.value = [];
+    state.totalResults.value = undefined;
+    state.currentPage.value = 0;
+    state.searchEntry.value = null;
     try {
       // first get the id of the search for this query
-      searchId.value = await api.getSearchId(query.value);
+      state.searchId.value = await api.getSearchId(state.query.value);
 
       // then use the id to get the actual results
-      searchById(searchId.value);
-      return searchId.value;
+      actions(state).searchById(state.searchId.value);
+      return state.searchId.value;
     } catch (error) {
       console.error(error);
-      status.value = "error";
+      state.status.value = "error";
     }
-  }
-
-  const hasMoreResults = computed(() => {
-    return matches.value.length < (totalResults.value ?? 0);
-  });
-
-  async function loadMore() {
-    if (!searchId.value) {
+  },
+  async loadMore() {
+    if (!state.searchId.value) {
       throw new Error(
         "No search id found. Did you forget to call search() or searchById() first?"
       );
     }
 
-    if (!hasMoreResults.value) {
+    if (!getters(state).hasMoreResults.value) {
       console.log("cannot load more results, already at the end");
       return;
     }
 
-    status.value = "fetching";
-    const prevPage = currentPage.value;
+    state.status.value = "fetching";
+    const prevPage = state.currentPage.value;
     try {
-      currentPage.value = prevPage + 1;
+      state.currentPage.value = prevPage + 1;
       const res = await api.getSearchResultsById(
-        searchId.value,
-        currentPage.value
+        state.searchId.value,
+        state.currentPage.value
       );
-      matches.value.push(...res.matches);
-      searchEntry.value = res.searchEntry;
-      status.value = "success";
+      state.matches.value.push(...res.matches);
+      state.searchEntry.value = res.searchEntry;
+      state.status.value = "success";
     } catch (error) {
-      status.value = "error";
+      state.status.value = "error";
       // rollback page if error
-      currentPage.value = prevPage;
+      state.currentPage.value = prevPage;
       console.error(error);
     }
-  }
-
-  async function searchById(id: string) {
-    currentPage.value = 0;
-    searchId.value = id;
-    status.value = "fetching";
+  },
+  async searchById(id: string) {
+    state.currentPage.value = 0;
+    state.searchId.value = id;
+    state.status.value = "fetching";
 
     try {
       const res = await api.getSearchResultsById(id);
 
-      searchEntry.value = res.searchEntry;
-      totalResults.value = res.totalResults;
-      matches.value = res.matches;
-      status.value = "success";
+      state.searchEntry.value = res.searchEntry;
+      state.totalResults.value = res.totalResults;
+      state.matches.value = res.matches;
+      state.status.value = "success";
     } catch (error) {
       console.error(error);
-      status.value = "error";
+      state.status.value = "error";
     }
-  }
+  },
+});
+
+export const useSearchStore = defineStore("search", () => {
+  const state = createState();
+  const storeGetters = getters(state);
+  const storeActions = actions(state);
 
   return {
-    // expose refs as computed values to make readonly
-    // readonly() was causing type issues for some reason
-    query,
-    matches: computed(() => matches.value),
-    status: computed(() => status.value),
-    searchId: computed(() => searchId.value),
-    totalResults: computed(() => totalResults.value),
-    currentPage: computed(() => currentPage.value),
-    searchEntry: computed(() => searchEntry.value),
-    collectionIds: computed((): number[] | null => {
-      if (!searchEntry.value?.collection) return null;
-      // convert to numbers, as the api returns strings
-      return searchEntry.value.collection.map(Number.parseInt);
-    }),
-    hasMoreResults,
-    search,
-    searchById,
-    loadMore,
-    isReady,
+    ...storeGetters,
+    ...storeActions,
+    ...state,
   };
 });


### PR DESCRIPTION
This adds a navbar with links to the previous and next search result assets on the Asset Page.

Asset page with viewer:
<img width="500" alt="CleanShot 2023-04-10 at 17 14 33@2x" src="https://user-images.githubusercontent.com/980170/231009134-145401da-88e6-4e8d-bbb3-6c507c1828e7.png">

Meta data only page:
<img width="500" alt="CleanShot 2023-04-10 at 17 15 20@2x" src="https://user-images.githubusercontent.com/980170/231009399-c0a90466-49d2-4643-84e8-d5751ab8f7f7.png">

This version uses the searchStore for determining the next/prev search results, rather than doing another API query. When the user is within LOAD_MORE_THRESHOLD (currently 5) results of the last loaded result, more will be fetched.

currently up: <https://dev.elevator.umn.edu/defaultinstance/>

Closes #56 


