### PR TITLE
fix some`<Button>` component tab-ability

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -9,15 +9,15 @@
         variant === 'tertiary',
     }"
     v-bind="$attrs"
-    :to="to"
-    :href="href"
+    :to="componentType === RouterLink ? to : undefined"
+    :href="resolvedHref"
   >
     <slot />
   </component>
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import { RouterLink, type RouteLocationRaw } from "vue-router";
+import { RouterLink, type RouteLocationRaw, useRouter } from "vue-router";
 
 const props = withDefaults(
   defineProps<{
@@ -31,6 +31,17 @@ const props = withDefaults(
     to: undefined,
   }
 );
+
+const router = useRouter();
+const resolvedHref = computed(() => {
+  if (props.href) {
+    return props.href;
+  } else if (props.to && componentType.value === RouterLink) {
+    // If `to` is an object, resolve it to a string URL
+    return router.resolve(props.to).href;
+  }
+  return undefined;
+});
 
 const componentType = computed(() => {
   if (props.href) return "a";


### PR DESCRIPTION
The `<Button>` component creates an `<a>`, `<RouterLink>`, or `<button>` all styled uniformly depending on the attributes passed. `to` creates a `RouterLink`, while `href` creates an anchor tag. 

The generated `RouterLink` component wouldn't have a proper href attribute though, preventing tabbing and urls showing up in the status bar. 

It was noticeable when tab-navigating through this page, for example:
![ScreenShot 2023-06-02 at 17 13 58@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/7e328067-0441-459a-ad88-d8da4fb29b9b)

This fix prevents the Button generated RouterLinks from swallowing hrefs.

On <https://dev.elevator.umn.edu/defaultinstance/> with #149 for testing.