### PR TITLE
fix: search results title should not show html tags

### DIFF
--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -50,7 +50,7 @@
 
 <script lang="ts" setup>
 import { SearchResultMatch } from "@/types";
-import { getAssetUrl, getThumbURL } from "@/helpers/displayUtils";
+import { getAssetUrl, getThumbURL, stripTags } from "@/helpers/displayUtils";
 import { computed, ref } from "vue";
 import MediaCard from "../MediaCard/MediaCard.vue";
 import Link from "@/components/Link/Link.vue";
@@ -65,11 +65,11 @@ const cardContents = ref<HTMLElement | null>(null);
 
 const title = computed(() => {
   if (Array.isArray(props.searchMatch.title)) {
-    return props.searchMatch.title.join(",");
+    return props.searchMatch.title.map((str) => stripTags(str)).join(",");
   }
 
   if (props.searchMatch.title && props.searchMatch.title.length > 0) {
-    return props.searchMatch.title;
+    return stripTags(props.searchMatch.title);
   }
 
   return "(no title)";

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -131,7 +131,7 @@ export function toClickToSearchUrl(
     return (
       config.instance.base.url +
       "/search/querySearch/" +
-      encodeURIComponent(cleanedLinkText)
+      stripTags(cleanedLinkText)
     );
   }
 

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -116,6 +116,11 @@ export function getAssetTitle(asset: Asset): string {
   return asset?.title?.[0] ?? "(No Title)";
 }
 
+export function stripTags(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return doc.body.textContent || "";
+}
+
 export function toClickToSearchUrl(
   linkText: string,
   widgetProps: WidgetProps


### PR DESCRIPTION
- strips any html tags out of the title on the search results card (keeps them on asset page)
- fix title link on asset page. Previously, if a user clicked on one of the title links, and the title had html, it would encode the HTML in the `querySearch`. This wouldn't show the correct result(s). Now this just strips HTML from the `querySearch`:
<img width="937" alt="image" src="https://user-images.githubusercontent.com/980170/236293698-b136b0c0-4150-445e-b6ea-00ba6586c638.png">
