### PR TITLE
fix: non-logged in user should not see Drawers in the menu

### DIFF
--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -9,7 +9,7 @@
 
       <AppMenuItem :to="`/search/listCollections`"> Collections </AppMenuItem>
 
-      <AppMenuItem :href="`${BASE_URL}/drawers/listDrawers`">
+      <AppMenuItem v-if="currentUser" :href="`${BASE_URL}/drawers/listDrawers`">
         Drawers
       </AppMenuItem>
 


### PR DESCRIPTION
Drawers won't appear in app menu if a user is not logged in.

Not logged in:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/980170/236050757-2a686038-a29a-4b3e-8b5c-7bf48a48dd0c.png">

Logged in:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/980170/236050875-a7df2764-b477-4f14-b165-6721d8756896.png">

Fixes #88