### PR TITLE
App Header: Move Theme Selector, Fix Avatar Proportions (stacked on #115)

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -10,13 +10,7 @@
       class="flex-1 w-full max-w-lg"
     />
     <div class="flex gap-2 items-center">
-      <ThemeSelector
-        v-show="config.instance.theming.enabled"
-        class="hidden sm:block"
-        :defaultTheme="config.instance.theming.defaultTheme"
-      />
       <AuthDropDown
-        class="hidden sm:block mr-2"
         :currentUser="currentUser"
         :instance="instanceStore.instance"
       />
@@ -26,13 +20,11 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import config from "@/config";
 import AppMenuButton from "@/components/AppMenuButton/AppMenuButton.vue";
-import ThemeSelector from "@/components/ThemeSelector/ThemeSelector.vue";
 import SearchBar from "@/components/SearchBar/SearchBar.vue";
 import AppLogoMark from "@/components/AppLogoMark/AppLogoMark.vue";
 import Link from "@/components/Link/Link.vue";
-import AuthDropDown from "./AuthDropDown.vue";
+import AuthDropDown from "@/components/AuthDropDown/AuthDropDown.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 
 const instanceStore = useInstanceStore();

--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -14,7 +14,7 @@
       </AppMenuItem>
 
       <EditNavSection
-        v-if="activeAssetId && currentUser?.canManageAssets"
+        v-if="currentUser?.canManageAssets"
         :currentUser="currentUser"
         :instance="instance"
         :assetId="activeAssetId"

--- a/src/components/AppMenu/AppMenuPure.vue
+++ b/src/components/AppMenu/AppMenuPure.vue
@@ -1,10 +1,10 @@
 <template>
   <nav
-    class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 sm:pb-4 p-4 h-full relative"
+    class="app-menu flex flex-col w-[90vw] sm:w-md sm:px-8 sm:py-4 p-4 h-full relative"
   >
     <XButton class="absolute right-4 top-4" @click="$emit('close')" />
     <header
-      class="app-menu__header flex mt-4 py-4 justify-between items-center"
+      class="app-menu__header flex mt-4 pt-6 pb-2 justify-between items-center"
     >
       <Link to="/">
         <h1 class="md:text-xl text-lg font-bold">

--- a/src/components/AppMenu/AppMenuPure.vue
+++ b/src/components/AppMenu/AppMenuPure.vue
@@ -3,26 +3,28 @@
     class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 p-4 h-full relative"
   >
     <XButton class="absolute right-4 top-4" @click="$emit('close')" />
-    <header class="app-menu__header flex mt-4 py-4">
+    <header
+      class="app-menu__header flex mt-4 py-4 justify-between items-center"
+    >
       <Link to="/">
-        <h1 class="md:text-2xl text-lg font-bold">
+        <h1 class="md:text-xl text-lg font-bold">
           {{ instance.name }}
         </h1>
       </Link>
+      <div class="flex items-center">
+        <ThemeSelector
+          v-show="config.instance.theming.enabled"
+          :defaultTheme="config.instance.theming.defaultTheme"
+        />
+        <AuthDropDown :currentUser="currentUser" :instance="instance" />
+      </div>
     </header>
     <div
       class="app-menu__items flex-1 py-4 border-y border-neutral-600 overflow-auto"
     >
       <slot />
     </div>
-    <AppMenuAuthSection
-      :instance="instance"
-      :currentUser="currentUser"
-      class="app-menu__auth-section py-4"
-    />
-    <footer
-      class="app-menu__footer py-4 sm:flex flex-col items-center text-sm hidden"
-    >
+    <footer class="app-menu__footer py-4 flex flex-col items-center text-sm">
       <p>
         Powered by <a href="https://umn-latis.github.io/elevator/">Elevator</a>
       </p>
@@ -37,10 +39,12 @@
 </template>
 <script setup lang="ts">
 import XButton from "@/components/XButton/XButton.vue";
-import AppMenuAuthSection from "./AppMenuAuthSection.vue";
 import Link from "@/components/Link/Link.vue";
 import { ElevatorInstance, User } from "@/types";
 import UMNLogo from "@/icons/UMNLogo.vue";
+import ThemeSelector from "@/components/ThemeSelector/ThemeSelector.vue";
+import config from "@/config";
+import AuthDropDown from "@/components/AuthDropDown/AuthDropDown.vue";
 
 defineProps<{
   instance: ElevatorInstance;

--- a/src/components/AppMenu/AppMenuPure.vue
+++ b/src/components/AppMenu/AppMenuPure.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 p-4 h-full relative"
+    class="app-menu flex flex-col w-[90vw] sm:w-md sm:p-8 sm:pb-4 p-4 h-full relative"
   >
     <XButton class="absolute right-4 top-4" @click="$emit('close')" />
     <header
@@ -16,7 +16,6 @@
           v-show="config.instance.theming.enabled"
           :defaultTheme="config.instance.theming.defaultTheme"
         />
-        <AuthDropDown :currentUser="currentUser" :instance="instance" />
       </div>
     </header>
     <div
@@ -24,7 +23,7 @@
     >
       <slot />
     </div>
-    <footer class="app-menu__footer py-4 flex flex-col items-center text-sm">
+    <footer class="app-menu__footer pt-4 flex flex-col items-center text-sm">
       <p>
         Powered by <a href="https://umn-latis.github.io/elevator/">Elevator</a>
       </p>
@@ -45,6 +44,7 @@ import UMNLogo from "@/icons/UMNLogo.vue";
 import ThemeSelector from "@/components/ThemeSelector/ThemeSelector.vue";
 import config from "@/config";
 import AuthDropDown from "@/components/AuthDropDown/AuthDropDown.vue";
+import AppMenuAuthSection from "./AppMenuAuthSection.vue";
 
 defineProps<{
   instance: ElevatorInstance;

--- a/src/components/AppMenu/EditNavSection.vue
+++ b/src/components/AppMenu/EditNavSection.vue
@@ -3,14 +3,16 @@
     <AppMenuItem :href="`${BASE_URL}/assetManager/addAssetModal`">
       Add Asset
     </AppMenuItem>
-    <AppMenuItem :href="`${BASE_URL}/assetManager/editAsset/${assetId}`">
-      Edit Asset
-    </AppMenuItem>
-    <AppMenuItem @click="handleDeleteAssetClick"> Delete Asset </AppMenuItem>
-    <AppMenuItem :href="`${BASE_URL}/assetManager/restoreAsset/${assetId}`">
-      Restore Asset
-    </AppMenuItem>
-    <Divider />
+    <template v-if="assetId">
+      <AppMenuItem :href="`${BASE_URL}/assetManager/editAsset/${assetId}`">
+        Edit Asset
+      </AppMenuItem>
+      <AppMenuItem @click="handleDeleteAssetClick"> Delete Asset </AppMenuItem>
+      <AppMenuItem :href="`${BASE_URL}/assetManager/restoreAsset/${assetId}`">
+        Restore Asset
+      </AppMenuItem>
+      <Divider />
+    </template>
     <AppMenuItem :href="`${BASE_URL}/assetManager/userAssets/`">
       All My Assets
     </AppMenuItem>
@@ -29,10 +31,14 @@ const BASE_URL = config.instance.base.url;
 const props = defineProps<{
   currentUser: User;
   instance: ElevatorInstance;
-  assetId: string;
+  assetId: string | null;
 }>();
 
 async function handleDeleteAssetClick() {
+  if (!props.assetId) {
+    throw new Error(`assetId is null. Cannot delete asset.`);
+  }
+
   if (
     !confirm("Are you sure you want to delete this asset and all derivatives")
   ) {

--- a/src/components/AuthDropDown/AuthDropDown.vue
+++ b/src/components/AuthDropDown/AuthDropDown.vue
@@ -5,6 +5,12 @@
       <span v-else>Login</span>
     </template>
     <template v-if="currentUser">
+      <div
+        class="p-4 border-b border-neutral-300 text-xs flex items-center gap-1"
+      >
+        <span class="text-neutral-400"> Signed in as </span>
+        <b class="font-normal">{{ currentUser.displayName }}</b>
+      </div>
       <DropDownItem
         v-if="currentUser.id"
         :href="`${config.instance.base.url}/permissions/editUser/${currentUser.id}`"

--- a/src/components/AuthDropDown/AuthDropDown.vue
+++ b/src/components/AuthDropDown/AuthDropDown.vue
@@ -1,5 +1,5 @@
 <template>
-  <DropDown :label="menuLabel">
+  <DropDown :label="menuLabel" :showChevron="false">
     <template #label>
       <Avatar v-if="currentUser" :name="currentUser.displayName" />
       <span v-else>Login</span>

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -1,9 +1,8 @@
 <template>
   <div
-    class="avatar inline-flex justify-center items-center rounded-md px-2 py-1 border"
-    :class="avatarColorClasses"
+    class="avatar inline-flex justify-center items-center rounded-full w-6 h-6 border text-xs border-neutral-900 font-sans"
   >
-    {{ initials }}
+    {{ firstInitial }}
   </div>
 </template>
 <script setup lang="ts">
@@ -12,42 +11,12 @@ const props = defineProps<{
   name: string;
 }>();
 
-const initials = computed(() => {
+const firstInitial = computed(() => {
   if (!props.name.length) {
     return "X";
   }
 
-  const allInitials = props.name
-    .split(" ")
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
-
-  return allInitials.length <= 2
-    ? allInitials
-    : // first and last initials
-      allInitials[0] + allInitials[allInitials.length - 1];
-});
-
-// possible avatar color sets
-const colorOptions = [
-  "bg-blue-100 text-blue-700 border-blue-200",
-  "bg-green-100 text-green-700 border-green-200",
-  "bg-indigo-100 text-indigo-700 border-indigo-200",
-  "bg-yellow-100 text-yellow-700 border-yellow-200",
-  "bg-red-100 text-red-700 border-red-200",
-  "bg-cyan-100 text-cyan-700 border-cyan-200",
-  "bg-purple-100 text-purple-700 border-purple-200",
-  "bg-orange-100 text-orange-700 border-orange-200",
-  "bg-teal-100 text-teal-700 border-teal-200",
-];
-
-const avatarColorClasses = computed(() => {
-  // sum up the char codes for the name and use that to pick a color
-  const colorIndex = props.name
-    .split("")
-    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
-  return colorOptions[colorIndex % colorOptions.length];
+  return props.name[0].toUpperCase();
 });
 </script>
 <style scoped></style>

--- a/src/components/DropDown/DropDown.vue
+++ b/src/components/DropDown/DropDown.vue
@@ -7,7 +7,11 @@
         <slot name="label">
           {{ label }}
         </slot>
-        <ChevronDownIcon class="xl:block h-4 w-4 m-1" aria-hidden="true" />
+        <ChevronDownIcon
+          v-if="showChevron"
+          class="xl:block h-4 w-4 m-1"
+          aria-hidden="true"
+        />
       </MenuButton>
     </div>
 
@@ -44,9 +48,11 @@ withDefaults(
   defineProps<{
     label: string;
     alignment?: "left" | "right";
+    showChevron?: boolean;
   }>(),
   {
     alignment: "right",
+    showChevron: true,
   }
 );
 </script>

--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -19,7 +19,7 @@
         :type="type"
         :name="id"
         :value="value"
-        class="block w-full rounded-md border-none focus:ring-indigo-500 focus:ring-offset-2 focus:ring-2 sm:text-sm py-2 bg-transparent-black-100"
+        class="block w-full rounded-md border-none focus:ring-indigo-500 focus:ring-offset-2 focus:ring-2 sm:text-sm py-2 bg-transparent-black-100 placeholder-transparent-black-400"
         :class="{
           'pl-10': $slots.prepend,
           'pr-10': $slots.append,

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -14,9 +14,9 @@
       >
         <template #prepend>
           <SearchIcon
-            class="h-5 w-5 text-neutral-400"
+            class="h-5 w-5 text-transparent-black-500"
             :class="{
-              'text-neutral-600': searchInputHasFocus,
+              'text-transparent-black-800': searchInputHasFocus,
             }"
             aria-hidden="true"
           />
@@ -26,13 +26,17 @@
             <button
               v-if="searchStore.query.length"
               type="button"
-              class="text-neutral-400 hover:text-neutral-900"
+              class="text-transparent-black-500 hover:text-neutral-900"
               @click="handleClearSearchInput"
             >
-              <CircleXIcon />
+              <CircleXIcon class="" />
             </button>
 
-            <KeyboardShortcut class="hidden sm:block"> ⌘K </KeyboardShortcut>
+            <KeyboardShortcut
+              class="hidden sm:block text-transparent-black-500 border-transparent-black-500"
+            >
+              ⌘K
+            </KeyboardShortcut>
           </div>
         </template>
       </InputGroup>

--- a/src/components/ThemeSelector/ThemeSelector.vue
+++ b/src/components/ThemeSelector/ThemeSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <DropDown label="Select Theme">
+  <DropDown label="Select Theme" :showChevron="false">
     <template #label>
       <ThemeIcon />
     </template>

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -16,7 +16,7 @@
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
 import { useAssetStore } from "@/stores/assetStore";
-import { useRoute } from "vue-router";
+import { useRoute, onBeforeRouteLeave } from "vue-router";
 import NoScrollLayout from "@/layouts/NoScrollLayout.vue";
 import AssetView from "./AssetView.vue";
 import MetaDataOnlyView from "./MetaDataOnlyView.vue";
@@ -70,6 +70,12 @@ watch([() => props.assetId, () => route.params?.assetId], onAssetIdChange, {
 
 watch([() => props.objectId, () => route.hash], async () => {
   await assetStore.setActiveObject(objectId.value);
+});
+
+onBeforeRouteLeave(() => {
+  // clear the active asset so that the next page (e.g. Home Page)
+  // doesn't show editing controls for this asset
+  assetStore.setActiveAsset(null);
 });
 </script>
 <style scoped></style>


### PR DESCRIPTION
Resolves:
- #101 
- #85 

This updates the app header:
- moves the Theme selector to App Menu flyout.
- Fixes the Avatar initial proportions and simplifies the look: circular, without background color, drops the chevron, adds "Signed in as..." to the dropdown menu. Also changes the first initial font to be generic `sans-serif`. Some fonts (like open sans) have uppercase glyphs (like "J") that descend below the baseline and look off-center.
- Since the Avatar dropdown now shows "Signed in as", this info in dropped from the flyout App Menu.
- Changes the Search Input colors from neutrals to transparent blacks. The grayscale text looks off when the background has a color, like in the Folwell theme. Neutral black mixes better with the bg color.

Stacked on #115 

Live on dev: <https://dev.elevator.umn.edu/defaultinstance/>

## Screenshots

Not Logged in:
<img width="500" alt="ScreenShot 2023-04-26 at 14 46 16@2x" src="https://user-images.githubusercontent.com/980170/234686063-141d5c58-313e-4329-9847-602571395c48.png">

Logged in. With updated avatar, and "Logged in as..." in dropdown:
<img width="500" alt="ScreenShot 2023-04-26 at 14 45 41@2x" src="https://user-images.githubusercontent.com/980170/234686096-b44f1706-fd30-4731-bea9-45753bfe87fa.png">

Updated app menu. Theme Selector across from "default instance":
<img width="500" alt="ScreenShot 2023-04-26 at 14 45 53@2x" src="https://user-images.githubusercontent.com/980170/234686078-86dce253-618e-49f9-8787-00eda982bb99.png">

