### PR TITLE
Persist Search Results Page tab state (e.g. 'list', 'grid')

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -17,12 +17,12 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import { RouterLink } from "vue-router";
+import { RouterLink, type RouteLocationRaw } from "vue-router";
 
 const props = withDefaults(
   defineProps<{
     href?: string;
-    to?: string;
+    to?: RouteLocationRaw;
     variant?: "primary" | "secondary" | "tertiary";
   }>(),
   {

--- a/src/components/Link/Link.vue
+++ b/src/components/Link/Link.vue
@@ -9,10 +9,10 @@
   </component>
 </template>
 <script setup lang="ts">
-import { RouterLink } from "vue-router";
+import { type RouteLocationRaw, RouterLink } from "vue-router";
 
 defineProps<{
-  to?: string;
+  to?: RouteLocationRaw;
   href?: string;
 }>();
 </script>

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -16,7 +16,7 @@
 
     <div class="flex justify-center text-xs text-gray-500 leading-none p-2">
       <Button
-        :to="`/search/s/${searchStore.searchId}#object-${assetStore.activeAssetId}`"
+        :to="`/search/s/${searchStore.searchId}?objectId=${assetStore.activeAssetId}#${searchStore.resultsView}`"
         variant="tertiary"
       >
         {{ currentAssetIndex + 1 }} of {{ searchStore.totalResults }}

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -16,7 +16,14 @@
 
     <div class="flex justify-center text-xs text-gray-500 leading-none p-2">
       <Button
-        :to="`/search/s/${searchStore.searchId}?objectId=${assetStore.activeAssetId}#${searchStore.resultsView}`"
+        :to="{
+          name: 'search',
+          params: { searchId: searchStore.searchId },
+          query: {
+            objectId: assetStore.activeAssetId,
+            resultsView: searchStore.resultsView,
+          },
+        }"
         variant="tertiary"
       >
         {{ currentAssetIndex + 1 }} of {{ searchStore.totalResults }}

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -4,7 +4,6 @@
     class="group hover:no-underline relative"
   >
     <MediaCard
-      :id="`object-${searchMatch.objectId}`"
       :imgSrc="thumbnailImgSrc"
       :imgAlt="title"
       class="search-result-card transition-all max-w-sm flex w-full h-full group-hover:outline outline-blue-600 group-hover:bg-blue-50 group-hover:text-blue-700 relative"

--- a/src/components/SearchResultsGrid/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid/SearchResultsGrid.vue
@@ -18,6 +18,7 @@
       >
         <SearchResultCard
           v-for="match in matches"
+          :id="`object-${match.objectId}`"
           :key="match.objectId"
           :searchMatch="match"
           :showDetails="false"

--- a/src/components/SearchResultsList/SearchResultsList.vue
+++ b/src/components/SearchResultsList/SearchResultsList.vue
@@ -17,6 +17,7 @@
       >
         <SearchResultRow
           v-for="match in matches"
+          :id="`object-${match.objectId}`"
           :key="match.objectId"
           :searchMatch="match"
           :showDetails="false"

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -2,13 +2,13 @@
   <div>
     <div class="tabs flex" :class="labelsClass">
       <button
-        v-for="(tab, index) in tabs"
+        v-for="tab in tabs"
         :key="tab.id"
         class="tab-button px-4 py-2 text-sm border-b-2"
         :class="{
-          'border-transparent text-neutral-400': index !== activeTabIndex,
+          'border-transparent text-neutral-400': tab.id !== activeTabId,
           'tab-button--is-active border-neutral-900 text-neutral-900 font-bold':
-            index === activeTabIndex,
+            tab.id === activeTabId,
         }"
         @click="setActiveTab(tab.id)"
       >
@@ -26,12 +26,16 @@ import { ref, provide } from "vue";
 import { TabsInjectionKey } from "@/constants/constants";
 import type { Tab, TabsContext } from "@/types";
 
-defineProps<{
+const props = defineProps<{
   labelsClass?: string;
+  activeTabId: string;
+}>();
+
+const emit = defineEmits<{
+  (event: "tabChange", tab: Tab): void;
 }>();
 
 const tabs = ref<Tab[]>([]);
-const activeTabIndex = ref(0);
 
 const addTab = (tab: Tab) => {
   tabs.value.push(tab);
@@ -40,23 +44,19 @@ const addTab = (tab: Tab) => {
 const removeTab = (tab: Tab) => {
   const index = tabs.value.findIndex((t) => t.id === tab.id);
   if (index === -1) return;
-  if (index === activeTabIndex.value) {
-    activeTabIndex.value = 0;
-  }
-
   tabs.value.splice(index, 1);
 };
 
 const setActiveTab = (tabId: string) => {
-  const index = tabs.value.findIndex((t) => t.id === tabId);
-  if (index === -1) return;
-  activeTabIndex.value = index;
+  const newActiveTab = tabs.value.find((t) => t.id === tabId);
+  if (!newActiveTab) {
+    throw new Error(`Tab with id ${tabId} not found`);
+  }
+  emit("tabChange", newActiveTab);
 };
 
 const isActiveTab = (tabId: string) => {
-  const index = tabs.value.findIndex((t) => t.id === tabId);
-  if (index === -1) return false;
-  return index === activeTabIndex.value;
+  return tabId === props.activeTabId;
 };
 
 provide<TabsContext>(TabsInjectionKey, {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -7,3 +7,5 @@ export const UMN_LNGLAT: LngLat = {
 };
 
 export const TabsInjectionKey = Symbol("Tabs") as InjectionKey<string>;
+
+export const SEARCH_RESULTS_VIEWS = ["grid", "list"] as const;

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -59,7 +59,6 @@ import SearchResultsList from "@/components/SearchResultsList/SearchResultsList.
 import type { SearchResultsView, Tab as TabType } from "@/types";
 import { SEARCH_RESULTS_VIEWS } from "@/constants/constants";
 import { nextTick } from "process";
-import Skeleton from "@/components/Skeleton/Skeleton.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -88,7 +87,8 @@ watch(
 
 const browsingCollectionId = computed((): number | null => {
   const isBrowsing =
-    searchStore.query === "" && searchStore.collectionIds?.length === 1;
+    searchStore.searchEntry?.searchText === "" &&
+    searchStore.collectionIds?.length === 1;
   if (!isBrowsing) return null;
   return searchStore.collectionIds[0];
 });

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -1,23 +1,26 @@
 <template>
   <DefaultLayout class="search-results-page">
     <div class="px-4">
-      <BrowseCollectionHeader
-        v-if="browsingCollectionId"
-        :collectionId="browsingCollectionId"
-      />
-      <h2
-        v-if="searchStore.searchEntry?.searchText"
-        class="text-4xl my-8 font-bold"
-      >
-        <q>{{ searchStore.searchEntry.searchText }}</q>
-      </h2>
-      <h2
-        v-if="!browsingCollectionId && !searchStore.searchEntry?.searchText"
-        class="text-4xl my-8 font-bold"
-      >
-        All Assets
-      </h2>
       <p v-if="searchStore.status === 'error'">Error loading search results.</p>
+
+      <template v-if="searchStore.status === 'success'">
+        <BrowseCollectionHeader
+          v-if="browsingCollectionId"
+          :collectionId="browsingCollectionId"
+        />
+        <h2
+          v-if="searchStore.searchEntry?.searchText"
+          class="text-4xl my-8 font-bold"
+        >
+          <q>{{ searchStore.searchEntry.searchText }}</q>
+        </h2>
+        <h2
+          v-if="!browsingCollectionId && !searchStore.searchEntry?.searchText"
+          class="text-4xl my-8 font-bold"
+        >
+          All Assets
+        </h2>
+      </template>
       <Tabs
         labelsClass="sticky top-14 z-20 search-results-page__tabs -mx-4 px-4 border-b border-neutral-200 pt-4"
         :activeTabId="searchStore.resultsView"
@@ -56,6 +59,7 @@ import SearchResultsList from "@/components/SearchResultsList/SearchResultsList.
 import type { SearchResultsView, Tab as TabType } from "@/types";
 import { SEARCH_RESULTS_VIEWS } from "@/constants/constants";
 import { nextTick } from "process";
+import Skeleton from "@/components/Skeleton/Skeleton.vue";
 
 const props = withDefaults(
   defineProps<{

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -134,8 +134,8 @@ watch(
     if (!objectId) return;
     nextTick(() => {
       const el = document.getElementById(`object-${objectId}`);
-      console.log("scrolling to", el);
       if (!el) return;
+
       el.scrollIntoView({
         behavior: "smooth",
         block: "center",

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -44,7 +44,7 @@
   </DefaultLayout>
 </template>
 <script setup lang="ts">
-import { watch, computed, ref, onMounted } from "vue";
+import { watch, computed, onMounted } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useSearchStore } from "@/stores/searchStore";
@@ -111,7 +111,21 @@ function handleTabChange(tab: TabType) {
   });
 }
 
-onMounted(() => searchStore.setResultsView(props.resultsView || "grid"));
+onMounted(() => {
+  const initialTabId = props.resultsView || searchStore.resultsView || "grid";
+  // if the query param is set, use it to set the state
+  // otherwise we'll fall back to the current resultsView
+  // or failing that, the default "grid" view
+  searchStore.setResultsView(initialTabId);
+
+  // update the url query param to match state
+  router.replace({
+    query: {
+      ...route.query,
+      resultsView: initialTabId,
+    },
+  });
+});
 
 // scroll to objectId if it's in the search results
 watch(

--- a/src/router.ts
+++ b/src/router.ts
@@ -90,7 +90,11 @@ const router = createRouter({
       path: "/search/s/:searchId",
       component: () =>
         import("@/pages/SearchResultsPage/SearchResultsPage.vue"),
-      props: true,
+      props: (route) => ({
+        searchId: route.params.searchId,
+        objectId: route.query.objectId ?? null,
+        resultsView: route.query.resultsView ?? null,
+      }),
     },
     {
       name: "StaticContentPage",

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -11,6 +11,7 @@ const createState = () => ({
   totalResults: ref<number | undefined>(undefined),
   currentPage: ref(0),
   searchEntry: ref<SearchEntry | null>(null),
+  resultsView: ref<"grid" | "list">("grid"),
 });
 
 const getters = (state: ReturnType<typeof createState>) => ({

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -1,7 +1,13 @@
 import { defineStore } from "pinia";
 import api from "@/api";
 import { ref, computed } from "vue";
-import { FetchStatus, SearchResultMatch, SearchEntry } from "@/types";
+
+import {
+  FetchStatus,
+  SearchResultMatch,
+  SearchEntry,
+  SearchResultsView,
+} from "@/types";
 
 const createState = () => ({
   searchId: ref<string | undefined>(undefined),
@@ -11,7 +17,7 @@ const createState = () => ({
   totalResults: ref<number | undefined>(undefined),
   currentPage: ref(0),
   searchEntry: ref<SearchEntry | null>(null),
-  resultsView: ref<"grid" | "list">("grid"),
+  resultsView: ref<SearchResultsView>("grid"),
 });
 
 const getters = (state: ReturnType<typeof createState>) => ({
@@ -99,6 +105,9 @@ const actions = (state: ReturnType<typeof createState>) => ({
       console.error(error);
       state.status.value = "error";
     }
+  },
+  setResultsView(view: SearchResultsView) {
+    state.resultsView.value = view;
   },
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { SEARCH_RESULTS_VIEWS } from "@/constants/constants";
+
 export interface AppConfig {
   instance: {
     base: {
@@ -497,4 +499,8 @@ export interface TabsContext {
   removeTab: (tab: Tab) => void;
   setActiveTab: (id: string) => void;
   isActiveTab: (id: string) => boolean;
+  initialTabId?: string;
 }
+
+// must be a member of the SEARCH_RESULTS_VIEWS array
+export type SearchResultsView = typeof SEARCH_RESULTS_VIEWS[number];


### PR DESCRIPTION
This makes the search results page's tab view "sticky", meaning that:
1. if a user changes tab views (i.e. from "grid" view to "list" view), and then does another search, the search results will be displayed in the same view as the first search ("list" view)
2. if a user shares a url, the view state will be embedded as a query parameter
3. if a user navigates to a particular asset, clicking on the back to search results button (e.g. "13 of 243") will return the user to the same view

### Notables

- We're using `searchStore.resultsView` as the "source of truth" of what the search results view should be, and then deriving state and url info from that. I opted for this because the AssetViewPage might have a navbar with previous, next, and a middle "back to results" button. I wanted clicking back to results to return to the previous view (item 3 above), and this required knowing what the previous view was. It seemed easier to track this in pinia, than add this view state query param to asset view page url.

- As part of this update, the `<Tabs>` component no longer keeps internal state for which tab is the active tab. Instead it's a fully "controlled" component with one way data flow.

- When clicking "back to results" button, we were previously included a hash to indicate an objectId.  This has been changed to a query param as well. No particular reason other than we're using query params for the other item too.

Altogether, the search url will look something like: `/search/s/12345?resultsView=list&objectId=abcde`.

PR up here for testing: <https://dev.elevator.umn.edu/defaultinstance/search/s/bb4a1b67-cc7e-4d6d-a2c2-af01c03b6718?resultsView=list>