### PR TITLE
Change Search Page `Load More` button to `Load All`

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -265,7 +265,8 @@ export default {
 
   async getSearchResultsById(
     searchId: string,
-    page = 0
+    page = 0,
+    loadAll = false
   ): Promise<SearchResultsResponse> {
     // check the cache first
     const searchMap = paginatedSearchResults.get(searchId);
@@ -274,7 +275,7 @@ export default {
     }
 
     const res = await axios.get<SearchResultsResponse>(
-      `${BASE_URL}/search/searchResults/${searchId}/${page}/false`
+      `${BASE_URL}/search/searchResults/${searchId}/${page}/${loadAll}`
     );
 
     const searchResults = res.data;

--- a/src/components/ResultsCount/ResultsCount.vue
+++ b/src/components/ResultsCount/ResultsCount.vue
@@ -9,7 +9,7 @@
         variant="tertiary"
         @click="$emit('loadMore')"
       >
-        Load More
+        <slot name="loadMoreButtonLabel">Load More</slot>
         <SpinnerIcon
           v-show="status === 'fetching'"
           class="w-3 h-3 text-blue-600 ml-1"

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -25,8 +25,15 @@
           :total="searchStore.totalResults ?? 0"
           :status="searchStore.status"
           class="mb-2"
-          @loadMore="() => searchStore.loadMore()"
-        />
+          @loadMore="() => searchStore.loadMore({ loadAll: true })"
+        >
+          <template #loadMoreButtonLabel>
+            {{
+              // if we have 1000+ results, then we can't load all at once
+              (searchStore.totalResults ?? 0) <= 1000 ? "Load All" : "Load More"
+            }}
+          </template>
+        </ResultsCount>
         <Tab id="grid" label="Grid">
           <SearchResultsGrid
             :totalResults="searchStore.totalResults"

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -59,7 +59,7 @@ const actions = (state: ReturnType<typeof createState>) => ({
       state.status.value = "error";
     }
   },
-  async loadMore() {
+  async loadMore({ loadAll } = { loadAll: false }) {
     if (!state.searchId.value) {
       throw new Error(
         "No search id found. Did you forget to call search() or searchById() first?"
@@ -77,7 +77,8 @@ const actions = (state: ReturnType<typeof createState>) => ({
       state.currentPage.value = prevPage + 1;
       const res = await api.getSearchResultsById(
         state.searchId.value,
-        state.currentPage.value
+        state.currentPage.value,
+        loadAll
       );
       state.matches.value.push(...res.matches);
       state.searchEntry.value = res.searchEntry;


### PR DESCRIPTION
The search page has a result count with a button for Loading More results. The default behavior for loading more is loading 30 more results. For larger result sets, it can be annoying to repeatedly click "Load More" when you want all the results – especially on Map or Timeline views which don't have infinite scroll.

This changes the "Load More" button to get 1000 results instead of the default 30. The button text will be "Load All" if we can get all results. If not, the text will be "Load More".

This PR adds an additional `loadMore` params to `searchStore.loadMore` and `api.getSearchResultsById`.

I added a slot to the the `<ResultsCount>` component so that the parent can pass down the "Load More" or "Load All" button text. I opted for the slot approach since ResultsCount was just emitting `loadMore`, leaving the handling to the parent. If the parent was controlling what the `loadMore` button should do, it seemed it should also control what the button should say. TMTOWTDI.


## Screenshots

Less than 1000 results. The button says "Load All":
![ScreenShot 2023-04-24 at 11 34 53](https://user-images.githubusercontent.com/980170/234066147-8ef5a652-069f-4b42-8ef3-9ebb4b7d3048.gif)

More than 1000, the button says "Load More":
![ScreenShot 2023-04-24 at 11 34 22](https://user-images.githubusercontent.com/980170/234066170-500d5bc4-8134-43d2-bb39-dc8163202865.gif)