### PR TITLE
Change build to generate a `manifest.json` so that it can use hashes in file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "build:watch": "vite build --watch",
     "build:remotedev": "vite build --mode development --base \"/assets/elevator-ui/dist/\"",
+    "build:prod": "vite build --mode production --base \"/assets/elevator-ui/dist/\"",
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,13 +28,9 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
+      manifest: true,
       rollupOptions: {
-        // https://rollupjs.org/guide/en/#big-list-of-options
-        output: {
-          assetFileNames: "assets/[name].[ext]",
-          entryFileNames: "assets/[name].js",
-          chunkFileNames: "assets/[name].js",
-        },
+        input: "/src/main.ts",
       },
       sourcemap: true,
     },


### PR DESCRIPTION
This resolves an issue with asset caching beyond the main js and css files using the approach outlined in the [Vite Backend Integration Guide](https://vitejs.dev/guide/backend-integration.html).

This changes vite's build step to generate a `manifest.json` file can be used by the backend for cache-busting.