### PR TITLE
Fix App Menu `Edit` doesn't appear

### DIFF
--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -14,7 +14,7 @@
       </AppMenuItem>
 
       <EditNavSection
-        v-if="activeAssetId && currentUser?.canManageAssets"
+        v-if="currentUser?.canManageAssets"
         :currentUser="currentUser"
         :instance="instance"
         :assetId="activeAssetId"

--- a/src/components/AppMenu/EditNavSection.vue
+++ b/src/components/AppMenu/EditNavSection.vue
@@ -3,14 +3,16 @@
     <AppMenuItem :href="`${BASE_URL}/assetManager/addAssetModal`">
       Add Asset
     </AppMenuItem>
-    <AppMenuItem :href="`${BASE_URL}/assetManager/editAsset/${assetId}`">
-      Edit Asset
-    </AppMenuItem>
-    <AppMenuItem @click="handleDeleteAssetClick"> Delete Asset </AppMenuItem>
-    <AppMenuItem :href="`${BASE_URL}/assetManager/restoreAsset/${assetId}`">
-      Restore Asset
-    </AppMenuItem>
-    <Divider />
+    <template v-if="assetId">
+      <AppMenuItem :href="`${BASE_URL}/assetManager/editAsset/${assetId}`">
+        Edit Asset
+      </AppMenuItem>
+      <AppMenuItem @click="handleDeleteAssetClick"> Delete Asset </AppMenuItem>
+      <AppMenuItem :href="`${BASE_URL}/assetManager/restoreAsset/${assetId}`">
+        Restore Asset
+      </AppMenuItem>
+      <Divider />
+    </template>
     <AppMenuItem :href="`${BASE_URL}/assetManager/userAssets/`">
       All My Assets
     </AppMenuItem>
@@ -29,10 +31,14 @@ const BASE_URL = config.instance.base.url;
 const props = defineProps<{
   currentUser: User;
   instance: ElevatorInstance;
-  assetId: string;
+  assetId: string | null;
 }>();
 
 async function handleDeleteAssetClick() {
+  if (!props.assetId) {
+    throw new Error(`assetId is null. Cannot delete asset.`);
+  }
+
   if (
     !confirm("Are you sure you want to delete this asset and all derivatives")
   ) {

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -16,7 +16,7 @@
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
 import { useAssetStore } from "@/stores/assetStore";
-import { useRoute } from "vue-router";
+import { useRoute, onBeforeRouteLeave } from "vue-router";
 import NoScrollLayout from "@/layouts/NoScrollLayout.vue";
 import AssetView from "./AssetView.vue";
 import MetaDataOnlyView from "./MetaDataOnlyView.vue";
@@ -70,6 +70,12 @@ watch([() => props.assetId, () => route.params?.assetId], onAssetIdChange, {
 
 watch([() => props.objectId, () => route.hash], async () => {
   await assetStore.setActiveObject(objectId.value);
+});
+
+onBeforeRouteLeave(() => {
+  // clear the active asset so that the next page (e.g. Home Page)
+  // doesn't show editing controls for this asset
+  assetStore.setActiveAsset(null);
 });
 </script>
 <style scoped></style>


### PR DESCRIPTION
When there's no asset loaded in the assetStore, the Edit menu won't appear in the App Menu since this `assetId` is null.

This removes the check for a truthy `assetId` from `<AppMenu>` and instead checks within the `EditNavSection` so that users still have an option to Add Assets or view all their assets if they `canManageAssets`.
