### PR TITLE
Add gallery view for search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@knight-lab/timelinejs": "^3.9.2",
     "@mdx-js/react": "^2.1.3",
     "@storybook/client-api": "^6.5.12",
+    "@vueuse/components": "^10.1.2",
     "@vueuse/core": "^9.3.0",
     "autolink-js": "^1.0.2",
     "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "shave": "^5.0.0",
     "storybook-vue3-router": "^2.3.1",
     "striptags": "^4.0.0-alpha.4",
+    "swiper": "^9.2.4",
     "vue": "^3.2.39",
     "vue-router": "4",
     "vue-toasted": "^1.1.28",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,7 +10,6 @@ import {
   ApiInstanceNavResponse,
   ApiStaticPageResponse,
   FileDownloadNormalized,
-  RelatedAssetCacheItemWithId,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -143,30 +142,6 @@ const api = {
     return asset;
   },
 
-  /**
-   * gets any related objects for a given asset
-   * for example, an asset may have several images associated with
-   * it. This would return those related images.
-   */
-  async getAssetChildren(
-    assetId: string
-  ): Promise<RelatedAssetCacheItemWithId[]> {
-    const asset = await api.getAsset(assetId);
-
-    if (!asset || !asset.relatedAssetCache) {
-      return [];
-    }
-
-    return Object.entries(asset.relatedAssetCache).reduce(
-      (acc, [id, maybeRelatedAsset]) => {
-        if (!maybeRelatedAsset) {
-          return acc;
-        }
-        return [...acc, { ...maybeRelatedAsset, id }];
-      },
-      [] as RelatedAssetCacheItemWithId[]
-    );
-  },
   async getAssetWithTemplate(
     assetId: string | null
   ): Promise<{ asset: Asset | null; template: Template | null }> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,7 @@ import {
   ApiInstanceNavResponse,
   ApiStaticPageResponse,
   FileDownloadNormalized,
+  RelatedAssetCacheItemWithId,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -131,7 +132,7 @@ async function fetchStaticPage(pageId: number): Promise<ApiStaticPageResponse> {
   return res.data;
 }
 
-export default {
+const api = {
   async getAsset(assetId: string): Promise<Asset | null> {
     if (!assetId) return null;
 
@@ -140,6 +141,31 @@ export default {
     assets.set(assetId, asset);
 
     return asset;
+  },
+
+  /**
+   * gets any related objects for a given asset
+   * for example, an asset may have several images associated with
+   * it. This would return those related images.
+   */
+  async getAssetChildren(
+    assetId: string
+  ): Promise<RelatedAssetCacheItemWithId[]> {
+    const asset = await api.getAsset(assetId);
+
+    if (!asset || !asset.relatedAssetCache) {
+      return [];
+    }
+
+    return Object.entries(asset.relatedAssetCache).reduce(
+      (acc, [id, maybeRelatedAsset]) => {
+        if (!maybeRelatedAsset) {
+          return acc;
+        }
+        return [...acc, { ...maybeRelatedAsset, id }];
+      },
+      [] as RelatedAssetCacheItemWithId[]
+    );
   },
   async getAssetWithTemplate(
     assetId: string | null
@@ -314,3 +340,5 @@ export default {
     return res.data;
   },
 };
+
+export default api;

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -2,13 +2,10 @@
   <div class="search-results-gallery mb-8">
     <div v-if="mainSwiper" class="flex items-center justify-between mb-1">
       <Button variant="tertiary" @click="mainSwiper.slidePrev()">
-        <ChevronLeftIcon />
+        <ChevronLeftIcon class="w-5" />
         Previous
       </Button>
-      <div class="flex flex-col items-center justify-center">
-        <span class="text-xs">
-          {{ activeSlideIndex + 1 }} / {{ slides.length }}
-        </span>
+      <div class="flex flex-col items-center justify-center flex-1">
         <h2>
           <Link
             v-if="activeSlide.objectId"
@@ -19,7 +16,11 @@
         </h2>
       </div>
 
-      <Button variant="tertiary" @click="mainSwiper.slideNext()">
+      <Button
+        variant="tertiary"
+        class="!m-0 !-mr-2"
+        @click="mainSwiper.slideNext()"
+      >
         Next
         <ChevronRightIcon />
       </Button>
@@ -29,7 +30,6 @@
       :modules="modules"
       :slidesPerView="1"
       :spaceBetween="50"
-      :scrollbar="{ draggable: true }"
       :thumbs="{ swiper: thumbsSwiper }"
       @swiper="setMainSwiper"
       @slideChange="onMainSlideChange"
@@ -59,10 +59,11 @@
     <!-- It is also required to set watchSlidesProgress prop -->
     <Swiper
       class="thumbs-swiper w-full"
-      :modules="[Thumbs]"
+      :modules="[Thumbs, Scrollbar]"
       :watchSlidesProgress="true"
       :slidesPerView="10"
       :centeredSlides="true"
+      :scrollbar="{ draggable: true, dragSize: 32 }"
       :spaceBetween="4"
       @swiper="setThumbsSwiper"
     >
@@ -71,6 +72,7 @@
           class="border border-neutral-400 aspect-video flex items-center justify-center w-full relative"
         >
           <div
+            v-if="i !== activeSlideIndex"
             class="absolute bottom-0 left-0 w-6 h-6 text-xs z-10 flex items-center justify-center bg-transparent-white-800 text-neutral-900"
           >
             {{ i + 1 }}
@@ -85,6 +87,21 @@
         </div>
       </SwiperSlide>
     </Swiper>
+
+    <div v-if="mainSwiper" class="flex items-center justify-center mb-1">
+      <Button variant="tertiary" class="!m-0" @click="mainSwiper.slidePrev()">
+        <ChevronLeftIcon />
+      </Button>
+      <div
+        class="flex flex-col items-center justify-center text-xs text-center px-4 py-2"
+      >
+        {{ activeSlideIndex + 1 }} / {{ slides.length }}
+      </div>
+
+      <Button variant="tertiary" class="!m-0" @click="mainSwiper.slideNext()">
+        <ChevronRightIcon />
+      </Button>
+    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -153,7 +170,7 @@ watch(
 <style>
 .main-swiper {
   width: 100%;
-  height: 50vh;
+  height: 66vh;
 }
 
 .swiper-slide {
@@ -166,6 +183,13 @@ watch(
   justify-content: center;
   align-items: center;
   height: 100%;
+}
+
+.thumbs-swiper {
+  --swiper-scrollbar-size: 0.5rem;
+  --swiper-scrollbar-bottom: -0rem;
+  --swiper-scrollbar-bg-color: rgba(0, 0, 0, 0.1);
+  --swiper-scrollbar-drag-bg-color: rgba(0, 0, 0, 0.5);
 }
 
 .thumbs-swiper .swiper-slide {

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="search-results-gallery">
+    <h1>Gallery Goes Here</h1>
+  </div>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -66,6 +66,8 @@
       :scrollbar="{ draggable: true, dragSize: 32 }"
       :spaceBetween="4"
       @swiper="setThumbsSwiper"
+      @touchEnd="onThumbSlideChange"
+      @scrollbarDragEnd="onThumbSlideChange"
     >
       <SwiperSlide v-for="(slide, i) in slides" :key="slide.id">
         <div
@@ -151,11 +153,17 @@ const setThumbsSwiper = (swiper: SwiperType) => {
 const setMainSwiper = (swiper) => {
   mainSwiper.value = swiper;
 };
-const onMainSlideChange = (args) => {
-  activeSlideIndex.value = args.activeIndex;
+
+const onMainSlideChange = (mainSwiper: SwiperType) => {
+  activeSlideIndex.value = mainSwiper.activeIndex;
   // center the active slide in the thumbs swiper
   if (!thumbsSwiper.value) return;
-  thumbsSwiper.value.slideTo(args.activeIndex);
+  thumbsSwiper.value.slideTo(mainSwiper.activeIndex);
+};
+
+const onThumbSlideChange = (thumbsSwiper: SwiperType) => {
+  activeSlideIndex.value = thumbsSwiper.activeIndex;
+  mainSwiper.value?.slideTo(thumbsSwiper.activeIndex);
 };
 
 watch(

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -1,44 +1,121 @@
+ty
 <template>
   <div class="search-results-gallery">
     <h1>Gallery</h1>
 
+    <!-- Main Swiper -> pass thumbs swiper instance -->
     <Swiper
+      class="main-swiper"
       :modules="modules"
       :slidesPerView="1"
       :spaceBetween="50"
       navigation
       :pagination="{ clickable: true }"
       :scrollbar="{ draggable: true }"
+      :thumbs="{ swiper: thumbsSwiper }"
       @swiper="onSwiper"
       @slideChange="onSlideChange"
     >
-      <SwiperSlide>Slide 1</SwiperSlide>
-      <SwiperSlide>Slide 2</SwiperSlide>
-      <SwiperSlide>Slide 3</SwiperSlide>
-      <SwiperSlide>Slide 2</SwiperSlide>
-
-      <SwiperSlide>Slide 2</SwiperSlide>
-
-      <SwiperSlide>Slide 2</SwiperSlide>
-
-      <SwiperSlide>Slide 2</SwiperSlide>
+      <SwiperSlide v-for="(slide, i) in slides" :key="i">
+        <div class="flex items-center justify-center w-full">
+          <LazyLoadImage
+            v-if="slide.thumb.src"
+            :src="slide.thumb.src"
+            :alt="slide.thumb.alt"
+            class="swiper-lazy h-full"
+          />
+          <DocumentIcon v-else />
+        </div>
+      </SwiperSlide>
     </Swiper>
+
+    <!-- Thumbs Swiper -> store swiper instance -->
+    <!-- It is also required to set watchSlidesProgress prop -->
+    <swiper
+      :modules="[Thumbs]"
+      watchSlidesProgress
+      :slidesPerView="10"
+      :spaceBetween="4"
+      @swiper="setThumbsSwiper"
+    >
+      <SwiperSlide v-for="(slide, i) in slides" :key="i">
+        <div
+          class="border border-neutral-400 aspect-video flex items-center justify-center w-full"
+        >
+          <LazyLoadImage
+            v-if="slide.thumb.src"
+            :src="slide.thumb.src"
+            :alt="slide.thumb.alt"
+            class="swiper-lazy object-cover w-full h-full"
+          />
+          <DocumentIcon v-else />
+        </div>
+      </SwiperSlide>
+    </swiper>
   </div>
 </template>
 <script setup lang="ts">
-// import Swiper core and required modules
-import { Navigation, Pagination, Scrollbar, A11y } from "swiper";
-
-// Import Swiper Vue.js components
+import { ref, computed } from "vue";
 import { Swiper, SwiperSlide } from "swiper/vue";
+import { Navigation, Pagination, Scrollbar, A11y, Thumbs } from "swiper";
+import { SearchResultMatch } from "@/types";
+import DocumentIcon from "@/icons/DocumentIcon.vue";
 
-// Import Swiper styles
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
 import "swiper/css/scrollbar";
+import { getThumbURL } from "@/helpers/displayUtils";
+import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
 
-const modules = [Navigation, Pagination, Scrollbar, A11y];
+const props = defineProps<{
+  totalResults: number;
+  matches: SearchResultMatch[];
+  status: string;
+}>();
+
+defineEmits<{
+  (event: "loadMore");
+}>();
+
+const modules = [Navigation, Pagination, Scrollbar, A11y, Thumbs];
+const thumbsSwiper = ref(null);
+
+interface Slide {
+  title: string;
+  thumb: {
+    src: string | null;
+    alt: string;
+  };
+}
+const slides = computed((): Slide[] =>
+  props.matches.map(
+    (match): Slide => ({
+      title: selectTitleFromMatch(match),
+      thumb: {
+        src: selectThumbSrc(match),
+        alt: selectTitleFromMatch(match),
+      },
+    })
+  )
+);
+const selectTitleFromMatch = (match: SearchResultMatch) => {
+  const noTitleText = "No Title";
+  if (Array.isArray(match.title)) {
+    return match.title?.[0] ?? noTitleText;
+  }
+  return match.title ?? noTitleText;
+};
+
+const selectThumbSrc = (match: SearchResultMatch) => {
+  const { primaryHandlerId } = match;
+  return primaryHandlerId ? getThumbURL(primaryHandlerId) : null;
+};
+
+const setThumbsSwiper = (swiper) => {
+  console.log(swiper);
+  thumbsSwiper.value = swiper;
+};
 
 const onSwiper = (swiper) => {
   console.log(swiper);
@@ -48,9 +125,9 @@ const onSlideChange = () => {
 };
 </script>
 <style>
-.swiper {
+.main-swiper {
   width: 100%;
-  height: 75vh;
+  height: 50vh;
 }
 
 .swiper-slide {

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -6,11 +6,16 @@ ty
         <ChevronLeftIcon />
         Previous
       </Button>
-      <h2>
-        <Link :to="getAssetUrl(activeSlide.objectId)">
-          {{ activeSlide.title }}
-        </Link>
-      </h2>
+      <div class="flex flex-col items-center justify-center">
+        <span class="text-xs">
+          {{ activeSlideIndex + 1 }} / {{ slides.length }}
+        </span>
+        <h2>
+          <Link :to="getAssetUrl(activeSlide.objectId)">
+            {{ activeSlide.title }}
+          </Link>
+        </h2>
+      </div>
 
       <Button variant="tertiary" @click="mainSwiper.slideNext()">
         Next

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -10,7 +10,6 @@ ty
       :slidesPerView="1"
       :spaceBetween="50"
       navigation
-      :pagination="{ clickable: true }"
       :scrollbar="{ draggable: true }"
       :thumbs="{ swiper: thumbsSwiper }"
       @swiper="onSwiper"
@@ -22,7 +21,7 @@ ty
             v-if="slide.thumb.src"
             :src="slide.thumb.src"
             :alt="slide.thumb.alt"
-            class="swiper-lazy h-full"
+            class="swiper-lazy"
           />
           <DocumentIcon v-else />
         </div>
@@ -32,8 +31,9 @@ ty
     <!-- Thumbs Swiper -> store swiper instance -->
     <!-- It is also required to set watchSlidesProgress prop -->
     <swiper
+      class="thumbs-swiper"
       :modules="[Thumbs]"
-      watchSlidesProgress
+      :watchSlidesProgress="true"
       :slidesPerView="10"
       :spaceBetween="4"
       @swiper="setThumbsSwiper"
@@ -57,16 +57,16 @@ ty
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { Swiper, SwiperSlide } from "swiper/vue";
-import { Navigation, Pagination, Scrollbar, A11y, Thumbs } from "swiper";
+import { Navigation, Scrollbar, A11y, Thumbs } from "swiper";
 import { SearchResultMatch } from "@/types";
 import DocumentIcon from "@/icons/DocumentIcon.vue";
+import { getThumbURL } from "@/helpers/displayUtils";
+import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
 
 import "swiper/css";
 import "swiper/css/navigation";
-import "swiper/css/pagination";
 import "swiper/css/scrollbar";
-import { getThumbURL } from "@/helpers/displayUtils";
-import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
+import "swiper/css/thumbs";
 
 const props = defineProps<{
   totalResults: number;
@@ -78,7 +78,7 @@ defineEmits<{
   (event: "loadMore");
 }>();
 
-const modules = [Navigation, Pagination, Scrollbar, A11y, Thumbs];
+const modules = [Navigation, Scrollbar, A11y, Thumbs];
 const thumbsSwiper = ref(null);
 
 interface Slide {
@@ -124,7 +124,7 @@ const onSlideChange = () => {
   console.log("slide change");
 };
 </script>
-<style>
+<style scoped>
 .main-swiper {
   width: 100%;
   height: 50vh;
@@ -140,6 +140,17 @@ const onSlideChange = () => {
   justify-content: center;
   align-items: center;
   height: 100%;
+}
+
+.thumbs-swiper .swiper-slide {
+  width: 25%;
+  height: 100%;
+  opacity: 0.25;
+}
+
+.thumbs-swiper .swiper-slide-thumb-active {
+  opacity: 1;
+  border: 2px solid #0d6efd;
 }
 
 .swiper-slide img {

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -129,7 +129,7 @@ const props = defineProps<{
   status: string;
 }>();
 
-defineEmits<{
+const emit = defineEmits<{
   (event: "loadMore");
 }>();
 
@@ -166,6 +166,19 @@ watch(
     slides = useSlidesForMatches(props.matches);
   }
 );
+
+watch(activeSlideIndex, () => {
+  console.log("activeSlideIndex", activeSlideIndex.value);
+  if (!mainSwiper.value) return;
+
+  const hasMoreResults = props.matches.length < props.totalResults;
+  const closeToEnd = activeSlideIndex.value >= slides.length - 10;
+
+  if (hasMoreResults && closeToEnd) {
+    console.log("emitting loadMore");
+    emit("loadMore");
+  }
+});
 </script>
 <style>
 .main-swiper {

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -60,6 +60,7 @@ ty
       :modules="[Thumbs]"
       :watchSlidesProgress="true"
       :slidesPerView="10"
+      :centeredSlides="true"
       :spaceBetween="4"
       @swiper="setThumbsSwiper"
     >
@@ -82,6 +83,7 @@ ty
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { Swiper, SwiperSlide } from "swiper/vue";
+import { type Swiper as SwiperType } from "swiper";
 import { Navigation, Scrollbar, A11y, Thumbs } from "swiper";
 import { SearchResultMatch } from "@/types";
 import DocumentIcon from "@/icons/DocumentIcon.vue";
@@ -108,8 +110,8 @@ defineEmits<{
 }>();
 
 const modules = [Navigation, Scrollbar, A11y, Thumbs];
-const thumbsSwiper = ref(null);
-const mainSwiper = ref<typeof Swiper | null>(null);
+const thumbsSwiper = ref<SwiperType | null>(null);
+const mainSwiper = ref<SwiperType | null>(null);
 
 // this is taked from the main swiper on updated on slide change
 const activeSlideIndex = ref(0);
@@ -154,7 +156,7 @@ const selectThumbSrc = (match: SearchResultMatch) => {
   return primaryHandlerId ? getThumbURL(primaryHandlerId) : null;
 };
 
-const setThumbsSwiper = (swiper) => {
+const setThumbsSwiper = (swiper: SwiperType) => {
   thumbsSwiper.value = swiper;
 };
 
@@ -163,6 +165,9 @@ const setMainSwiper = (swiper) => {
 };
 const onMainSlideChange = (args) => {
   activeSlideIndex.value = args.activeIndex;
+  // center the active slide in the thumbs swiper
+  if (!thumbsSwiper.value) return;
+  thumbsSwiper.value.slideTo(args.activeIndex);
 };
 </script>
 <style>
@@ -189,7 +194,7 @@ const onMainSlideChange = (args) => {
   opacity: 0.25;
 }
 
-.thumbs-swiper .swiper-slide-thumb-active {
+.thumbs-swiper .swiper-slide-active {
   opacity: 1;
   border: 2px solid #0d6efd;
 }

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -54,6 +54,7 @@
         :slidesPerView="1"
         :spaceBetween="50"
         :thumbs="{ swiper: thumbsSwiper }"
+        :keyboard="{ enabled: true, onlyInViewport: false }"
         @swiper="setMainSwiper"
         @slideChange="onMainSlideChange"
       >
@@ -162,7 +163,7 @@
 import { ref, computed, watch } from "vue";
 import { Swiper, SwiperSlide } from "swiper/vue";
 import { type Swiper as SwiperType } from "swiper";
-import { Navigation, Scrollbar, A11y, Thumbs } from "swiper";
+import { Navigation, Scrollbar, A11y, Thumbs, Keyboard } from "swiper";
 import { SearchResultMatch } from "@/types";
 import DocumentIcon from "@/icons/DocumentIcon.vue";
 import { getAssetUrl } from "@/helpers/displayUtils";
@@ -194,7 +195,7 @@ const emit = defineEmits<{
   (event: "loadMore");
 }>();
 
-const modules = [Navigation, Scrollbar, A11y, Thumbs];
+const modules = [Navigation, Scrollbar, A11y, Thumbs, Keyboard];
 const thumbsSwiper = ref<SwiperType | null>(null);
 const mainSwiper = ref<SwiperType | null>(null);
 const { slides, createSlidesForMatch } = useSlidesForMatches([]);

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -122,6 +122,7 @@ import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/scrollbar";
 import "swiper/css/thumbs";
+import { difference } from "ramda";
 
 const props = defineProps<{
   totalResults: number;
@@ -136,12 +137,9 @@ const emit = defineEmits<{
 const modules = [Navigation, Scrollbar, A11y, Thumbs];
 const thumbsSwiper = ref<SwiperType | null>(null);
 const mainSwiper = ref<SwiperType | null>(null);
-
-// this is taked from the main swiper on updated on slide change
-const activeSlideIndex = ref(0);
-
 const { slides, createSlidesForMatch } = useSlidesForMatches([]);
 
+const activeSlideIndex = ref(0);
 const activeSlide = computed((): Slide => {
   return slides[activeSlideIndex.value];
 });
@@ -161,10 +159,15 @@ const onMainSlideChange = (args) => {
 };
 
 watch(
-  () => props.matches,
+  // we do this spread biznez so that oldMatches and newMatches are not the
+  // same reference. ...props.matches makes a shallow copy of the contents,
+  // while the oldMatches is a reference to the previous value of props.matches
+  () => [...(props.matches ?? [])],
   (newMatches, oldMatches) => {
+    console.log("watch matches", { newMatches, oldMatches });
     if (!newMatches) return;
-    newMatches.forEach(createSlidesForMatch);
+    const matchesDiff = difference(newMatches, oldMatches ?? []);
+    matchesDiff.forEach(createSlidesForMatch);
   },
   { deep: true, immediate: true }
 );

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -1,110 +1,162 @@
 <template>
-  <div class="search-results-gallery mb-8">
-    <div v-if="mainSwiper" class="flex items-center justify-between mb-1">
-      <Button variant="tertiary" @click="mainSwiper.slidePrev()">
-        <ChevronLeftIcon class="w-5" />
-        Previous
-      </Button>
-      <div class="flex flex-col items-center justify-center flex-1">
-        <h2>
+  <UseFullscreen v-slot="{ toggle: toggleFullscreen, isFullscreen }">
+    <div
+      class="search-results-gallery"
+      :class="{
+        'h-screen flex flex-col items-center justify-center': isFullscreen,
+      }"
+    >
+      <div
+        v-if="mainSwiper"
+        class="flex items-center justify-between w-full gap-4"
+        :class="{
+          'p-4': isFullscreen,
+          'py-2': !isFullscreen,
+        }"
+      >
+        <h2 class="font-bold">
           <Link
             v-if="activeSlide.objectId"
             :to="getAssetUrl(activeSlide.objectId)"
+            class="transition-colors hover:text-blue-600 !no-underline"
+            :class="{
+              'text-neutral-300 text-4xl ': isFullscreen,
+              'text-xl text-blue-700 ': !isFullscreen,
+            }"
           >
             {{ activeSlide.title }}
           </Link>
         </h2>
-      </div>
-
-      <Button
-        variant="tertiary"
-        class="!m-0 !-mr-2"
-        @click="mainSwiper.slideNext()"
-      >
-        Next
-        <ChevronRightIcon />
-      </Button>
-    </div>
-    <Swiper
-      class="main-swiper"
-      :modules="modules"
-      :slidesPerView="1"
-      :spaceBetween="50"
-      :thumbs="{ swiper: thumbsSwiper }"
-      @swiper="setMainSwiper"
-      @slideChange="onMainSlideChange"
-    >
-      <SwiperSlide
-        v-for="slide in slides"
-        :key="slide.id"
-        v-slot="{ isActive, isPrev, isNext }"
-      >
-        <div class="w-full h-full border">
-          <ObjectViewer
-            v-if="slide.primaryHandlerId && (isActive || isPrev || isNext)"
-            class="border w-full h-full"
-            :fileHandlerId="slide.primaryHandlerId"
-          />
-          <div
-            v-else
-            class="w-full h-full flex items-center justify-center -mt-12"
-          >
-            <DocumentIcon />
-          </div>
-        </div>
-      </SwiperSlide>
-    </Swiper>
-
-    <!-- Thumbs Swiper -> store swiper instance -->
-    <!-- It is also required to set watchSlidesProgress prop -->
-    <Swiper
-      class="thumbs-swiper w-full"
-      :modules="[Thumbs, Scrollbar]"
-      :watchSlidesProgress="true"
-      :slidesPerView="10"
-      :centeredSlides="true"
-      :scrollbar="{ draggable: true, dragSize: 32 }"
-      :spaceBetween="4"
-      @swiper="setThumbsSwiper"
-      @touchEnd="onThumbSlideChange"
-      @scrollbarDragEnd="onThumbSlideChange"
-    >
-      <SwiperSlide v-for="(slide, i) in slides" :key="slide.id">
-        <div
-          class="border border-neutral-400 aspect-video flex items-center justify-center w-full relative"
+        <button
+          class="inline-flex gap-1 py-2 px-4 items-center justify-center rounded-md text-xs uppercase tracking-wide whitespace-nowrap group transition-all"
+          :class="{
+            ' text-neutral-900 bg-transparent-black-100 hover:bg-blue-600 hover:text-blue-100':
+              !isFullscreen,
+            'bg-transparent-white-300 text-neutral-500 hover:bg-blue-600 hover:text-blue-100':
+              isFullscreen,
+          }"
+          @click="toggleFullscreen"
         >
-          <div
-            v-if="i !== activeSlideIndex"
-            class="absolute bottom-0 left-0 w-6 h-6 text-xs z-10 flex items-center justify-center bg-transparent-white-800 text-neutral-900"
-          >
-            {{ i + 1 }}
-          </div>
-          <LazyLoadImage
-            v-if="slide.thumb.src"
-            :src="slide.thumb.src"
-            :alt="slide.thumb.alt ?? 'Loading...'"
-            class="swiper-lazy object-cover w-full h-full"
+          <FullscreenIcon
+            v-if="!isFullscreen"
+            class="fill-neutral-900 group-hover:fill-neutral-200 transition-all"
           />
-          <DocumentIcon v-else />
-        </div>
-      </SwiperSlide>
-    </Swiper>
-
-    <div v-if="mainSwiper" class="flex items-center justify-center mb-1">
-      <Button variant="tertiary" class="!m-0" @click="mainSwiper.slidePrev()">
-        <ChevronLeftIcon />
-      </Button>
-      <div
-        class="flex flex-col items-center justify-center text-xs text-center px-4 py-2"
-      >
-        {{ activeSlideIndex + 1 }} / {{ slides.length }}
+          <ExitFullscreenIcon
+            v-else
+            class="fill-neutral-500 group-hover:fill-neutral-100 transition-all"
+          />
+          {{ isFullscreen ? "Exit" : "" }} Fullscreen
+        </button>
       </div>
+      <Swiper
+        class="main-swiper"
+        :modules="modules"
+        :slidesPerView="1"
+        :spaceBetween="50"
+        :thumbs="{ swiper: thumbsSwiper }"
+        @swiper="setMainSwiper"
+        @slideChange="onMainSlideChange"
+      >
+        <SwiperSlide
+          v-for="slide in slides"
+          :key="slide.id"
+          v-slot="{ isActive, isPrev, isNext }"
+        >
+          <div class="w-full h-full border">
+            <ObjectViewer
+              v-if="slide.primaryHandlerId && (isActive || isPrev || isNext)"
+              class="border w-full h-full"
+              :fileHandlerId="slide.primaryHandlerId"
+            />
+            <div
+              v-else
+              class="w-full h-full flex items-center justify-center -mt-12"
+            >
+              <DocumentIcon />
+            </div>
+          </div>
+        </SwiperSlide>
+      </Swiper>
 
-      <Button variant="tertiary" class="!m-0" @click="mainSwiper.slideNext()">
-        <ChevronRightIcon />
-      </Button>
+      <!-- Thumbs Swiper -> store swiper instance -->
+      <!-- It is also required to set watchSlidesProgress prop -->
+      <Swiper
+        class="thumbs-swiper w-full"
+        :modules="[Thumbs, Scrollbar]"
+        :watchSlidesProgress="true"
+        :slidesPerView="10"
+        :centeredSlides="true"
+        :scrollbar="{ draggable: true, dragSize: 32 }"
+        :spaceBetween="4"
+        @swiper="setThumbsSwiper"
+        @touchEnd="onThumbSlideChange"
+        @scrollbarDragEnd="onThumbSlideChange"
+      >
+        <SwiperSlide v-for="(slide, i) in slides" :key="slide.id">
+          <div
+            class="border border-neutral-400 aspect-video flex items-center justify-center w-full relative"
+          >
+            <div
+              v-if="i !== activeSlideIndex"
+              class="absolute bottom-0 left-0 w-6 h-6 text-xs z-10 flex items-center justify-center bg-transparent-white-800 text-neutral-900"
+            >
+              {{ i + 1 }}
+            </div>
+            <LazyLoadImage
+              v-if="slide.thumb.src"
+              :src="slide.thumb.src"
+              :alt="slide.thumb.alt ?? 'Loading...'"
+              class="swiper-lazy object-cover w-full h-full"
+            />
+            <DocumentIcon v-else />
+          </div>
+        </SwiperSlide>
+      </Swiper>
+
+      <div
+        v-if="mainSwiper"
+        class="flex items-center justify-center mb-1 relative py-4"
+        :class="{
+          'text-neutral-50': isFullscreen,
+          'text-neutral-900': !isFullscreen,
+        }"
+      >
+        <Button
+          variant="tertiary"
+          class="!m-0 bg-transparent hover:!bg-transparent-white-500"
+          :class="{
+            'opacity-30': activeSlideIndex === 0,
+          }"
+          @click="mainSwiper.slidePrev()"
+        >
+          <ChevronLeftIcon
+            :class="{
+              'text-neutral-50': isFullscreen,
+              'text-neutral-900': !isFullscreen,
+            }"
+          />
+        </Button>
+        <div
+          class="flex flex-col items-center justify-center text-xs text-center px-4 py-2"
+        >
+          {{ activeSlideIndex + 1 }}
+        </div>
+
+        <Button
+          variant="tertiary"
+          class="!m-0 bg-transparent hover:!bg-transparent-white-500"
+          @click="mainSwiper.slideNext()"
+        >
+          <ChevronRightIcon
+            :class="{
+              'text-neutral-50 ': isFullscreen,
+              'text-neutral-900': !isFullscreen,
+            }"
+          />
+        </Button>
+      </div>
     </div>
-  </div>
+  </UseFullscreen>
 </template>
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
@@ -118,13 +170,19 @@ import LazyLoadImage from "@/components/LazyLoadImage/LazyLoadImage.vue";
 import Button from "@/components/Button/Button.vue";
 import ObjectViewer from "../ObjectViewer/ObjectViewer.vue";
 import Link from "../Link/Link.vue";
-import { ChevronLeftIcon, ChevronRightIcon } from "@/icons";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ExitFullscreenIcon,
+  FullscreenIcon,
+} from "@/icons";
 import { useSlidesForMatches, type Slide } from "./useSlidesForMatches";
+import { UseFullscreen } from "@vueuse/components";
+import { difference } from "ramda";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/scrollbar";
 import "swiper/css/thumbs";
-import { difference } from "ramda";
 
 const props = defineProps<{
   totalResults: number;
@@ -196,7 +254,7 @@ watch(activeSlideIndex, () => {
 <style>
 .main-swiper {
   width: 100%;
-  height: 66vh;
+  height: 60vh;
 }
 
 .swiper-slide {

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -169,7 +169,7 @@ watch(
     const matchesDiff = difference(newMatches, oldMatches ?? []);
     matchesDiff.forEach(createSlidesForMatch);
   },
-  { deep: true, immediate: true }
+  { immediate: true }
 );
 
 watch(activeSlideIndex, () => {

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -1,16 +1,30 @@
 ty
 <template>
   <div class="search-results-gallery mb-8">
-    <!-- Main Swiper -> pass thumbs swiper instance -->
+    <div v-if="mainSwiper" class="flex items-center justify-between mb-1">
+      <Button variant="tertiary" @click="mainSwiper.slidePrev()">
+        <ChevronLeftIcon />
+        Previous
+      </Button>
+      <h2>
+        <Link :to="getAssetUrl(activeSlide.objectId)">
+          {{ activeSlide.title }}
+        </Link>
+      </h2>
+
+      <Button variant="tertiary" @click="mainSwiper.slideNext()">
+        Next
+        <ChevronRightIcon />
+      </Button>
+    </div>
     <Swiper
       class="main-swiper"
       :modules="modules"
       :slidesPerView="1"
       :spaceBetween="50"
-      navigation
       :scrollbar="{ draggable: true }"
       :thumbs="{ swiper: thumbsSwiper }"
-      @swiper="onSwiper"
+      @swiper="setMainSwiper"
       @slideChange="onSlideChange"
     >
       <SwiperSlide
@@ -19,9 +33,6 @@ ty
         v-slot="{ isActive, isPrev, isNext }"
       >
         <div class="w-full h-full border">
-          <h2 class="my-4">
-            <Link :to="getAssetUrl(slide.objectId)">{{ slide.title }}</Link>
-          </h2>
           <ObjectViewer
             v-if="slide.primaryHandlerId && (isActive || isPrev || isNext)"
             class="border w-full h-full"
@@ -70,7 +81,8 @@ import { Navigation, Scrollbar, A11y, Thumbs } from "swiper";
 import { SearchResultMatch } from "@/types";
 import DocumentIcon from "@/icons/DocumentIcon.vue";
 import { getAssetUrl, getThumbURL } from "@/helpers/displayUtils";
-import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
+import LazyLoadImage from "@/components/LazyLoadImage/LazyLoadImage.vue";
+import Button from "@/components/Button/Button.vue";
 
 import "swiper/css";
 import "swiper/css/navigation";
@@ -78,6 +90,7 @@ import "swiper/css/scrollbar";
 import "swiper/css/thumbs";
 import ObjectViewer from "../ObjectViewer/ObjectViewer.vue";
 import Link from "../Link/Link.vue";
+import { ChevronLeftIcon, ChevronRightIcon } from "@/icons";
 
 const props = defineProps<{
   totalResults: number;
@@ -91,6 +104,7 @@ defineEmits<{
 
 const modules = [Navigation, Scrollbar, A11y, Thumbs];
 const thumbsSwiper = ref(null);
+const mainSwiper = ref<typeof Swiper | null>(null);
 
 interface Slide {
   title: string;
@@ -114,6 +128,12 @@ const slides = computed((): Slide[] =>
     })
   )
 );
+
+const activeSlide = computed((): Slide => {
+  const activeIndex = mainSwiper.value?.activeIndex ?? 0;
+  return slides.value[activeIndex];
+});
+
 const selectTitleFromMatch = (match: SearchResultMatch) => {
   const noTitleText = "No Title";
   if (Array.isArray(match.title)) {
@@ -128,15 +148,14 @@ const selectThumbSrc = (match: SearchResultMatch) => {
 };
 
 const setThumbsSwiper = (swiper) => {
-  console.log(swiper);
   thumbsSwiper.value = swiper;
 };
 
-const onSwiper = (swiper) => {
-  console.log(swiper);
+const setMainSwiper = (swiper) => {
+  mainSwiper.value = swiper;
 };
-const onSlideChange = () => {
-  console.log("slide change");
+const onSlideChange = (args) => {
+  console.log("slide change", { args });
 };
 </script>
 <style scoped>

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -1,7 +1,74 @@
 <template>
   <div class="search-results-gallery">
-    <h1>Gallery Goes Here</h1>
+    <h1>Gallery</h1>
+
+    <Swiper
+      :modules="modules"
+      :slidesPerView="1"
+      :spaceBetween="50"
+      navigation
+      :pagination="{ clickable: true }"
+      :scrollbar="{ draggable: true }"
+      @swiper="onSwiper"
+      @slideChange="onSlideChange"
+    >
+      <SwiperSlide>Slide 1</SwiperSlide>
+      <SwiperSlide>Slide 2</SwiperSlide>
+      <SwiperSlide>Slide 3</SwiperSlide>
+      <SwiperSlide>Slide 2</SwiperSlide>
+
+      <SwiperSlide>Slide 2</SwiperSlide>
+
+      <SwiperSlide>Slide 2</SwiperSlide>
+
+      <SwiperSlide>Slide 2</SwiperSlide>
+    </Swiper>
   </div>
 </template>
-<script setup lang="ts"></script>
-<style scoped></style>
+<script setup lang="ts">
+// import Swiper core and required modules
+import { Navigation, Pagination, Scrollbar, A11y } from "swiper";
+
+// Import Swiper Vue.js components
+import { Swiper, SwiperSlide } from "swiper/vue";
+
+// Import Swiper styles
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/scrollbar";
+
+const modules = [Navigation, Pagination, Scrollbar, A11y];
+
+const onSwiper = (swiper) => {
+  console.log(swiper);
+};
+const onSlideChange = () => {
+  console.log("slide change");
+};
+</script>
+<style>
+.swiper {
+  width: 100%;
+  height: 75vh;
+}
+
+.swiper-slide {
+  text-align: center;
+  font-size: 18px;
+  background: #fff;
+
+  /* Center slide text vertically */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.swiper-slide img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+</style>

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -164,7 +164,6 @@ watch(
   // while the oldMatches is a reference to the previous value of props.matches
   () => [...(props.matches ?? [])],
   (newMatches, oldMatches) => {
-    console.log("watch matches", { newMatches, oldMatches });
     if (!newMatches) return;
     const matchesDiff = difference(newMatches, oldMatches ?? []);
     matchesDiff.forEach(createSlidesForMatch);

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -1,6 +1,6 @@
 ty
 <template>
-  <div class="search-results-gallery">
+  <div class="search-results-gallery mb-8">
     <h1>Gallery</h1>
 
     <!-- Main Swiper -> pass thumbs swiper instance -->
@@ -31,7 +31,7 @@ ty
     <!-- Thumbs Swiper -> store swiper instance -->
     <!-- It is also required to set watchSlidesProgress prop -->
     <swiper
-      class="thumbs-swiper"
+      class="thumbs-swiper w-full"
       :modules="[Thumbs]"
       :watchSlidesProgress="true"
       :slidesPerView="10"

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -30,7 +30,7 @@ ty
       :scrollbar="{ draggable: true }"
       :thumbs="{ swiper: thumbsSwiper }"
       @swiper="setMainSwiper"
-      @slideChange="onSlideChange"
+      @slideChange="onMainSlideChange"
     >
       <SwiperSlide
         v-for="(slide, i) in slides"
@@ -111,6 +111,9 @@ const modules = [Navigation, Scrollbar, A11y, Thumbs];
 const thumbsSwiper = ref(null);
 const mainSwiper = ref<typeof Swiper | null>(null);
 
+// this is taked from the main swiper on updated on slide change
+const activeSlideIndex = ref(0);
+
 interface Slide {
   title: string;
   objectId: string;
@@ -135,8 +138,7 @@ const slides = computed((): Slide[] =>
 );
 
 const activeSlide = computed((): Slide => {
-  const activeIndex = mainSwiper.value?.activeIndex ?? 0;
-  return slides.value[activeIndex];
+  return slides.value[activeSlideIndex.value];
 });
 
 const selectTitleFromMatch = (match: SearchResultMatch) => {
@@ -159,11 +161,11 @@ const setThumbsSwiper = (swiper) => {
 const setMainSwiper = (swiper) => {
   mainSwiper.value = swiper;
 };
-const onSlideChange = (args) => {
-  console.log("slide change", { args });
+const onMainSlideChange = (args) => {
+  activeSlideIndex.value = args.activeIndex;
 };
 </script>
-<style scoped>
+<style>
 .main-swiper {
   width: 100%;
   height: 50vh;

--- a/src/components/SearchResultsGallery/SearchResultsGallery.vue
+++ b/src/components/SearchResultsGallery/SearchResultsGallery.vue
@@ -35,8 +35,8 @@
       @slideChange="onMainSlideChange"
     >
       <SwiperSlide
-        v-for="(slide, i) in slides"
-        :key="i"
+        v-for="slide in slides"
+        :key="slide.id"
         v-slot="{ isActive, isPrev, isNext }"
       >
         <div class="w-full h-full border">
@@ -66,10 +66,15 @@
       :spaceBetween="4"
       @swiper="setThumbsSwiper"
     >
-      <SwiperSlide v-for="(slide, i) in slides" :key="i">
+      <SwiperSlide v-for="(slide, i) in slides" :key="slide.id">
         <div
-          class="border border-neutral-400 aspect-video flex items-center justify-center w-full"
+          class="border border-neutral-400 aspect-video flex items-center justify-center w-full relative"
         >
+          <div
+            class="absolute bottom-0 left-0 w-6 h-6 text-xs z-10 flex items-center justify-center bg-transparent-white-800 text-neutral-900"
+          >
+            {{ i + 1 }}
+          </div>
           <LazyLoadImage
             v-if="slide.thumb.src"
             :src="slide.thumb.src"

--- a/src/components/SearchResultsGallery/useSlidesForMatches.ts
+++ b/src/components/SearchResultsGallery/useSlidesForMatches.ts
@@ -2,7 +2,6 @@ import { SearchResultMatch, RelatedAssetCacheItemWithId, Asset } from "@/types";
 import { reactive } from "vue";
 import { getThumbURL, getAssetTitle } from "@/helpers/displayUtils";
 import api from "@/api";
-import { selectValuesOfPropFromObj } from "@/helpers/selectValuesOfPropFromObj";
 
 export interface Slide {
   id: string;
@@ -20,8 +19,6 @@ export interface Slide {
   parentTitle?: string;
   totalChildren?: number;
 }
-
-const slides = reactive<Array<Slide>>([]);
 
 const selectTitleFromMatch = (match: SearchResultMatch) => {
   const noTitleText = "No Title";
@@ -182,6 +179,7 @@ async function fetchChildSlides(parentObjectId: string): Promise<Slide[]> {
 }
 
 export function useSlidesForMatches(matches: SearchResultMatch[]): Slide[] {
+  const slides = reactive<Array<Slide>>([]);
   matches.forEach((match) => {
     const slide = matchToSlide(match);
 
@@ -196,7 +194,6 @@ export function useSlidesForMatches(matches: SearchResultMatch[]): Slide[] {
     // now, we queue up a featch for child slide data
     // which we'll use to replace the placeholder slides
     fetchChildSlides(match.objectId).then((childSlides) => {
-      console.log({ childSlides });
       childSlides.forEach((childSlide, index) => {
         const { id: placeholderSlideId } = placeholdersForChildren[index];
         const indexOfPlaceholder = slides.findIndex(

--- a/src/components/SearchResultsGallery/useSlidesForMatches.ts
+++ b/src/components/SearchResultsGallery/useSlidesForMatches.ts
@@ -1,0 +1,126 @@
+import { SearchResultMatch, RelatedAssetCacheItemWithId } from "@/types";
+import { reactive } from "vue";
+import { getThumbURL } from "@/helpers/displayUtils";
+import api from "@/api";
+
+export interface Slide {
+  objectId: string | undefined;
+  title: string | undefined;
+  primaryHandlerId: string | null | undefined;
+  thumb: {
+    src: string | null | undefined;
+    alt: string | undefined;
+  };
+  isChildSlide?: boolean;
+  childIndex?: number;
+  parentObjectId?: string;
+  parentTitle?: string;
+  totalChildren?: number;
+}
+
+const slides = reactive<Array<Slide>>([]);
+
+const selectTitleFromMatch = (match: SearchResultMatch) => {
+  const noTitleText = "No Title";
+  if (Array.isArray(match.title)) {
+    return match.title?.[0] ?? noTitleText;
+  }
+  return match.title ?? noTitleText;
+};
+
+const selectThumbSrc = (match: SearchResultMatch) => {
+  const { primaryHandlerId } = match;
+  return primaryHandlerId ? getThumbURL(primaryHandlerId) : null;
+};
+
+const matchToSlide = (match: SearchResultMatch): Slide => ({
+  objectId: match.objectId,
+  primaryHandlerId: match.primaryHandlerId ?? null,
+  title: selectTitleFromMatch(match),
+  thumb: {
+    src: selectThumbSrc(match),
+    alt: selectTitleFromMatch(match),
+  },
+});
+
+function createPlaceholderSlidesForChildren(match: SearchResultMatch): Slide[] {
+  const { fileAssets, objectId } = match;
+  const placeholders: Slide[] = [];
+
+  if (!fileAssets) return placeholders;
+
+  for (let i = 1; i < fileAssets; i++) {
+    const placeholder: Slide = {
+      objectId: undefined,
+      title: undefined,
+      primaryHandlerId: undefined,
+      thumb: {
+        src: undefined,
+        alt: undefined,
+      },
+      isChildSlide: true,
+      parentObjectId: objectId,
+      parentTitle: selectTitleFromMatch(match),
+      childIndex: i,
+      totalChildren: fileAssets,
+    };
+    placeholders.push(placeholder);
+  }
+
+  return placeholders;
+}
+
+function convertRelatedAssetToSlide(
+  relatedAsset: RelatedAssetCacheItemWithId
+): Slide {
+  const {
+    id: objectId,
+    relatedAssetTitle,
+    primaryHandler: primaryHandlerId,
+  } = relatedAsset;
+
+  const title = Array.isArray(relatedAssetTitle)
+    ? relatedAssetTitle[0]
+    : relatedAssetTitle ?? "No Title";
+
+  return {
+    objectId,
+    title,
+    primaryHandlerId,
+    thumb: {
+      src: primaryHandlerId ? getThumbURL(primaryHandlerId) : null,
+      alt: title,
+    },
+  };
+}
+
+async function fetchChildSlide(parentObjectId, childIndex): Promise<Slide> {
+  const childAssets = await api.getAssetChildren(parentObjectId);
+  const childAsset = childAssets[childIndex];
+
+  return convertRelatedAssetToSlide(childAsset);
+}
+
+export function useSlidesForMatches(matches: SearchResultMatch[]): Slide[] {
+  matches.forEach((match) => {
+    const slide = matchToSlide(match);
+
+    // add the parent slide to the slides array
+    slides.push(slide);
+
+    // if there are children, add a placeholder slide for each child
+    const placeholdersForChildren = createPlaceholderSlidesForChildren(match);
+    slides.push(...placeholdersForChildren);
+
+    // finally, for each child, fetch it's real data
+    // and replace the placeholder slide with the real slide
+    placeholdersForChildren.forEach(async (placeholder) => {
+      const { parentObjectId, childIndex } = placeholder;
+      const childSlide = await fetchChildSlide(parentObjectId, childIndex);
+      slides.splice(slides.indexOf(placeholder), 1, childSlide);
+    });
+  });
+
+  // returns data in slide format for each search result
+  return slides;
+}

--- a/src/components/SearchResultsGallery/useSlidesForMatches.ts
+++ b/src/components/SearchResultsGallery/useSlidesForMatches.ts
@@ -50,7 +50,7 @@ function createPlaceholderSlidesForChildren(match: SearchResultMatch): Slide[] {
 
   if (!fileAssets) return placeholders;
 
-  for (let i = 1; i < fileAssets; i++) {
+  for (let i = 0; i < fileAssets; i++) {
     const placeholder: Slide = {
       id: `${objectId}-placeholder-${i}`,
       objectId: undefined,
@@ -194,12 +194,11 @@ export function useSlidesForMatches(matches: SearchResultMatch[]): Slide[] {
     // now, we queue up a featch for child slide data
     // which we'll use to replace the placeholder slides
     fetchChildSlides(match.objectId).then((childSlides) => {
-      childSlides.forEach((childSlide, index) => {
-        const { id: placeholderSlideId } = placeholdersForChildren[index];
+      placeholdersForChildren.forEach((placeholder, index) => {
+        const childSlide = childSlides[index];
         const indexOfPlaceholder = slides.findIndex(
-          (slide) => slide.id === placeholderSlideId
+          (slide) => slide.id === placeholder.id
         );
-        console.log("index of placeholder", indexOfPlaceholder);
         slides[indexOfPlaceholder] = childSlide;
       });
     });

--- a/src/components/SearchResultsGallery/useSlidesForMatches.ts
+++ b/src/components/SearchResultsGallery/useSlidesForMatches.ts
@@ -178,9 +178,13 @@ async function fetchChildSlides(parentObjectId: string): Promise<Slide[]> {
   ];
 }
 
-export function useSlidesForMatches(matches: SearchResultMatch[]): Slide[] {
+export function useSlidesForMatches(matches: SearchResultMatch[]): {
+  slides: Slide[];
+  createSlidesForMatch: (match: SearchResultMatch) => void;
+} {
   const slides = reactive<Array<Slide>>([]);
-  matches.forEach((match) => {
+
+  function createSlidesForMatch(match: SearchResultMatch) {
     const slide = matchToSlide(match);
 
     // add the parent slide to the slides array
@@ -202,8 +206,11 @@ export function useSlidesForMatches(matches: SearchResultMatch[]): Slide[] {
         slides[indexOfPlaceholder] = childSlide;
       });
     });
+  }
+
+  matches.forEach((match) => {
+    createSlidesForMatch(match);
   });
 
-  // returns data in slide format for each search result
-  return slides;
+  return { slides, createSlidesForMatch };
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -15,4 +15,5 @@ export const SEARCH_RESULTS_VIEWS = [
   "list",
   "timeline",
   "map",
+  "gallery",
 ] as const;

--- a/src/icons/ExitFullscreenIcon.vue
+++ b/src/icons/ExitFullscreenIcon.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="48"
+    viewBox="0 96 960 960"
+    width="48"
+    class="w-5 h-5"
+  >
+    <path
+      d="M333 856V723H200v-60h193v193h-60Zm234 0V663h193v60H627v133h-60ZM200 489v-60h133V296h60v193H200Zm367 0V296h60v133h133v60H567Z"
+    />
+  </svg>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/src/icons/FullscreenIcon.vue
+++ b/src/icons/FullscreenIcon.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="48"
+    viewBox="0 96 960 960"
+    width="48"
+    class="w-5 h-5"
+  >
+    <path
+      d="M200 856V663h60v133h133v60H200Zm0-367V296h193v60H260v133h-60Zm367 367v-60h133V663h60v193H567Zm133-367V356H567v-60h193v193h-60Z"
+    />
+  </svg>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -9,6 +9,8 @@ export { default as CircleXIcon } from "./CircleXIcon.vue";
 export { default as DocumentIcon } from "./DocumentIcon.vue";
 export { default as DownloadIcon } from "./DownloadIcon.vue";
 export { default as ElevatorIcon } from "./ElevatorIcon.vue";
+export { default as ExitFullscreenIcon } from "./ExitFullscreenIcon.vue";
+export { default as FullscreenIcon } from "./FullscreenIcon.vue";
 export { default as ImageIcon } from "./ImageIcon.vue";
 export { default as InfoIcon } from "./InfoIcon.vue";
 export { default as MinusIcon } from "./MinusIcon.vue";

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -3,19 +3,19 @@
     <div class="px-4">
       <p v-if="searchStore.status === 'error'">Error loading search results.</p>
 
-      <template v-else>
-        <BrowseCollectionHeader
-          v-if="browsingCollectionId"
-          :collectionId="browsingCollectionId"
-        />
-        <h2
-          v-if="searchStore.searchEntry?.searchText"
-          class="text-4xl my-8 font-bold"
-        >
-          <q>{{ searchStore.searchEntry.searchText }}</q>
-        </h2>
-      </template>
+      <BrowseCollectionHeader
+        v-if="browsingCollectionId"
+        :collectionId="browsingCollectionId"
+      />
+      <h2
+        v-else-if="searchStore.searchEntry?.searchText"
+        class="text-4xl my-8 font-bold"
+      >
+        <q>{{ searchStore.searchEntry.searchText }}</q>
+      </h2>
+
       <Tabs
+        v-if="isNewSearchReadyForDisplay"
         labelsClass="sticky top-14 z-20 search-results-page__tabs -mx-4 px-4 border-b border-neutral-200 pt-4"
         :activeTabId="searchStore.resultsView"
         @tabChange="handleTabChange"
@@ -99,7 +99,7 @@
   </DefaultLayout>
 </template>
 <script setup lang="ts">
-import { watch, computed, onMounted, nextTick } from "vue";
+import { watch, computed, onMounted, nextTick, ref } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useSearchStore } from "@/stores/searchStore";
@@ -129,13 +129,27 @@ const props = withDefaults(
 
 const searchStore = useSearchStore();
 
+// will be true once a new search with a new searchId has been loaded for the
+// first time this is used to get tabs to remount with new search results
+// preventing old results from displaying.
+const isNewSearchReadyForDisplay = ref(false);
+searchStore.onBeforeNewSearch(() => {
+  isNewSearchReadyForDisplay.value = false;
+});
+searchStore.onAfterNewSearch(() => {
+  isNewSearchReadyForDisplay.value = true;
+});
+
 // if search with this id is not currently in flight,
 // then kick it off
 watch(
   () => props.searchId,
   () => {
-    if (searchStore.searchId === props.searchId) return;
-    searchStore.searchById(props.searchId);
+    if (searchStore.searchId === props.searchId) {
+      isNewSearchReadyForDisplay.value = true;
+      return;
+    }
+    searchStore.search(props.searchId);
   },
   { immediate: true }
 );

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -71,7 +71,7 @@
         <Tab id="gallery" label="Gallery">
           <SearchResultsGallery
             v-if="searchStore.isReady"
-            :totalResults="searchStore.totalResults"
+            :totalResults="searchStore.totalResults ?? Infinity"
             :matches="searchStore.matches"
             :status="searchStore.status"
             @loadMore="() => searchStore.loadMore()"

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -68,6 +68,15 @@
             @loadMore="() => searchStore.loadMore()"
           />
         </Tab>
+        <Tab id="gallery" label="Gallery">
+          <SearchResultsGallery
+            v-if="searchStore.isReady"
+            :totalResults="searchStore.totalResults"
+            :matches="searchStore.matches"
+            :status="searchStore.status"
+            @loadMore="() => searchStore.loadMore()"
+          />
+        </Tab>
         <ResultsCount
           v-if="
             ['grid', 'list'].includes(searchStore.resultsView) &&
@@ -102,9 +111,10 @@ import SearchResultsGrid from "@/components/SearchResultsGrid/SearchResultsGrid.
 import SearchResultsList from "@/components/SearchResultsList/SearchResultsList.vue";
 import SearchResultsTimeline from "@/components/SearchResultsTimeline/SearchResultsTimeline.vue";
 import SearchResultsMap from "@/components/SearchResultsMap/SearchResultsMap.vue";
+import SearchResultsGallery from "@/components/SearchResultsGallery/SearchResultsGallery.vue";
+import ResultsCount from "@/components/ResultsCount/ResultsCount.vue";
 import type { SearchResultsView, Tab as TabType } from "@/types";
 import { SEARCH_RESULTS_VIEWS } from "@/constants/constants";
-import ResultsCount from "@/components/ResultsCount/ResultsCount.vue";
 
 const props = withDefaults(
   defineProps<{

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -70,7 +70,6 @@
         </Tab>
         <Tab id="gallery" label="Gallery">
           <SearchResultsGallery
-            v-if="searchStore.isReady"
             :totalResults="searchStore.totalResults ?? Infinity"
             :matches="searchStore.matches"
             :status="searchStore.status"

--- a/src/pages/TestPages/SlidesTestPage.vue
+++ b/src/pages/TestPages/SlidesTestPage.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="search-results-gallery mb-8">
+    <h1>Slides Test Page</h1>
+    <div v-if="mainSwiper" class="flex items-center justify-between mb-1">
+      <Button variant="tertiary" @click="mainSwiper.slidePrev()">
+        <ChevronLeftIcon />
+        Previous
+      </Button>
+      <div class="flex flex-col items-center justify-center">
+        <h2>
+          {{ activeSlide.title }}
+        </h2>
+        <span class="text-xs">
+          {{ activeSlideIndex + 1 }} / {{ slides.length }}
+        </span>
+      </div>
+
+      <Button variant="tertiary" @click="mainSwiper.slideNext()">
+        Next
+        <ChevronRightIcon />
+      </Button>
+    </div>
+    <Swiper
+      class="main-swiper"
+      :modules="modules"
+      :slidesPerView="1"
+      :spaceBetween="50"
+      :scrollbar="{ draggable: true }"
+      :thumbs="{ swiper: thumbsSwiper }"
+      @swiper="setMainSwiper"
+      @slideChange="onMainSlideChange"
+    >
+      <SwiperSlide v-for="(slide, i) in slides" :key="i">
+        <div class="w-full h-full border">
+          <h2 class="text-xl font-bold">{{ slide.title }}</h2>
+          <img :src="slide.thumb.src" :alt="slide.thumb.alt" />
+        </div>
+      </SwiperSlide>
+    </Swiper>
+
+    <!-- Thumbs Swiper -> store swiper instance -->
+    <!-- It is also required to set watchSlidesProgress prop -->
+    <Swiper
+      class="thumbs-swiper w-full"
+      :modules="[Thumbs]"
+      :watchSlidesProgress="true"
+      :slidesPerView="10"
+      :centeredSlides="true"
+      :spaceBetween="4"
+      @swiper="setThumbsSwiper"
+    >
+      <SwiperSlide v-for="(slide, i) in slides" :key="i">
+        <div
+          class="border border-neutral-400 aspect-video flex items-center justify-center w-full"
+        >
+          <LazyLoadImage
+            v-if="slide.thumb.src"
+            :src="slide.thumb.src"
+            :alt="slide.thumb.alt ?? 'Loading...'"
+            class="swiper-lazy object-cover w-full h-full"
+          />
+          <DocumentIcon v-else />
+        </div>
+      </SwiperSlide>
+    </Swiper>
+  </div>
+</template>
+<script setup lang="ts">
+import { ref, computed, reactive, onMounted } from "vue";
+import { Swiper, SwiperSlide } from "swiper/vue";
+import { type Swiper as SwiperType } from "swiper";
+import { Navigation, Scrollbar, A11y, Thumbs } from "swiper";
+import DocumentIcon from "@/icons/DocumentIcon.vue";
+import Button from "@/components/Button/Button.vue";
+import { ChevronLeftIcon, ChevronRightIcon } from "@/icons";
+import LazyLoadImage from "@/components/LazyLoadImage/LazyLoadImage.vue";
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/scrollbar";
+import "swiper/css/thumbs";
+
+defineEmits<{
+  (event: "loadMore");
+}>();
+
+const modules = [Navigation, Scrollbar, A11y, Thumbs];
+const thumbsSwiper = ref<SwiperType | null>(null);
+const mainSwiper = ref<SwiperType | null>(null);
+
+interface Slide {
+  title: string;
+  thumb: {
+    src: string;
+    alt?: string;
+  };
+}
+
+const slides = reactive([] as Slide[]);
+
+// this is taked from the main swiper on updated on slide change
+const activeSlideIndex = ref(0);
+
+const activeSlide = computed((): Slide => {
+  return slides[activeSlideIndex.value];
+});
+
+const setThumbsSwiper = (swiper: SwiperType) => {
+  thumbsSwiper.value = swiper;
+};
+
+const setMainSwiper = (swiper) => {
+  mainSwiper.value = swiper;
+};
+const onMainSlideChange = (args) => {
+  activeSlideIndex.value = args.activeIndex;
+  // center the active slide in the thumbs swiper
+  if (!thumbsSwiper.value) return;
+  thumbsSwiper.value.slideTo(args.activeIndex);
+};
+
+onMounted(() => {
+  const createSlide = (n: number) => ({
+    title: `Slide ${n}`,
+    thumb: {
+      src: `https://picsum.photos/id/${n}/500/300`,
+      alt: `Slide ${n}`,
+    },
+  });
+
+  const createPlaceholderSlide = (n: number) => ({
+    title: `Placeholder Slide ${n}`,
+    thumb: {
+      src: "https://placehold.it/500x300",
+      alt: `Slide ${n}`,
+    },
+  });
+
+  // create 10 placeholder slides
+  for (let i = 0; i < 10; i++) {
+    slides.push(createPlaceholderSlide(i));
+  }
+
+  slides.forEach((slide, index) => {
+    setTimeout(() => {
+      slides[index] = createSlide(index);
+    }, 1000 * index);
+  });
+});
+</script>
+<style>
+.main-swiper {
+  width: 100%;
+  height: 50vh;
+}
+
+.swiper-slide {
+  text-align: center;
+  font-size: 18px;
+  background: #fff;
+
+  /* Center slide text vertically */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.thumbs-swiper .swiper-slide {
+  width: 25%;
+  height: 100%;
+  opacity: 0.25;
+}
+
+.thumbs-swiper .swiper-slide-active {
+  opacity: 1;
+  border: 2px solid #0d6efd;
+}
+
+.swiper-slide img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -113,7 +113,9 @@ const router = createRouter({
       name: "error",
       path: "/error/:errorCode",
       component: () => import("@/pages/ErrorPage/ErrorPage.vue"),
-      props: true,
+      props: (route) => ({
+        errorCode: parseIntFromParam(route.params.errorCode),
+      }),
     },
     {
       path: "/:pathMatch(.*)",

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,6 +31,10 @@ const routesForTesting: RouteRecordRaw[] = [
       objectId: route.hash?.substring(1),
     }),
   },
+  {
+    path: "/test/slides",
+    component: () => import("@/pages/TestPages/SlidesTestPage.vue"),
+  },
 ];
 
 const router = createRouter({

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,10 +31,6 @@ const routesForTesting: RouteRecordRaw[] = [
       objectId: route.hash?.substring(1),
     }),
   },
-  {
-    path: "/test/slides",
-    component: () => import("@/pages/TestPages/SlidesTestPage.vue"),
-  },
 ];
 
 const router = createRouter({

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -30,12 +30,6 @@ const getters = (state: ReturnType<typeof createState>) => ({
     // convert to numbers, as the api returns strings
     return state.searchEntry.value.collection.map((id) => Number.parseInt(id));
   }),
-  matches: computed(() => state.matches.value),
-  status: computed(() => state.status.value),
-  searchId: computed(() => state.searchId.value),
-  totalResults: computed(() => state.totalResults.value),
-  currentPage: computed(() => state.currentPage.value),
-  searchEntry: computed(() => state.searchEntry.value),
 });
 
 const actions = (state: ReturnType<typeof createState>) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -371,7 +371,11 @@ export interface RelatedAssetCacheItem {
   relatedAssetTitle: string[];
 }
 
-type RelatedAssetCache = Record<
+export interface RelatedAssetCacheItemWithId extends RelatedAssetCacheItem {
+  id: string;
+}
+
+export type RelatedAssetCache = Record<
   string,
   RelatedAssetCacheItem | null | undefined
 >;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -371,6 +371,16 @@ export interface RelatedAssetCacheItem {
   relatedAssetTitle: string[];
 }
 
+export interface ChildOrRelatedAsset {
+  id: string;
+  title: string;
+  objectId?: string;
+  thumb: {
+    src: string;
+    alt: string;
+  };
+}
+
 export interface RelatedAssetCacheItemWithId extends RelatedAssetCacheItem {
   id: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11312,6 +11312,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+ssr-window@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-4.0.2.tgz#dc6b3ee37be86ac0e3ddc60030f7b3bc9b8553be"
+  integrity sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==
+
 ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz"
@@ -11597,6 +11602,13 @@ sveltedoc-parser@^4.2.1:
     eslint "8.4.1"
     espree "9.2.0"
     htmlparser2-svelte "4.1.0"
+
+swiper@^9.2.4:
+  version "9.2.4"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-9.2.4.tgz#2fa3cf58cef586366f674a10fa56fe6eec2026fe"
+  integrity sha512-L7y3K/iiMXNYQ94FbfcJn7jex4QPnS4+voXGupTdC+UHW4XrR40QDdm4c9hXJ+Br0Il7PP0vP1W3goM9/Ly6Sg==
+  dependencies:
+    ssr-window "^4.0.2"
 
 symbol.prototype.description@^1.0.0:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,6 +3035,11 @@
   resolved "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.15.tgz"
   integrity sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==
 
+"@types/web-bluetooth@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz#5c9f3c617f64a9735d7b72a7cc671e166d900c40"
+  integrity sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==
+
 "@types/webpack-env@^1.16.0":
   version "1.18.0"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.0.tgz"
@@ -3419,6 +3424,25 @@
   resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz"
   integrity sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==
 
+"@vueuse/components@^10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/components/-/components-10.1.2.tgz#0543dad9a0f0bfc2b2a9025c4a9cee2c55baf603"
+  integrity sha512-HlYFYCg3twMhnQgPS4/muz8XIYKViFVKnpL0Xtw5+9ib2gtWvu1Qu7hj6kDMDtOIw1CnNRsUbMLiNI+LXkxSSQ==
+  dependencies:
+    "@vueuse/core" "10.1.2"
+    "@vueuse/shared" "10.1.2"
+    vue-demi ">=0.14.0"
+
+"@vueuse/core@10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.1.2.tgz#2499eadec36c5d7109338e3a2b73725040ae8011"
+  integrity sha512-roNn8WuerI56A5uiTyF/TEYX0Y+VKlhZAF94unUfdhbDUI+NfwQMn4FUnUscIRUhv3344qvAghopU4bzLPNFlA==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.17"
+    "@vueuse/metadata" "10.1.2"
+    "@vueuse/shared" "10.1.2"
+    vue-demi ">=0.14.0"
+
 "@vueuse/core@^9.3.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@vueuse/core/-/core-9.3.0.tgz"
@@ -3429,10 +3453,22 @@
     "@vueuse/shared" "9.3.0"
     vue-demi "*"
 
+"@vueuse/metadata@10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.1.2.tgz#d8ffe557b1042efd03a0aa88540a00c25d193ee3"
+  integrity sha512-3mc5BqN9aU2SqBeBuWE7ne4OtXHoHKggNgxZR2K+zIW4YLsy6xoZ4/9vErQs6tvoKDX6QAqm3lvsrv0mczAwIQ==
+
 "@vueuse/metadata@9.3.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.3.0.tgz"
   integrity sha512-GnnfjbzIPJIh9ngL9s9oGU1+Hx/h5/KFqTfJykzh/1xjaHkedV9g0MASpdmPZIP+ynNhKAcEfA6g5i8KXwtoMA==
+
+"@vueuse/shared@10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.1.2.tgz#31d8733a217a6396eb67706319133bf62cdd8baa"
+  integrity sha512-1uoUTPBlgyscK9v6ScGeVYDDzlPSFXBlxuK7SfrDGyUTBiznb3mNceqhwvZHjtDRELZEN79V5uWPTF1VDV8svA==
+  dependencies:
+    vue-demi ">=0.14.0"
 
 "@vueuse/shared@9.3.0":
   version "9.3.0"
@@ -12354,6 +12390,11 @@ vue-demi@*:
   version "0.13.11"
   resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz"
   integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
+
+vue-demi@>=0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.0.tgz#dcfd9a9cf9bb62ada1582ec9042372cf67ca6190"
+  integrity sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==
 
 vue-docgen-api@^4.44.15:
   version "4.52.0"


### PR DESCRIPTION
This adds a gallery view of search results:
- The gallery creates slides for search matches, any files within the asset (that is, any objects with a defined `fileId`), and any related assets items found in the asset's `relatedAssetCache`. 
- While adjacent results are loading asynchronously, placeholder slides will be used.  
- When the `activeSlideIndex` is within 10 of the last slide, the gallery will load more search results.

(At least) one bug that needs to be resolved: with some searches on dev, like "Test", the gallery with throw an error and the active slide index won't update properly in the main slider. I'm probably making an incorrect assumption about the shape or existence of some match result or asset data.

Currently up on dev for testing: 
https://dev.elevator.umn.edu/defaultinstance/search/s/7eeb0e19-1f48-4806-a22c-238c2aa39199?resultsView=gallery

<img width="500" alt="image" src="https://user-images.githubusercontent.com/980170/235742341-0080e1b9-8310-4bf5-b66f-d1f5471d9298.png">

Closes #58 




