### PR TITLE
fix: Link component ctrl-click

### DIFF
--- a/src/components/FeaturedAssetCard/FeaturedAssetCard.vue
+++ b/src/components/FeaturedAssetCard/FeaturedAssetCard.vue
@@ -1,7 +1,7 @@
 <template>
   <Link :to="getAssetUrl(assetId)" class="group hover:no-underline relative">
     <article
-      class="media-card flex flex-col overflow-hidden rounded-md shadow-sm max-w-xs"
+      class="media-card flex flex-col overflow-hidden rounded-md shadow-sm max-w-xs group-hover:border-blue-700"
     >
       <div
         class="placeholder-image aspect-video flex items-center justify-center w-full overflow-hidden bg-transparent-black-200 p-4"
@@ -15,17 +15,13 @@
         />
         <DocumentIcon v-else />
       </div>
-      <div class="flex-1 p-4">
-        <div ref="cardContents" class="relative h-full">
-          <h1
-            class="search-result-card__title font-bold leading-tight mb-2 group-hover:text-blue-700 text-center"
-          >
-            <SanitizedHTML :html="title" />
-          </h1>
-          <ArrowButton
-            class="absolute bottom-0 right-0 !transition-all group-hover:opacity-100 opacity-0 !bg-blue-700 !border-blue-700"
-          />
-        </div>
+      <div class="flex-1 p-4 flex justify-between items-center">
+        <h1
+          class="search-result-card__title font-bold leading-tight group-hover:text-blue-700 text-center"
+        >
+          <SanitizedHTML :html="title" />
+        </h1>
+        <ArrowForwardIcon class="group-hover:text-blue-700" />
       </div>
     </article>
   </Link>
@@ -40,10 +36,9 @@ import {
 } from "@/helpers/displayUtils";
 import { computed, ref, watch } from "vue";
 import Link from "@/components/Link/Link.vue";
-import ArrowButton from "@/components/ArrowButton/ArrowButton.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import LazyLoadImage from "@/components/LazyLoadImage/LazyLoadImage.vue";
-import { DocumentIcon } from "@/icons";
+import { DocumentIcon, ArrowForwardIcon } from "@/icons";
 import api from "@/api";
 
 const props = defineProps<{

--- a/src/components/Link/Link.vue
+++ b/src/components/Link/Link.vue
@@ -1,20 +1,20 @@
 <template>
-  <component
-    :is="to ? RouterLink : 'a'"
-    :to="to"
-    :href="href"
-    class="cursor-pointer"
-  >
-    <slot />
-  </component>
+  <RouterLink v-if="to" :to="to"><slot /></RouterLink>
+  <a v-else :href="href"><slot /></a>
 </template>
 <script setup lang="ts">
 import { type RouteLocationRaw, RouterLink } from "vue-router";
 
-defineProps<{
-  to?: RouteLocationRaw;
-  href?: string;
-}>();
+withDefaults(
+  defineProps<{
+    to?: RouteLocationRaw;
+    href?: string;
+  }>(),
+  {
+    to: undefined,
+    href: "#",
+  }
+);
 </script>
 
 <style scoped></style>

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -37,9 +37,12 @@
             </div>
           </dl>
         </div>
-        <ArrowButton
-          class="absolute bottom-0 right-0 !transition-all group-hover:opacity-100 opacity-0 !bg-blue-700 !border-blue-700"
-        />
+        <div
+          class="absolute right-2 bottom-2 bg-transparent-black-100 w-10 h-10 inline-flex justify-center items-center rounded-full group-hover:!bg-blue-700 group-hover:!text-white"
+        >
+          <ArrowForwardIcon />
+          <span class="sr-only">View Asset</span>
+        </div>
       </div>
     </MediaCard>
   </Link>
@@ -51,8 +54,8 @@ import { getAssetUrl, getThumbURL } from "@/helpers/displayUtils";
 import { computed, ref } from "vue";
 import MediaCard from "../MediaCard/MediaCard.vue";
 import Link from "@/components/Link/Link.vue";
-import ArrowButton from "../ArrowButton/ArrowButton.vue";
 import Chip from "../Chip/Chip.vue";
+import { ArrowForwardIcon } from "@/icons";
 
 const props = defineProps<{
   searchMatch: SearchResultMatch;

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -38,7 +38,7 @@
           </dl>
         </div>
         <div
-          class="absolute right-2 bottom-2 bg-transparent-black-100 w-10 h-10 inline-flex justify-center items-center rounded-full group-hover:!bg-blue-700 group-hover:!text-white"
+          class="absolute w-10 h-10 bottom-0 right-0 inline-flex justify-center items-center rounded-full group-hover:!bg-blue-700 group-hover:!text-white"
         >
           <ArrowForwardIcon />
           <span class="sr-only">View Asset</span>

--- a/src/components/SearchResultRow/SearchResultRow.vue
+++ b/src/components/SearchResultRow/SearchResultRow.vue
@@ -4,7 +4,7 @@
     class="group hover:no-underline relative text-inherit group focus:outline-blue-700 focus:outline-offset-2 focus-within:outline-solid"
   >
     <div
-      class="search-result-row flex bg-white p-2 sm:p-4 gap-4 group-hover:bg-blue-50 transition-all rounded-md border-2 border-transparent hover:border-blue-700 group-focus:bg-blue-50 group-focus:border-blue-700"
+      class="search-result-row flex bg-white p-2 sm:p-4 gap-4 group-hover:bg-blue-50 transition-all rounded-md border-2 border-transparent hover:border-blue-700 group-focus:bg-blue-50 group-focus:border-blue-700 items-center"
     >
       <LazyLoadImage
         v-if="imgSrc"
@@ -39,9 +39,11 @@
         </dl>
       </div>
       <div
-        class="not-sr-only hidden sm:inline-flex opacity-0 group-hover:opacity-100 group-focus:opacity-100 self-center rounded-full w-10 h-10 bg-blue-700 items-center justify-center"
+        class="not-sr-only hidden sm:inline-flex self-center rounded-full w-10 h-10 items-center justify-center group-hover:bg-blue-700 transition-all"
       >
-        <ArrowForwardIcon class="text-blue-50" />
+        <ArrowForwardIcon
+          class="text-neutral-900 group-hover:text-white transition-all"
+        />
       </div>
     </div>
   </Link>

--- a/src/components/SearchResultRow/SearchResultRow.vue
+++ b/src/components/SearchResultRow/SearchResultRow.vue
@@ -53,7 +53,6 @@ import { computed } from "vue";
 import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
 import Link from "../Link/Link.vue";
 import { getAssetUrl } from "@/helpers/displayUtils";
-import ArrowButton from "../ArrowButton/ArrowButton.vue";
 import { ArrowForwardIcon } from "@/icons";
 
 const props = defineProps<{


### PR DESCRIPTION
Fixes a few issues:
 - `<Link>` couldn't be opened in a new window
 -  hovering over a link in the browser won't show it's destination in the status text.
	<img width="500" alt="image" src="https://user-images.githubusercontent.com/980170/236036049-8e84572d-32bc-4389-acad-05d039d8e711.png">
- Fixes #95 

See [CSS Tricks: Annoying Mobile Double Tap Link Issue](https://css-tricks.com/annoying-mobile-double-tap-link-issue/) for info on what was causing #95.