### PR TITLE
fix skeleton showing when seach query is empty

### DIFF
--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -7,8 +7,9 @@
           v-if="searchStore.browsingCollectionId"
           :collectionId="searchStore.browsingCollectionId"
         />
-        <h2 v-else-if="nonBrowsingPageTitle" class="text-4xl my-8 font-bold">
-          <q>{{ nonBrowsingPageTitle }}</q>
+        <h2 v-else-if="searchStore.isReady" class="text-4xl my-8 font-bold">
+          <q v-if="nonBrowsingPageTitle">{{ nonBrowsingPageTitle }}</q>
+          <span v-else>Search Results</span>
         </h2>
         <Skeleton v-else class="!w-1/2 !h-12 !my-8" />
 


### PR DESCRIPTION
This fixes an issue where the results loading skeleton would show up in place of the page title if the search query was empty. Now a generic "Search Results" title will be shown:

<img width="500" alt="ScreenShot 2023-05-17 at 14 07 27@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/edb19638-6467-45fb-ae7a-08eeb7e81d47">

On dev for testing:
<https://dev.elevator.umn.edu/defaultinstance/search/s/c2487d87-6bc8-40aa-8f6e-6b9dcbd84564?resultsView=grid>