### PR TITLE
add bg to AppMenuItem on hover

### DIFF
--- a/src/components/AppMenu/AppMenuItem.vue
+++ b/src/components/AppMenu/AppMenuItem.vue
@@ -2,7 +2,7 @@
   <Link
     :href="href"
     :to="to"
-    class="app-menu-item group w-full flex items-center pl-2 py-2 font-medium my-1 hover:no-underline"
+    class="app-menu-item group w-full flex items-center pl-2 py-2 font-medium my-1 hover:no-underline focus:outline-none focus:ring-2 focus:ring-indigo-500 hover:bg-blue-100 hover:text-neutral-900"
     :class="{
       'is-current-page': isCurrentPage,
     }"


### PR DESCRIPTION
Previously, `AppMenuGroup` had a background color, but `AppMenuItem` didn't. Which meant some menu items, like links to "Collections" and static pages had different effects on hover than groups like "Edit" and "Help".

This applies the same styles to `AppMenuItem`.

<img width="300" alt="ScreenShot 2023-04-26 at 08 32 13@2x" src="https://user-images.githubusercontent.com/980170/234592046-3c72dcd3-91d1-40de-aaec-742af059816b.png">
