### PR TITLE
fix: hide collections in app menu if no collections and not logged in

### DIFF
--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -7,7 +7,12 @@
     >
       <PagesNavSection :pages="pages" />
 
-      <AppMenuItem :to="`/search/listCollections`"> Collections </AppMenuItem>
+      <AppMenuItem
+        v-if="currentUser || instanceStore.collections.length"
+        :to="`/search/listCollections`"
+      >
+        Collections
+      </AppMenuItem>
 
       <AppMenuItem :href="`${BASE_URL}/drawers/listDrawers`">
         Drawers


### PR DESCRIPTION
Fixes #89

Screenshots of 4 states below...

not logged in, and no public collections (link hidden):
<img width="800" alt="image" src="https://user-images.githubusercontent.com/980170/236054159-1218e379-f042-4fce-82f2-d0c83133bc24.png">

not logged in, but there are public collections (link appears):
<img width="800" alt="image" src="https://user-images.githubusercontent.com/980170/236054099-dd14f4e9-619e-4f14-aee1-d52a6c79c3a7.png">

logged in, and no collections (link still appears):
<img width="800" alt="image" src="https://user-images.githubusercontent.com/980170/236054431-41076317-ffa6-42bd-8485-b256b4de4db3.png">

logged in, and collections exist (link appears like normal):
<img width="800" alt="image" src="https://user-images.githubusercontent.com/980170/236054579-0235fb6e-5c11-433f-9d0c-9410187e37e9.png">
