### PR TITLE
fix: don't show homepage content when user cannot search and browse

### DIFF
--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -5,31 +5,36 @@
       :currentUser="instanceStore.currentUser"
       @close="$emit('close')"
     >
-      <PagesNavSection :pages="pages" />
+      <template v-if="instanceStore.instance.userCanSearchAndBrowse">
+        <PagesNavSection :pages="pages" />
 
-      <AppMenuItem
-        v-if="currentUser || instanceStore.collections.length"
-        :to="`/search/listCollections`"
-      >
-        Collections
-      </AppMenuItem>
+        <AppMenuItem
+          v-if="currentUser || instanceStore.collections.length"
+          :to="`/search/listCollections`"
+        >
+          Collections
+        </AppMenuItem>
 
-      <AppMenuItem v-if="currentUser" :href="`${BASE_URL}/drawers/listDrawers`">
-        Drawers
-      </AppMenuItem>
+        <AppMenuItem
+          v-if="currentUser"
+          :href="`${BASE_URL}/drawers/listDrawers`"
+        >
+          Drawers
+        </AppMenuItem>
 
-      <EditNavSection
-        v-if="currentUser?.canManageAssets"
-        :currentUser="currentUser"
-        :instance="instance"
-        :assetId="activeAssetId"
-      />
+        <EditNavSection
+          v-if="currentUser?.canManageAssets"
+          :currentUser="currentUser"
+          :instance="instance"
+          :assetId="activeAssetId"
+        />
 
-      <AdminNavSection
-        v-if="currentUser?.isAdmin"
-        :currentUser="currentUser"
-        :instance="instance"
-      />
+        <AdminNavSection
+          v-if="currentUser?.isAdmin"
+          :currentUser="currentUser"
+          :instance="instance"
+        />
+      </template>
       <HelpNavSection :instance="instance" />
     </AppMenuPure>
   </div>

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -2,6 +2,7 @@
   <DefaultLayout>
     <SignInRequiredNotice v-if="isReady && !canSearchAndBrowse" />
     <div
+      v-if="isReady && canSearchAndBrowse"
       class="home-page-content md:grid"
       :class="{
         'md:grid-cols-2': !featuredAssetId,

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -77,6 +77,10 @@ watch(
   () => instanceStore.fetchStatus,
   async () => {
     if (instanceStore.fetchStatus !== "success") return;
+
+    // if the can't search and browse, we're done
+    if (!canSearchAndBrowse.value) return;
+
     const homePageId = findHomePageId();
     page.value = await fetchHomePage(homePageId);
     featuredAsset.value = await fetchFeaturedAsset(featuredAssetId.value);


### PR DESCRIPTION
 If `userCanSearchAndBrowse` is false:
- hides homepage content
- hides app menu content (except help)