### PR TITLE
fix: search input empty on search page

### DIFF
--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -100,7 +100,7 @@
 </template>
 <script setup lang="ts">
 import { watch, computed, onMounted, nextTick, ref } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRouter, useRoute, onBeforeRouteLeave } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useSearchStore } from "@/stores/searchStore";
 import BrowseCollectionHeader from "./BrowseCollectionHeader.vue";
@@ -185,7 +185,9 @@ function handleTabChange(tab: TabType) {
 }
 
 onMounted(() => {
+  // set the initial tab based on the query param
   const initialTabId = props.resultsView || searchStore.resultsView || "grid";
+
   // if the query param is set, use it to set the state
   // otherwise we'll fall back to the current resultsView
   // or failing that, the default "grid" view
@@ -217,6 +219,11 @@ watch(
   },
   { immediate: true }
 );
+
+// clear the search query when leaving this page
+onBeforeRouteLeave(() => {
+  searchStore.query = "";
+});
 </script>
 <style scoped></style>
 <style>

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -82,6 +82,13 @@ const actions = (state: SearchStoreState) => ({
           state.matches.value = res.matches;
           state.status.value = "success";
 
+          // set query to the search text if it's not already set
+          // to something. This handles the case when a user enters
+          // the search results page with a search id in the url, but
+          // nothing yet in the search input box
+          state.query.value =
+            state.query.value || res.searchEntry?.searchText || "";
+
           // call all registered after handlers
           state.afterNewSearchHandlers.forEach((fn) => fn(state));
         })


### PR DESCRIPTION
Two updates:
- when a search completes, if the `searchStore.query` is empty, it will be set to the `searchText` returned from the search. This handles the case where a user enters a search result page directly (without typing in a query into the search input), or if the user refreshes the page. (#98 )
- When leaving the search results page, `searchStore.query` will be cleared. So the search text won't stick around as a user navigates to other pages. (#99 )

On <https://dev.elevator.umn.edu/defaultinstance/> for testing

Fixes #98
Fixes #99 
