### PR TITLE
Fix prev/next search border rendering

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -1,6 +1,6 @@
 <template>
-  <header class="app-header px-4 py-2 flex flex-col gap-2">
-    <div class="flex justify-between items-center gap-8">
+  <header class="app-header flex flex-col gap-2">
+    <div class="flex justify-between items-center gap-8 px-4 py-2">
       <div class="flex gap-2 items-center">
         <Link to="/" class="app-header__logo-link hover:no-underline">
           <AppLogoMark />
@@ -18,7 +18,9 @@
         <AppMenuButton />
       </div>
     </div>
-    <slot />
+    <div class="app-header__secondary-nav">
+      <slot />
+    </div>
   </header>
 </template>
 <script setup lang="ts">
@@ -68,5 +70,9 @@ const currentUser = computed(() => instanceStore.currentUser);
     color: var(--app-appHeader-menuButton-active-textColor);
     border-color: var(--app-appHeader-menuButton-active-borderColor);
   }
+}
+
+.app-header__secondary-nav {
+  background: var(--app-appHeader-secondaryNav-backgroundColor);
 }
 </style>

--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -1,21 +1,24 @@
 <template>
-  <header class="app-header flex justify-between items-center px-4 py-2 gap-8">
-    <div class="flex gap-2 items-center">
-      <Link to="/" class="app-header__logo-link hover:no-underline">
-        <AppLogoMark />
-      </Link>
-    </div>
-    <SearchBar
-      v-if="instanceStore.instance.userCanSearchAndBrowse"
-      class="flex-1 w-full max-w-lg"
-    />
-    <div class="flex gap-2 items-center">
-      <AuthDropDown
-        :currentUser="currentUser"
-        :instance="instanceStore.instance"
+  <header class="app-header px-4 py-2 flex flex-col gap-2">
+    <div class="flex justify-between items-center gap-8">
+      <div class="flex gap-2 items-center">
+        <Link to="/" class="app-header__logo-link hover:no-underline">
+          <AppLogoMark />
+        </Link>
+      </div>
+      <SearchBar
+        v-if="instanceStore.instance.userCanSearchAndBrowse"
+        class="flex-1 w-full max-w-lg"
       />
-      <AppMenuButton />
+      <div class="flex gap-2 items-center">
+        <AuthDropDown
+          :currentUser="currentUser"
+          :instance="instanceStore.instance"
+        />
+        <AppMenuButton />
+      </div>
     </div>
+    <slot />
   </header>
 </template>
 <script setup lang="ts">

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -1,7 +1,7 @@
 <template>
   <nav
     v-if="currentAssetIndex !== null"
-    class="justify-between items-center gap-4 grid grid-cols-3"
+    class="justify-between items-center gap-4 grid grid-cols-3 px-4 py-1"
   >
     <div class="flex justify-start">
       <Button

--- a/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
+++ b/src/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue
@@ -1,7 +1,7 @@
 <template>
   <nav
     v-if="currentAssetIndex !== null"
-    class="justify-between py-2 px-4 items-center gap-4 grid grid-cols-3"
+    class="justify-between items-center gap-4 grid grid-cols-3"
   >
     <div class="flex justify-start">
       <Button

--- a/src/css/themes/default.css
+++ b/src/css/themes/default.css
@@ -15,6 +15,7 @@
   * App Header
   */
   --app-appHeader-backgroundColor: var(--app-backgroundColor);
+  --app-appHeader-secondaryNav-backgroundColor: transparent;
   --app-wordmark-textColor: var(--app-textColor);
   --app-appHeader-wordmark-textColor: var(--app-textColor);
   --app-appHeader-logo-color: var(--app-textColor);

--- a/src/css/themes/folwell.css
+++ b/src/css/themes/folwell.css
@@ -28,6 +28,7 @@
   * App Header
   */
   --app-appHeader-backgroundColor: var(--gold-light);
+  --app-appHeader-secondaryNav-backgroundColor: var(--white);
   --app-appHeader-textColor: var(--black);
   --app-appHeader-wordmark-textColor: var(--black);
   --app-appHeader-logo-color: var(--maroon);

--- a/src/layouts/NoScrollLayout.vue
+++ b/src/layouts/NoScrollLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-screen flex flex-col">
     <AppHeader class="top-0 w-full z-20 backdrop-blur-sm">
-      <PrevNextSearchResultNav />
+      <slot name="secondaryAppHeader" />
     </AppHeader>
     <div ref="contentContainer" class="flex-1 mt-18 md:mt-0 overflow-auto">
       <slot />
@@ -10,6 +10,5 @@
 </template>
 <script setup lang="ts">
 import AppHeader from "@/components/AppHeader/AppHeader.vue";
-import PrevNextSearchResultNav from "@/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
 </script>
 <style></style>

--- a/src/layouts/NoScrollLayout.vue
+++ b/src/layouts/NoScrollLayout.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="h-screen flex flex-col">
-    <AppHeader class="top-0 w-full z-20 backdrop-blur-sm" />
-    <PrevNextSearchResultNav />
+    <AppHeader class="top-0 w-full z-20 backdrop-blur-sm">
+      <PrevNextSearchResultNav />
+    </AppHeader>
     <div ref="contentContainer" class="flex-1 mt-18 md:mt-0 overflow-auto">
       <slot />
     </div>

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -1,5 +1,8 @@
 <template>
   <NoScrollLayout class="overflow-x-hidden">
+    <template #secondaryAppHeader>
+      <PrevNextSearchResultNav />
+    </template>
     <template v-if="isPageLoaded">
       <MetaDataOnlyView
         v-if="isMetaDataOnly"
@@ -22,6 +25,7 @@ import AssetView from "./AssetView.vue";
 import MetaDataOnlyView from "./MetaDataOnlyView.vue";
 import { getAssetTitle } from "@/helpers/displayUtils";
 import { usePageTitle } from "@/helpers/usePageTitle";
+import PrevNextSearchResultNav from "@/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
 import { striptags } from "striptags";
 
 const assetStore = useAssetStore();


### PR DESCRIPTION
Previously, on the asset view page, if the prev/next results search bar would show up it would render below the app header without a bottom border. This creates a slot for secondary navs within the app header, and moves the prev/next component into it.

Fixes #96

<img width="500" alt="image" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/8d6d2639-ca29-4555-929a-36f93fa03967">

<img width="500" alt="image" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/1cf551be-9616-4d0b-b86f-8602885612b4">
