### PR TITLE
fix: search bar should show up if user can search and browse

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -6,7 +6,7 @@
       </Link>
     </div>
     <SearchBar
-      v-if="currentUser?.canSearchAndBrowse"
+      v-if="instanceStore.instance.userCanSearchAndBrowse"
       class="flex-1 w-full max-w-lg"
     />
     <div class="flex gap-2 items-center">

--- a/src/helpers/selectInstanceFromResponse.ts
+++ b/src/helpers/selectInstanceFromResponse.ts
@@ -35,6 +35,6 @@ export function selectInstanceFromResponse(
     contact: contact,
     featuredAssetId,
     featuredAssetText,
-    canSearchAndBrowse: userCanSearchAndBrowse,
+    userCanSearchAndBrowse,
   };
 }

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -40,7 +40,7 @@ import SignInRequiredNotice from "./SignInRequiredNotice.vue";
 const page = ref<StaticContentPage | null>(null);
 const instanceStore = useInstanceStore();
 const canSearchAndBrowse = computed(
-  () => instanceStore.instance?.canSearchAndBrowse ?? false
+  () => instanceStore.instance?.userCanSearchAndBrowse ?? false
 );
 const isReady = computed(() => instanceStore.isReady);
 

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -29,7 +29,7 @@ const createState = () => ({
     centralAuthLabel: "Central Auth",
     featuredAssetId: null,
     featuredAssetText: null,
-    canSearchAndBrowse: false,
+    userCanSearchAndBrowse: false,
   }),
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -483,7 +483,9 @@ export interface ElevatorInstance {
   centralAuthLabel: string; // label for central auth
   featuredAssetId: string | null; // featured asset for homepage
   featuredAssetText: string | null; // text appearing above the featured asset
-  canSearchAndBrowse: boolean; // whether or not to show search and browse
+  // whether or not to show search and browse
+  // may be true even if user is not logged in
+  userCanSearchAndBrowse: boolean;
 }
 
 export interface RawAssetCollection {
@@ -515,7 +517,6 @@ export interface User {
   isSuperAdmin: boolean;
   canManageAssets: boolean;
   canManageDrawers: boolean;
-  canSearchAndBrowse: boolean;
 }
 
 export interface NavItem {


### PR DESCRIPTION
Fixes #90

Shows search bar if `userCanSearchAndBrowse` is true, even if the user is not logged in. 

Previously, I put the `canSearchAndBrowse` property under `currentUser`. But `currentUser` may be undefined if they're not logged in, which means `currentUser?.canSearchAndBrowse` will be falsey even if `canSearchAndBrowse` is true. This PR moves the prop from `currentUser` to `instance` in the `instanceStore`.

Up on dev for testing (stacked on #89 and #88).