### PR TITLE
Advanced Search: filter by text fields

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -236,6 +236,7 @@ const api = {
     const res = await axios.get<ApiInstanceNavResponse>(
       `${BASE_URL}/home/getInstanceNav`
     );
+
     return res.data;
   },
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,8 +10,8 @@ import {
   ApiInstanceNavResponse,
   ApiStaticPageResponse,
   FileDownloadNormalized,
-  SearchSortOptions,
   LocalLoginResponse,
+  SearchRequestOptions,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -242,21 +242,25 @@ const api = {
 
   async getSearchId(
     query: string,
-    opts: { sort?: keyof SearchSortOptions; collections?: number[] | null } = {}
+    opts: Omit<SearchRequestOptions, "searchText"> = {}
   ): Promise<string> {
     const params = new URLSearchParams();
-    const searchQuery: {
-      searchText: string;
-      sort?: keyof SearchSortOptions;
-      collection?: string[];
-    } = { searchText: query };
+    const searchQuery: SearchRequestOptions = { searchText: query };
 
     if (opts.sort) {
       searchQuery.sort = opts.sort;
     }
 
-    if (opts.collections) {
-      searchQuery.collection = opts.collections.map(String);
+    if (opts.collection) {
+      searchQuery.collection = opts.collection.map(String);
+    }
+
+    if (opts.specificFieldSearch) {
+      searchQuery.specificFieldSearch = opts.specificFieldSearch;
+
+      // default to OR combine operator
+      searchQuery.combineSpecificSearches =
+        opts.combineSpecificSearches ?? "OR";
     }
 
     params.append("searchQuery", JSON.stringify(searchQuery));

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
@@ -16,6 +16,7 @@
         </h2>
 
         <FilterByCollectionsSection />
+        <FilterByFieldsSection />
       </div>
     </div>
     <div
@@ -40,6 +41,7 @@ import { useSearchStore } from "@/stores/searchStore";
 import { onClickOutside } from "@vueuse/core";
 import SearchTextInputGroup from "../SearchBar/SearchTextInputGroup.vue";
 import FilterByCollectionsSection from "./FilterByCollectionsSection.vue";
+import FilterByFieldsSection from "./FilterByFieldsSection.vue";
 
 const emit = defineEmits<{
   (eventName: "close"): void;

--- a/src/components/AdvancedSearchForm/FilterByCollectionsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByCollectionsSection.vue
@@ -16,43 +16,44 @@
       below.
     </p>
 
-    <ul class="flex flex-wrap gap-2">
+    <ul
+      v-if="selectedCollections.length"
+      class="flex flex-wrap gap-2 bg-transparent-black-50 p-4 mb-4 rounded-md"
+    >
       <li
         v-for="collection in selectedCollections"
         :key="collection.id"
-        class="text-xs bg-neutral-100 py-1 px-2 rounded-md border border-neutral-200 inline-flex items-center"
+        class="text-xs bg-white rounded-md border border-neutral-800 inline-flex items-center text-neutral-900 px-2 py-1"
       >
         {{ collection.title }}
 
         <button
-          class="ml-2"
+          class="ml-2 h-full flex items-center justify-center"
           @click="searchStore.removeCollectionIdFilter(collection.id)"
         >
           <XIcon class="h-3 w-3" />
         </button>
       </li>
-      <li v-if="unselectedCollections.length" class="w-full">
-        <DropDown
-          v-if="unselectedCollections.length"
-          label="Add Collection"
-          class="border border-neutral-900 rounded-md flex w-1/4"
-          labelClass="justify-between pl-3"
-          alignment="left"
-        >
-          <div class="max-h-[50vh] overflow-y-auto">
-            <DropDownItem
-              v-for="collection in unselectedCollections"
-              :key="collection.id"
-              class="!whitespace-nowrap overflow-ellipsis overflow-x-hidden"
-              :title="prefixWithHyphens(collection.title)"
-              @click="searchStore.addCollectionIdFilter(collection.id)"
-            >
-              {{ prefixWithHyphens(collection.title) }}
-            </DropDownItem>
-          </div>
-        </DropDown>
-      </li>
     </ul>
+    <DropDown
+      v-if="unselectedCollections.length"
+      label="Add Collection"
+      class="border border-neutral-900 rounded-md"
+      labelClass="justify-between pl-3"
+      alignment="left"
+    >
+      <div class="max-h-[50vh] overflow-y-auto">
+        <DropDownItem
+          v-for="collection in unselectedCollections"
+          :key="collection.id"
+          class="!whitespace-nowrap overflow-ellipsis overflow-x-hidden"
+          :title="prefixWithHyphens(collection.title)"
+          @click="searchStore.addCollectionIdFilter(collection.id)"
+        >
+          {{ prefixWithHyphens(collection.title) }}
+        </DropDownItem>
+      </div>
+    </DropDown>
   </section>
 </template>
 <script setup lang="ts">

--- a/src/components/AdvancedSearchForm/FilterByCollectionsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByCollectionsSection.vue
@@ -35,9 +35,12 @@
         <DropDown
           v-if="unselectedCollections.length"
           label="Add Collection"
-          class="inline-flex border border-neutral-900 rounded-md text-xs"
+          class="inline-flex border border-neutral-900 rounded-md"
           alignment="left"
-          labelClass="text-xs py-0 !pr-0"
+          :labelClass="{
+            'text-xs py-0 !pr-0': !!selectedCollections.length,
+            'p-2 !pr-0': !selectedCollections.length,
+          }"
         >
           <div class="max-h-[50vh] overflow-y-auto">
             <DropDownItem

--- a/src/components/AdvancedSearchForm/FilterByCollectionsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByCollectionsSection.vue
@@ -16,7 +16,7 @@
       below.
     </p>
 
-    <ul class="inline-flex flex-wrap gap-2">
+    <ul class="flex flex-wrap gap-2">
       <li
         v-for="collection in selectedCollections"
         :key="collection.id"
@@ -31,16 +31,13 @@
           <XIcon class="h-3 w-3" />
         </button>
       </li>
-      <li v-if="unselectedCollections.length">
+      <li v-if="unselectedCollections.length" class="w-full">
         <DropDown
           v-if="unselectedCollections.length"
           label="Add Collection"
-          class="inline-flex border border-neutral-900 rounded-md"
+          class="border border-neutral-900 rounded-md flex w-1/4"
+          labelClass="justify-between pl-3"
           alignment="left"
-          :labelClass="{
-            'text-xs py-0 !pr-0': !!selectedCollections.length,
-            'p-2 !pr-0': !selectedCollections.length,
-          }"
         >
           <div class="max-h-[50vh] overflow-y-auto">
             <DropDownItem

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -27,7 +27,7 @@
         "
       >
         <option
-          v-for="field in instanceStore.searchableFields"
+          v-for="field in supportedSearchableFields"
           :key="field.id"
           :value="field.id"
         >
@@ -55,7 +55,7 @@
     </div>
 
     <DropDown
-      v-if="instanceStore.searchableFields.length"
+      v-if="supportedSearchableFields.length"
       label="Add Field"
       class="inline-flex border border-neutral-900 rounded-md"
       alignment="left"
@@ -63,7 +63,7 @@
     >
       <div class="max-h-[50vh] overflow-y-auto">
         <DropDownItem
-          v-for="field in instanceStore.searchableFields"
+          v-for="field in supportedSearchableFields"
           :key="field.id"
           @click="searchStore.addSearchableFieldFilter(field.id)"
         >
@@ -74,6 +74,7 @@
   </section>
 </template>
 <script setup lang="ts">
+import { computed } from "vue";
 import Button from "@/components/Button/Button.vue";
 import { CircleXIcon } from "@/icons";
 import { useSearchStore } from "@/stores/searchStore";
@@ -84,5 +85,12 @@ import InputGroup from "../InputGroup/InputGroup.vue";
 
 const instanceStore = useInstanceStore();
 const searchStore = useSearchStore();
+
+const supportedTypes = ["text"];
+const supportedSearchableFields = computed(() => {
+  return instanceStore.searchableFields.filter((field) =>
+    supportedTypes.includes(field.type)
+  );
+});
 </script>
 <style scoped></style>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -5,6 +5,10 @@
       <!-- <Button variant="tertiary"> clear </Button> -->
     </header>
 
+    <div>
+      {{ searchStore.filterBy.searchableFields }}
+    </div>
+
     <DropDown
       v-if="instanceStore.searchableFields.length"
       label="Add Field"
@@ -16,19 +20,18 @@
         <DropDownItem
           v-for="field in instanceStore.searchableFields"
           :key="field.id"
+          @click="
+            searchStore.addSearchableFieldFilter({
+              ...field,
+              value: '',
+              isFuzzy: false,
+            })
+          "
         >
           {{ field.label }}
         </DropDownItem>
       </div>
     </DropDown>
-
-    <div>
-      <ul>
-        <li v-for="field in instanceStore.searchableFields" :key="field.id">
-          {{ field }}
-        </li>
-      </ul>
-    </div>
   </section>
 </template>
 <script setup lang="ts">

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -40,7 +40,7 @@
           {{ index >= 1 ? searchStore.filterBy.searchableFieldsOperator : "" }}
         </Button>
         <select
-          class="rounded-md w-1/4"
+          class="rounded-md w-1/3"
           :value="searchStore.getSearchableFieldFilter(filterId)?.fieldId"
           @change="
             searchStore.updateSearchableFieldFilterWithNewFilterId(
@@ -65,6 +65,7 @@
           :label="filter.label"
           :value="filter.value"
           :labelHidden="true"
+          :placeholder="`Type your ${filter.label.toLowerCase()}...`"
           @input="
             searchStore.updateSearchableFieldFilterValue(
               filterId,

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -14,10 +14,10 @@
     <div
       v-for="[filterId, filter] in searchStore.filterBy.searchableFieldsMap"
       :key="filterId"
-      class="w-full flex items-center gap-2 py-2"
+      class="w-full flex items-center gap-2 my-2"
     >
       <select
-        class="rounded-md"
+        class="rounded-md w-1/4"
         :value="searchStore.getSearchableFieldFilter(filterId)?.fieldId"
         @change="
           searchStore.updateSearchableFieldFilterWithNewFilterId(
@@ -57,9 +57,9 @@
     <DropDown
       v-if="supportedSearchableFields.length"
       label="Add Field"
-      class="inline-flex border border-neutral-900 rounded-md"
+      class="flex border border-neutral-900 rounded-md w-1/4"
       alignment="left"
-      labelClass="p-2 !pr-0"
+      labelClass="justify-between pl-3"
     >
       <div class="max-h-[50vh] overflow-y-auto">
         <DropDownItem
@@ -67,7 +67,7 @@
           :key="field.id"
           @click="searchStore.addSearchableFieldFilter(field.id)"
         >
-          {{ field.label }}
+          <span class="flex-1">{{ field.label }}</span>
         </DropDownItem>
       </div>
     </DropDown>
@@ -93,4 +93,13 @@ const supportedSearchableFields = computed(() => {
   );
 });
 </script>
-<style scoped></style>
+<style scoped>
+select {
+  background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23111' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5' /%3E%3C/svg%3E");
+  background-position: right 0.75rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  padding-right: 2.5rem;
+  border-color: #111;
+}
+</style>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -1,12 +1,57 @@
 <template>
   <section class="my-4">
-    <header class="flex items-baseline gap-2">
+    <header class="flex items-baseline gap-2 mb-2">
       <h3 class="font-bold">Fields</h3>
-      <!-- <Button variant="tertiary"> clear </Button> -->
+      <Button
+        v-if="searchStore.filterBy.searchableFieldsMap.size"
+        variant="tertiary"
+        @click="searchStore.clearSearchableFieldsFilters"
+      >
+        clear
+      </Button>
     </header>
 
-    <div>
-      {{ searchStore.filterBy.searchableFields }}
+    <div
+      v-for="[filterId, filter] in searchStore.filterBy.searchableFieldsMap"
+      :key="filterId"
+      class="w-full flex items-center gap-2 py-2"
+    >
+      <select
+        class="rounded-md"
+        :value="searchStore.getSearchableFieldFilter(filterId)?.fieldId"
+        @change="
+          searchStore.updateSearchableFieldFilterWithNewFilterId(
+            filterId,
+            ($event.target as HTMLSelectElement).value
+          )
+        "
+      >
+        <option
+          v-for="field in instanceStore.searchableFields"
+          :key="field.id"
+          :value="field.id"
+        >
+          {{ field.label }}
+        </option>
+      </select>
+
+      <InputGroup
+        :id="filterId"
+        class="flex-1"
+        :label="filter.label"
+        :value="filter.value"
+        :labelHidden="true"
+        @input="
+          searchStore.updateSearchableFieldFilterValue(
+            filterId,
+            ($event.target as HTMLInputElement).value
+          )
+        "
+      />
+
+      <button @click="searchStore.removeSearchableFieldIdFilter(filterId)">
+        <CircleXIcon class="w-4 h-4" />
+      </button>
     </div>
 
     <DropDown
@@ -20,13 +65,7 @@
         <DropDownItem
           v-for="field in instanceStore.searchableFields"
           :key="field.id"
-          @click="
-            searchStore.addSearchableFieldFilter({
-              ...field,
-              value: '',
-              isFuzzy: false,
-            })
-          "
+          @click="searchStore.addSearchableFieldFilter(field.id)"
         >
           {{ field.label }}
         </DropDownItem>
@@ -35,13 +74,13 @@
   </section>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
 import Button from "@/components/Button/Button.vue";
-import { XIcon } from "@/icons";
+import { CircleXIcon } from "@/icons";
 import { useSearchStore } from "@/stores/searchStore";
 import DropDown from "@/components/DropDown/DropDown.vue";
 import DropDownItem from "@/components/DropDown/DropDownItem.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
+import InputGroup from "../InputGroup/InputGroup.vue";
 
 const instanceStore = useInstanceStore();
 const searchStore = useSearchStore();

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -1,0 +1,46 @@
+<template>
+  <section class="my-4">
+    <header class="flex items-baseline gap-2">
+      <h3 class="font-bold">Fields</h3>
+      <!-- <Button variant="tertiary"> clear </Button> -->
+    </header>
+
+    <DropDown
+      v-if="instanceStore.searchableFields.length"
+      label="Add Field"
+      class="inline-flex border border-neutral-900 rounded-md"
+      alignment="left"
+      labelClass="p-2 !pr-0"
+    >
+      <div class="max-h-[50vh] overflow-y-auto">
+        <DropDownItem
+          v-for="field in instanceStore.searchableFields"
+          :key="field.id"
+        >
+          {{ field.label }}
+        </DropDownItem>
+      </div>
+    </DropDown>
+
+    <div>
+      <ul>
+        <li v-for="field in instanceStore.searchableFields" :key="field.id">
+          {{ field }}
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import Button from "@/components/Button/Button.vue";
+import { XIcon } from "@/icons";
+import { useSearchStore } from "@/stores/searchStore";
+import DropDown from "@/components/DropDown/DropDown.vue";
+import DropDownItem from "@/components/DropDown/DropDownItem.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
+
+const instanceStore = useInstanceStore();
+const searchStore = useSearchStore();
+</script>
+<style scoped></style>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -1,76 +1,103 @@
 <template>
   <section class="my-4">
-    <header class="flex items-baseline gap-2 mb-2">
-      <h3 class="font-bold">Fields</h3>
-      <Button
-        v-if="searchStore.filterBy.searchableFieldsMap.size"
-        variant="tertiary"
-        @click="searchStore.clearSearchableFieldsFilters"
-      >
-        clear
-      </Button>
-    </header>
-
-    <div
-      v-for="[filterId, filter] in searchStore.filterBy.searchableFieldsMap"
-      :key="filterId"
-      class="w-full flex items-center gap-2 my-2"
-    >
-      <select
-        class="rounded-md w-1/4"
-        :value="searchStore.getSearchableFieldFilter(filterId)?.fieldId"
-        @change="
-          searchStore.updateSearchableFieldFilterWithNewFilterId(
-            filterId,
-            ($event.target as HTMLSelectElement).value
-          )
-        "
-      >
-        <option
-          v-for="field in supportedSearchableFields"
-          :key="field.id"
-          :value="field.id"
+    <div class="flex justify-between">
+      <header class="flex items-baseline gap-2 mb-2">
+        <h3 class="font-bold">Fields</h3>
+        <Button
+          v-if="searchStore.filterBy.searchableFieldsMap.size"
+          variant="tertiary"
+          @click="searchStore.clearSearchableFieldsFilters"
         >
-          {{ field.label }}
-        </option>
-      </select>
-
-      <InputGroup
-        :id="filterId"
-        class="flex-1"
-        :label="filter.label"
-        :value="filter.value"
-        :labelHidden="true"
-        @input="
-          searchStore.updateSearchableFieldFilterValue(
-            filterId,
-            ($event.target as HTMLInputElement).value
-          )
-        "
-      />
-
-      <button @click="searchStore.removeSearchableFieldIdFilter(filterId)">
-        <CircleXIcon class="w-4 h-4" />
-      </button>
+          clear
+        </Button>
+      </header>
     </div>
 
-    <DropDown
-      v-if="supportedSearchableFields.length"
-      label="Add Field"
-      class="flex border border-neutral-900 rounded-md w-1/4"
-      alignment="left"
-      labelClass="justify-between pl-3"
+    <div
+      v-if="fieldFilterCount"
+      class="p-2 bg-transparent-black-50 rounded-md mb-4"
     >
-      <div class="max-h-[50vh] overflow-y-auto">
-        <DropDownItem
-          v-for="field in supportedSearchableFields"
-          :key="field.id"
-          @click="searchStore.addSearchableFieldFilter(field.id)"
+      <div
+        v-for="(
+          [filterId, filter], index
+        ) in searchStore.filterBy.searchableFieldsMap.entries()"
+        :key="filterId"
+        class="w-full flex items-center gap-2 my-2"
+      >
+        <Button
+          v-if="fieldFilterCount > 1"
+          class="text-xs w-[1.5rem] ml-0"
+          variant="tertiary"
+          type="button"
+          @click="
+            searchStore.updateSearchableFieldsOperator(
+              searchStore.filterBy.searchableFieldsOperator === 'AND'
+                ? 'OR'
+                : 'AND'
+            )
+          "
         >
-          <span class="flex-1">{{ field.label }}</span>
-        </DropDownItem>
+          {{ index >= 1 ? searchStore.filterBy.searchableFieldsOperator : "" }}
+        </Button>
+        <select
+          class="rounded-md w-1/4"
+          :value="searchStore.getSearchableFieldFilter(filterId)?.fieldId"
+          @change="
+            searchStore.updateSearchableFieldFilterWithNewFilterId(
+              filterId,
+              ($event.target as HTMLSelectElement).value
+            )
+          "
+        >
+          <option
+            v-for="field in supportedSearchableFields"
+            :key="field.id"
+            :value="field.id"
+          >
+            {{ field.label }}
+          </option>
+        </select>
+
+        <InputGroup
+          :id="filterId"
+          class="flex-1"
+          inputClass="!bg-white !border !border-neutral-900"
+          :label="filter.label"
+          :value="filter.value"
+          :labelHidden="true"
+          @input="
+            searchStore.updateSearchableFieldFilterValue(
+              filterId,
+              ($event.target as HTMLInputElement).value
+            )
+          "
+        />
+
+        <button @click="searchStore.removeSearchableFieldIdFilter(filterId)">
+          <CircleXIcon class="w-4 h-4" />
+        </button>
       </div>
-    </DropDown>
+    </div>
+
+    <div class="flex justify-between items-baseline">
+      <DropDown
+        v-if="supportedSearchableFields.length"
+        label="Add Field"
+        class="border border-neutral-900 rounded-md w-1/4"
+        alignment="left"
+        labelClass="justify-between pl-3"
+      >
+        <div class="max-h-[50vh] overflow-y-auto">
+          <DropDownItem
+            v-for="field in supportedSearchableFields"
+            :key="field.id"
+            @click="searchStore.addSearchableFieldFilter(field.id)"
+          >
+            <span class="flex-1">{{ field.label }}</span>
+          </DropDownItem>
+        </div>
+      </DropDown>
+    </div>
   </section>
 </template>
 <script setup lang="ts">
@@ -92,6 +119,10 @@ const supportedSearchableFields = computed(() => {
     supportedTypes.includes(field.type)
   );
 });
+
+const fieldFilterCount = computed(
+  () => searchStore.filterBy.searchableFieldsMap.size
+);
 </script>
 <style scoped>
 select {

--- a/src/components/DropDown/DropDown.vue
+++ b/src/components/DropDown/DropDown.vue
@@ -1,20 +1,18 @@
 <template>
   <Menu as="div" class="relative inline-block text-left">
-    <div>
-      <MenuButton
-        class="inline-flex w-full justify-center rounded-md items-center focus:outline-none focus:ring-2 p-2 placeholder:focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100"
-        :class="labelClass"
-      >
-        <slot name="label">
-          {{ label }}
-        </slot>
-        <ChevronDownIcon
-          v-if="showChevron"
-          class="xl:block h-4 w-4 m-1"
-          aria-hidden="true"
-        />
-      </MenuButton>
-    </div>
+    <MenuButton
+      class="inline-flex w-full justify-center rounded-md items-center focus:outline-none focus:ring-2 p-2 placeholder:focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100"
+      :class="labelClass"
+    >
+      <slot name="label">
+        {{ label }}
+      </slot>
+      <ChevronDownIcon
+        v-if="showChevron"
+        class="xl:block h-4 w-4 m-1"
+        aria-hidden="true"
+      />
+    </MenuButton>
 
     <transition
       enterActiveClass="transition ease-out duration-100"

--- a/src/components/Toggle/Toggle.vue
+++ b/src/components/Toggle/Toggle.vue
@@ -1,0 +1,47 @@
+<template>
+  <SwitchGroup>
+    <div class="inline-flex items-center gap-1.5">
+      <SwitchLabel v-if="offLabel">{{ offLabel }}</SwitchLabel>
+      <Switch
+        :modelValue="isOn"
+        :class="[
+          isOn ? 'bg-blue-600' : 'bg-neutral-200',
+          'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2',
+          toggleClass,
+          isOn ? toggleOnClass : toggleOffClass,
+        ]"
+        @update:modelValue="$emit('toggle')"
+      >
+        <span class="sr-only">{{ settingLabel }}</span>
+        <span
+          aria-hidden="true"
+          :class="[
+            isOn ? 'translate-x-5' : 'translate-x-0',
+            'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+          ]"
+        />
+      </Switch>
+      <SwitchLabel v-if="onLabel"> {{ onLabel }}</SwitchLabel>
+    </div>
+  </SwitchGroup>
+</template>
+
+<script setup lang="ts">
+import { Switch, SwitchGroup, SwitchLabel } from "@headlessui/vue";
+
+type CSSClass = Record<string, boolean> | string[] | string;
+
+defineProps<{
+  isOn: boolean;
+  settingLabel: string;
+  offLabel?: string;
+  onLabel?: string;
+  toggleClass?: CSSClass;
+  toggleOnClass?: CSSClass;
+  toggleOffClass?: CSSClass;
+}>();
+
+defineEmits<{
+  (eventName: "toggle");
+}>();
+</script>

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -9,6 +9,7 @@ import {
   ElevatorInstance,
   User,
   AssetCollection,
+  SearchableField,
 } from "@/types";
 import {
   toCollectionIndex,
@@ -21,6 +22,7 @@ const createState = () => ({
   currentUser: ref<User | null>(null),
   pages: ref<Page[]>([]),
   collections: ref<AssetCollection[]>([]),
+  searchableFields: ref<SearchableField[]>([]),
   instance: ref<ElevatorInstance>({
     id: null,
     name: "Elevator",
@@ -77,6 +79,14 @@ const actions = (state: ReturnType<typeof createState>) => ({
       state.collections.value = normalizeAssetCollections(
         apiResponse.collections
       );
+
+      // add id to searchable field object from api response
+      state.searchableFields.value = Object.entries(
+        apiResponse.sortableFields
+      ).map(([fieldId, field]) => ({
+        ...field,
+        id: fieldId,
+      }));
 
       state.fetchStatus.value = "success";
     } catch (error) {

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -63,6 +63,10 @@ const getters = (state: ReturnType<typeof createState>) => ({
       return null;
     }
   },
+
+  getSearchableFieldById(fieldId: string) {
+    return state.searchableFields.value.find((f) => f.id === fieldId) ?? null;
+  },
 });
 
 const actions = (state: ReturnType<typeof createState>) => ({

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -256,8 +256,23 @@ const actions = (state: SearchStoreState) => ({
     state.filterBy.searchableFieldsMap.set(filterId, updatedFilter);
   },
 
+  updateSearchableFieldsOperator(operator: string) {
+    const allowedOperators = ["AND", "OR"];
+    if (!allowedOperators.includes(operator)) {
+      throw new Error(
+        `Cannot update searchable fields operator. ${operator} is not in ${allowedOperators.join(
+          ", "
+        )}`
+      );
+    }
+
+    state.filterBy.searchableFieldsOperator = operator as "AND" | "OR";
+  },
+
   clearAllFilters() {
     this.clearCollectionIdFilters();
+    this.clearSearchableFieldsFilters();
+    state.filterBy.searchableFieldsOperator = "OR";
   },
 
   async search(searchId?: string): Promise<string | void> {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -120,7 +120,9 @@ const getters = (state: SearchStoreState) => ({
   isBrowsingCollection: computed((): boolean => {
     return (
       state.searchEntry.value?.searchText === "" &&
-      state.searchEntry.value?.collection?.length === 1
+      state.searchEntry.value?.collection?.length === 1 &&
+      // if we're filtering by specific fields, we're not browsing
+      (state.searchEntry.value?.specificFieldSearch ?? []).length === 0
     );
   }),
   browsingCollectionId: computed((): number | null => {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -24,6 +24,7 @@ export interface SearchStoreState {
   // collections that were used in the previous search
   filterBy: {
     collectionIds: number[];
+    fieldIds: number[];
   };
 
   matches: Ref<SearchResultMatch[]>;
@@ -53,6 +54,7 @@ const createState = (): SearchStoreState => ({
   query: ref(""),
   filterBy: reactive({
     collectionIds: [],
+    fieldIds: [],
   }),
   matches: ref([]),
   totalResults: ref(undefined),

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -7,9 +7,9 @@ import {
   SearchEntry,
   SearchResultsView,
   SearchSortOptions,
+  SearchableFieldFilter,
 } from "@/types";
 import { SORT_KEYS } from "@/constants/constants";
-
 export interface SearchStoreState {
   searchId: Ref<string | undefined>;
   status: Ref<FetchStatus>;
@@ -24,7 +24,8 @@ export interface SearchStoreState {
   // collections that were used in the previous search
   filterBy: {
     collectionIds: number[];
-    fieldIds: number[];
+    searchableFields: SearchableFieldFilter[];
+    searchableFieldsOperator: "AND" | "OR";
   };
 
   matches: Ref<SearchResultMatch[]>;
@@ -54,7 +55,8 @@ const createState = (): SearchStoreState => ({
   query: ref(""),
   filterBy: reactive({
     collectionIds: [],
-    fieldIds: [],
+    searchableFields: [],
+    searchableFieldsOperator: "OR",
   }),
   matches: ref([]),
   totalResults: ref(undefined),
@@ -130,6 +132,28 @@ const actions = (state: SearchStoreState) => ({
 
   clearCollectionIdFilters() {
     state.filterBy.collectionIds = [];
+  },
+
+  addSearchableFieldFilter(newFilter: SearchableFieldFilter) {
+    state.filterBy.searchableFields.push(newFilter);
+  },
+
+  removeSearchableFieldIdFilter(fieldId: string) {
+    const index = state.filterBy.searchableFields.findIndex((filter) => {
+      return filter.id === fieldId;
+    });
+
+    if (index < 0) {
+      throw new Error(
+        `Cannot remove searchable field id ${fieldId} from searchStore. ID is not in filterBy.searchableFieldIds`
+      );
+    }
+
+    state.filterBy.searchableFields.splice(index, 1);
+  },
+
+  clearSearchableFieldIdFilters() {
+    state.filterBy.searchableFields = [];
   },
 
   clearAllFilters() {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -108,7 +108,7 @@ const getters = (state: SearchStoreState) => ({
       collection: state.filterBy.collectionIds.length
         ? state.filterBy.collectionIds
         : undefined,
-      combineSpecificSearches: "OR",
+      combineSpecificSearches: state.filterBy.searchableFieldsOperator,
       specificFieldSearch,
     };
   }),

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -151,9 +151,10 @@ const actions = (state: SearchStoreState) => ({
     }
 
     const newFilter: SearchableFieldFilter = {
-      ...field,
       id: crypto.randomUUID(),
       fieldId: field.id,
+      type: field.type,
+      label: field.label,
       value: "",
       isFuzzy: false,
     };
@@ -216,6 +217,8 @@ const actions = (state: SearchStoreState) => ({
     const updatedFilter = {
       ...currentFilter,
       fieldId: field.id,
+      label: field.label,
+      type: field.type,
     };
 
     state.filterBy.searchableFieldsMap.set(filterId, updatedFilter);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -448,6 +448,16 @@ export type ElevatorPluginType = "Canvas" | "Wordpress" | string;
 
 export type ElevatorCallbackType = "lti" | "JS";
 
+export interface RawSortableField {
+  label: string;
+  template: number;
+  type: WidgetType;
+}
+
+export interface SearchableField extends RawSortableField {
+  id: string;
+}
+
 export interface ApiInstanceNavResponse {
   pages: Page[];
   userId: number | null;
@@ -466,6 +476,7 @@ export interface ApiInstanceNavResponse {
   useCentralAuth: boolean;
   centralAuthLabel: string;
   collections: RawAssetCollection[];
+  sortableFields: Record<string, RawSortableField>;
   featuredAssetId: string; // featured asset for homepage
   featuredAssetText: string; // text appearing above the featured asset
 }
@@ -483,6 +494,7 @@ export interface InstanceStoreState {
   currentUser: User | null;
   instance: ElevatorInstance;
   collections: AssetCollection[];
+  searchableFields: SearchableField[];
 }
 
 export interface ElevatorInstance {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -458,10 +458,13 @@ export interface SearchableField extends RawSortableField {
   id: string;
 }
 
-export interface SearchableFieldFilter extends SearchableField {
+export interface SearchableFieldFilter {
+  id: string; // filter uuid not field id
+  fieldId: string;
+  type: WidgetType;
+  label: string;
   value: string;
   isFuzzy: boolean;
-  options?: []; // if type is select
 }
 
 export interface ApiInstanceNavResponse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -343,10 +343,7 @@ export interface SearchEntry {
   showHidden?: "0" | "1";
   fuzzySearch?: "0" | "1";
   sort?: string;
-  specificSearchField?: string[];
-  specificSearchText?: string[];
-  specificSearchFuzzy?: string[];
-  specificFieldSearch?: unknown[];
+  specificFieldSearch?: SpecificFieldSearchItem[];
 }
 
 export interface SearchSortOptions {
@@ -358,6 +355,28 @@ export interface SearchSortOptions {
 
   // sort options for specific searches
   [key: string]: string;
+}
+
+export interface SpecificFieldSearchItem {
+  field: string;
+  text: string;
+  fuzzy: boolean;
+}
+
+export interface SearchRequestOptions {
+  searchText?: string;
+  sort?: keyof SearchSortOptions;
+  collection?: string[] | number[] | null;
+  specificFieldSearch?: SpecificFieldSearchItem[];
+  combineSpecificSearches?: "OR" | "AND";
+  fileTypesSearch?: string;
+  distance?: string;
+  latitude?: string;
+  longitude?: string;
+  startDateText?: string;
+  startDate?: string;
+  endDateText?: string;
+  endDate?: string;
 }
 
 export interface SearchResultsResponse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -458,6 +458,12 @@ export interface SearchableField extends RawSortableField {
   id: string;
 }
 
+export interface SearchableFieldFilter extends SearchableField {
+  value: string;
+  isFuzzy: boolean;
+  options?: []; // if type is select
+}
+
 export interface ApiInstanceNavResponse {
   pages: Page[];
   userId: number | null;


### PR DESCRIPTION
This update introduces filtering by specific text fields to advanced search. Users can now add multiple text field filters, with the choice to toggle between AND/OR boolean operators. 

<img width="500" alt="image" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/5263b5a7-0201-4d8c-b5cc-11d18e458b54">

<img width="500" alt="ScreenShot 2023-05-23 at 21 03 46" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/5f6409e7-eb6c-4ddc-b966-caaf044290f6" />

While this PR covers only text field types, future PRs will expand to other types. The choice of text fields as a starting point is due to their simplicity and fewer API calls for displaying user options.

Potential search/sort fields are kept in `instanceStore`, while  `searchStore` keeps the field filters and handles creation, updates, and deletions. 

Search filters are assigned unique UUIDs to accommodate multiple filters for the same field. They are stored in a Map for faster value updates and are translated to a format suitable for the search POST request via `searchStore.searchRequestOptions`

In the UI, boolean operators OR/AND are displayed only when more than one field filter is present. They are interactive, enabling the user to toggle between OR/AND by clicking on them.

I'm seeing some unexpected results in some searches. For example, when searching collection "Geotime Test" for title "Dino", I don't get any results. Same with "Obama Speeches" and "Afghanistan". I'm not sure why.

Next up: fuzzy search and extend filtering capabilities to select and other field types.