### PR TITLE
Fixes HTML in result title in list view and gallery view

### DIFF
--- a/src/components/SearchResultRow/SearchResultRow.vue
+++ b/src/components/SearchResultRow/SearchResultRow.vue
@@ -50,7 +50,7 @@
 </template>
 <script setup lang="ts">
 import { SearchResultMatch } from "@/types";
-import { getThumbURL } from "@/helpers/displayUtils";
+import { getThumbURL, stripTags } from "@/helpers/displayUtils";
 import { computed } from "vue";
 import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
 import Link from "../Link/Link.vue";
@@ -63,11 +63,11 @@ const props = defineProps<{
 
 const title = computed(() => {
   if (Array.isArray(props.searchMatch.title)) {
-    return props.searchMatch.title.join(",");
+    return props.searchMatch.title.map(stripTags).join(",");
   }
 
   if (props.searchMatch.title && props.searchMatch.title.length > 0) {
-    return props.searchMatch.title;
+    return stripTags(props.searchMatch.title);
   }
 
   return "(no title)";

--- a/src/components/SearchResultsGallery/useSlidesForMatches.ts
+++ b/src/components/SearchResultsGallery/useSlidesForMatches.ts
@@ -1,6 +1,6 @@
 import { SearchResultMatch, RelatedAssetCacheItemWithId, Asset } from "@/types";
 import { reactive } from "vue";
-import { getThumbURL, getAssetTitle } from "@/helpers/displayUtils";
+import { getThumbURL, getAssetTitle, stripTags } from "@/helpers/displayUtils";
 import api from "@/api";
 
 export interface Slide {
@@ -21,11 +21,10 @@ export interface Slide {
 }
 
 const selectTitleFromMatch = (match: SearchResultMatch) => {
-  const noTitleText = "No Title";
   if (Array.isArray(match.title)) {
-    return match.title?.[0] ?? noTitleText;
+    return match.title.map(stripTags).join(", ");
   }
-  return match.title ?? noTitleText;
+  return match.title?.length ? stripTags(match.title) : "(No Title)";
 };
 
 const selectThumbSrc = (match: SearchResultMatch) => {

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -113,7 +113,8 @@ export function getWidgetsForDisplay({
 }
 
 export function getAssetTitle(asset: Asset): string {
-  return asset?.title?.[0] ?? "(No Title)";
+  const title = asset?.title?.[0] ?? "(No Title)";
+  return stripTags(title);
 }
 
 export function stripTags(html: string): string {


### PR DESCRIPTION
A few more html in title fixes, so these tabs display like the grid tab.