### PR TITLE
Add cascading multiselect to advanced search

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,9 +9,12 @@ import {
   ApiGetFieldInfoResponse,
   ApiGetSelectFieldInfoResponse,
   ApiGetCheckboxFieldInfoResponse,
+  ApiGetMultiSelectFieldInfoResponse,
   SearchableField,
   SearchableSelectField,
   SearchableCheckboxField,
+  SearchableMultiSelectField,
+  TreeNode,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import * as fetchers from "@/api/fetchers";
@@ -219,6 +222,16 @@ async function getSearchableCheckboxFieldValues(
   );
 }
 
+async function getSearchableMultiSelectFieldValues(
+  field: SearchableMultiSelectField
+): Promise<TreeNode> {
+  const data = await getSearchableFieldInfo<ApiGetMultiSelectFieldInfoResponse>(
+    field
+  );
+
+  return data?.rawContent ?? {};
+}
+
 const api = {
   getAsset,
   getAssetWithTemplate,
@@ -237,6 +250,7 @@ const api = {
   loginAsGuest: fetchers.loginAsGuest,
   getSearchableSelectFieldValues,
   getSearchableCheckboxFieldValues,
+  getSearchableMultiSelectFieldValues,
 };
 
 export default api;

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -90,7 +90,7 @@ import { useSearchStore } from "@/stores/searchStore";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import SelectFieldOptions from "./SelectFieldOptions.vue";
 import CheckboxFieldOptions from "./CheckboxFieldOptions.vue";
-import MultiSelectFieldOptions from "./MultiselectFieldOptions.vue";
+import MultiSelectFieldOptions from "./MultiSelectFieldOptions.vue";
 import type {
   SearchableFieldFilter,
   SearchableField,

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center gap-2">
+  <div class="flex items-baseline gap-2">
     <Button
       class="text-xs w-6 !ml-0"
       :class="{
@@ -50,6 +50,12 @@
       :filter="(filter as SearchableCheckboxFieldFilter)"
     />
 
+    <MultiSelectFieldOptions
+      v-if="currentField.type === 'multiselect'"
+      class="flex-1 text-sm"
+      :filter="filter"
+    />
+
     <label
       class="text-xs font-bold uppercase text-center cursor-pointer leading-none text-orient-sideways sm:text-orient-normal"
       :class="{
@@ -66,7 +72,11 @@
       Fuzzy
     </label>
 
-    <button type="button" @click="handleRemoveFilter">
+    <button
+      type="button"
+      class="self-start p-2 mt-[0.1rem]"
+      @click="handleRemoveFilter"
+    >
       <CircleXIcon class="w-5 h-5" />
     </button>
   </div>
@@ -80,6 +90,7 @@ import { useSearchStore } from "@/stores/searchStore";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import SelectFieldOptions from "./SelectFieldOptions.vue";
 import CheckboxFieldOptions from "./CheckboxFieldOptions.vue";
+import MultiSelectFieldOptions from "./MultiselectFieldOptions.vue";
 import type {
   SearchableFieldFilter,
   SearchableField,

--- a/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
@@ -3,9 +3,10 @@
     <CascadeSelect
       v-if="optionTree"
       :options="optionTree"
-      class="gap-0"
+      class="!gap-1"
       labelClass="sr-only"
       selectClass="text-sm border-neutral-200"
+      @change="handleCascadeSelectChange"
     />
   </div>
 </template>
@@ -36,6 +37,13 @@ const field = computed(() => {
 
 const optionTree = ref<TreeNode | null>(null);
 
+function handleCascadeSelectChange(selectedValues: string[]) {
+  searchStore.updateSearchableFieldFilterValue(
+    props.filter.id,
+    selectedValues.join(",")
+  );
+}
+
 watch(
   [field],
   async () => {
@@ -50,8 +58,6 @@ watch(
     optionTree.value = await api.getSearchableMultiSelectFieldValues(
       field.value
     );
-
-    console.log(optionTree.value);
   },
   { immediate: true }
 );

--- a/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <CascadeSelect
+      v-if="optionTree"
+      :options="optionTree"
+      class="gap-0"
+      labelClass="sr-only"
+      selectClass="text-sm border-neutral-200"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import api from "@/api";
+import {
+  SearchableFieldFilter,
+  SearchableMultiSelectField,
+  TreeNode,
+} from "@/types";
+import { ref, watch, computed } from "vue";
+import { useSearchStore } from "@/stores/searchStore";
+import { useInstanceStore } from "@/stores/instanceStore";
+import CascadeSelect from "@/components/CascadeSelect/CascadeSelect.vue";
+
+const props = defineProps<{
+  filter: SearchableFieldFilter;
+}>();
+
+const searchStore = useSearchStore();
+const instanceStore = useInstanceStore();
+
+const field = computed(() => {
+  return instanceStore.getSearchableField<SearchableMultiSelectField>(
+    props.filter.fieldId
+  );
+});
+
+const optionTree = ref<TreeNode | null>(null);
+
+watch(
+  [field],
+  async () => {
+    // if there's no field, throw an error
+    if (!field.value) {
+      throw new Error(
+        `Could not find searchable field with id ${props.filter.fieldId}`
+      );
+    }
+
+    // for other cases, update the options list
+    optionTree.value = await api.getSearchableMultiSelectFieldValues(
+      field.value
+    );
+
+    console.log(optionTree.value);
+  },
+  { immediate: true }
+);
+</script>
+<style scoped></style>

--- a/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
@@ -3,6 +3,7 @@
     <CascadeSelect
       v-if="optionTree"
       :options="optionTree"
+      :initialSelectedValues="props.filter.value.split(',')"
       class="!gap-1"
       labelClass="sr-only"
       selectClass="text-sm border-neutral-200"

--- a/src/components/CascadeSelect/CascadeSelect.stories.ts
+++ b/src/components/CascadeSelect/CascadeSelect.stories.ts
@@ -50,7 +50,5 @@ const options = {
 
 export const Default = Template.bind({});
 Default.args = {
-  options: {
-    city: ["mankato", "minneapolis"],
-  },
+  options,
 };

--- a/src/components/CascadeSelect/CascadeSelect.stories.ts
+++ b/src/components/CascadeSelect/CascadeSelect.stories.ts
@@ -1,0 +1,56 @@
+import { Meta, StoryFn } from "@storybook/vue3";
+import CascadeSelect from "./CascadeSelect.vue";
+
+export default {
+  component: CascadeSelect,
+} as Meta<typeof CascadeSelect>;
+
+const Template: StoryFn<typeof CascadeSelect> = (args) => ({
+  components: { CascadeSelect },
+  setup() {
+    return { args };
+  },
+  template: `
+    <CascadeSelect v-bind="args">
+    </CascadeSelect>
+  `,
+});
+
+const options = {
+  country: {
+    usa: {
+      state: {
+        minnesota: {
+          city: {
+            mankato: {
+              neighborhood: ["campus", "downtown"],
+            },
+            minneapolis: {
+              neighborhood: ["uptown", "downtown"],
+            },
+          },
+        },
+        wisconsin: {
+          city: ["madison", "milwaukee"],
+        },
+      },
+    },
+    canada: {
+      state: {
+        quebec: {
+          city: ["montreal"],
+        },
+        alberta: {
+          city: ["fakeville", "faketown"],
+        },
+      },
+    },
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  options: {
+    city: ["mankato", "minneapolis"],
+  },
+};

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -20,9 +20,11 @@
           )
         "
       >
-        <option value="" disabled>Select a {{ selected.label }}</option>
+        <option v-if="!selected.options.includes('')" value="" disabled>
+          Select a {{ selected.label }}
+        </option>
         <option v-for="opt in selected.options" :key="opt" :value="opt">
-          {{ opt }}
+          {{ opt === "" ? "-" : opt }}
         </option>
       </select>
     </div>

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -32,7 +32,7 @@
 </template>
 <script setup lang="ts">
 import { path } from "ramda";
-import { reactive, computed } from "vue";
+import { reactive, watch } from "vue";
 
 interface CascaderSelectOptions {
   [label: string]: string[] | CascaderSelectOptions;
@@ -178,5 +178,17 @@ function handleSelectChange(segmentLevel: number, value: string): void {
     listOfSelected.map((segment) => segment.value)
   );
 }
+
+watch(
+  () => props.options,
+  () => {
+    // reset the list of selected options
+    listOfSelected.splice(
+      0,
+      listOfSelected.length,
+      ...createInitialListOfSelected()
+    );
+  }
+);
 </script>
 <style scoped></style>

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="">
+    <label>
+      {{ getLabel(options) }}
+      <select v-model="selected">
+        <option value="" disabled>Select a {{ getLabel(options) }}</option>
+        <option v-for="opt in getOpts(options)" :key="opt" :value="opt">
+          {{ opt }}
+        </option>
+      </select>
+    </label>
+    <div>
+      <code>{{ options }}</code>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { ref } from "vue";
+
+interface CascaderSelectOptions {
+  [label: string]: string[] | CascaderSelectOptions;
+}
+
+defineProps<{
+  options: CascaderSelectOptions;
+}>();
+
+const selected = ref("");
+
+const getLabel = (options: CascaderSelectOptions): string => {
+  return Object.keys(options)[0];
+};
+
+const getOpts = (options: CascaderSelectOptions): string[] => {
+  const values = Object.values(options);
+
+  // option values could look like:
+  // [['minneapolis', 'st. paul']]
+  // or could be another level of nesting
+  // [{ 'minneapolis': ...}, {'st. paul': ... }]
+  // let's use the first value to determine which is which
+
+  // if there's no first value, return an empty array
+  if (values.length === 0) {
+    return [];
+  }
+
+  // if the first value is an object, then
+  // values looks like
+  // [{ 'minneapolis': ...}, { 'st. paul': ... }]
+  // and so we want the keys of each object within the array
+  if (!Array.isArray(values[0])) {
+    return values.map((obj) => Object.keys(obj)[0]);
+  }
+
+  // otherwise, values looks like [['minneapolis', 'st. paul']]
+  return values[0];
+};
+</script>
+<style scoped></style>

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="">
-    <label>
+    <label v-for="(selected, index) in listOfSelected" :key="index">
       {{ getLabel(options) }}
-      <select v-model="selected">
+      <select v-model="listOfSelected[index]">
         <option value="" disabled>Select a {{ getLabel(options) }}</option>
         <option v-for="opt in getOpts(options)" :key="opt" :value="opt">
           {{ opt }}
@@ -10,12 +10,17 @@
       </select>
     </label>
     <div>
-      <code>{{ options }}</code>
+      <p>
+        <code>options: {{ options }}</code>
+      </p>
+      <p>
+        <code>listOfSelected: {{ listOfSelected }}</code>
+      </p>
     </div>
   </div>
 </template>
 <script setup lang="ts">
-import { ref } from "vue";
+import { reactive } from "vue";
 
 interface CascaderSelectOptions {
   [label: string]: string[] | CascaderSelectOptions;
@@ -25,7 +30,7 @@ defineProps<{
   options: CascaderSelectOptions;
 }>();
 
-const selected = ref("");
+const listOfSelected = reactive<string[]>([""]);
 
 const getLabel = (options: CascaderSelectOptions): string => {
   return Object.keys(options)[0];

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -1,65 +1,119 @@
 <template>
-  <div class="">
-    <label v-for="(selected, index) in listOfSelected" :key="index">
-      {{ getLabel(options) }}
-      <select v-model="listOfSelected[index]">
-        <option value="" disabled>Select a {{ getLabel(options) }}</option>
-        <option v-for="opt in getOpts(options)" :key="opt" :value="opt">
+  <div class="flex flex-col gap-4">
+    <div
+      v-for="(selected, segmentLevel) in listOfSelected"
+      :key="segmentLevel"
+      class="flex flex-col gap-1"
+    >
+      <label class="uppercase text-xs font-medium tracking-wider">
+        {{ selected.label }}
+      </label>
+      <select
+        class="rounded-md"
+        :value="selected.value"
+        @change="
+          handleSelectChange(
+            segmentLevel,
+            ($event.target as HTMLSelectElement).value
+          )
+        "
+      >
+        <option value="" disabled>Select a {{ selected.label }}</option>
+        <option v-for="opt in selected.options" :key="opt" :value="opt">
           {{ opt }}
         </option>
       </select>
-    </label>
-    <div>
-      <p>
-        <code>options: {{ options }}</code>
-      </p>
-      <p>
-        <code>listOfSelected: {{ listOfSelected }}</code>
-      </p>
     </div>
   </div>
 </template>
 <script setup lang="ts">
-import { reactive } from "vue";
+import { path } from "ramda";
+import { reactive, computed } from "vue";
 
 interface CascaderSelectOptions {
   [label: string]: string[] | CascaderSelectOptions;
 }
 
-defineProps<{
+const props = defineProps<{
   options: CascaderSelectOptions;
 }>();
 
-const listOfSelected = reactive<string[]>([""]);
+interface SelectedSegment {
+  label: string;
+  options: string[];
+  value: string;
+}
 
-const getLabel = (options: CascaderSelectOptions): string => {
+const listOfSelected = reactive<SelectedSegment[]>([
+  {
+    label: getFirstKey(props.options),
+    options: getFirstOptions(props.options),
+    value: "",
+  },
+]);
+
+function getFirstKey(options: CascaderSelectOptions): string {
   return Object.keys(options)[0];
-};
+}
 
-const getOpts = (options: CascaderSelectOptions): string[] => {
-  const values = Object.values(options);
+function getFirstOptions(options: CascaderSelectOptions): string[] {
+  const values: Record<string, unknown> | string[] =
+    options[getFirstKey(options)];
 
-  // option values could look like:
-  // [['minneapolis', 'st. paul']]
-  // or could be another level of nesting
-  // [{ 'minneapolis': ...}, {'st. paul': ... }]
-  // let's use the first value to determine which is which
-
-  // if there's no first value, return an empty array
-  if (values.length === 0) {
-    return [];
+  // if the first value is an array, then
+  // values looks like: ['minneapolis', 'st. paul']
+  if (Array.isArray(values)) {
+    return values;
   }
 
-  // if the first value is an object, then
-  // values looks like
-  // [{ 'minneapolis': ...}, { 'st. paul': ... }]
-  // and so we want the keys of each object within the array
-  if (!Array.isArray(values[0])) {
-    return values.map((obj) => Object.keys(obj)[0]);
+  // otherwise, values is a record object like:
+  // { 'minneapolis': ..., 'st. paul': ... }
+  // and so the keys are our next level of options
+  return Object.keys(values);
+}
+
+function handleSelectChange(segmentLevel: number, value: string): void {
+  // update the value of the current segment
+  listOfSelected[segmentLevel].value = value;
+
+  // remove any segments after this one
+  listOfSelected.splice(segmentLevel + 1);
+
+  // if the value is empty, then we're done
+  if (!value) {
+    return;
   }
 
-  // otherwise, values looks like [['minneapolis', 'st. paul']]
-  return values[0];
-};
+  // otherwise, we need to add a new segment to the list
+  // get the current path by joining the labels and values
+  const currentPath: string[] = [];
+  listOfSelected.forEach((segment) => {
+    currentPath.push(segment.label);
+    currentPath.push(segment.value);
+  });
+
+  // the `path` function below takes an array of keys
+  // and returns the value at that path in the object:
+  // path(['a', 'b'], { a: { b: 2 } }); //=> 2
+  const nextSegmentOptions = path<CascaderSelectOptions>(
+    currentPath,
+    props.options
+  );
+
+  // if we couldn't find another segment at that path
+  // we're at the end of the road, so we're done
+  if (!nextSegmentOptions) {
+    return;
+  }
+
+  // otherwise add the next segment to the list of selected
+  const nextSegment: SelectedSegment = {
+    label: getFirstKey(nextSegmentOptions),
+    options: getFirstOptions(nextSegmentOptions),
+    value: "",
+  };
+
+  listOfSelected.push(nextSegment);
+}
 </script>
 <style scoped></style>

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -23,7 +23,7 @@
         <option v-if="!selected.options.includes('')" value="" disabled>
           Select a {{ selected.label }}
         </option>
-        <option v-for="opt in selected.options" :key="opt" :value="opt">
+        <option v-for="opt in selected.options.sort()" :key="opt" :value="opt">
           {{ opt === "" ? "-" : opt }}
         </option>
       </select>

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -5,11 +5,13 @@
       :key="segmentLevel"
       class="flex flex-col gap-1"
     >
-      <label class="uppercase text-xs font-medium tracking-wider">
+      <label
+        :class="['uppercase text-xs font-medium tracking-wider', labelClass]"
+      >
         {{ selected.label }}
       </label>
       <select
-        class="rounded-md"
+        :class="['rounded-md', selectClass]"
         :value="selected.value"
         @change="
           handleSelectChange(
@@ -36,6 +38,8 @@ interface CascaderSelectOptions {
 
 const props = defineProps<{
   options: CascaderSelectOptions;
+  selectClass?: Record<string, boolean> | string[] | string;
+  labelClass?: Record<string, boolean> | string[] | string;
 }>();
 
 interface SelectedSegment {

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -105,7 +105,6 @@ function createNextSelectedSegment(
   initialValue = "",
   cascadeSelectOptions = props.options
 ): SelectedSegment | null {
-  // otherwise, we need to add a new segment to the list
   // get the current path by joining the labels and values
   const currentPath: string[] = [];
   currentSegments.forEach((segment) => {
@@ -115,35 +114,34 @@ function createNextSelectedSegment(
 
   // the `path` function below takes an array of keys
   // and returns the value at that path in the object:
-  // path(['a', 'b'], { a: { b: 2 } }); //=> 2
+  // path(['a', 'b'], { a: { b: 2 } })  =>  2
   const nextSegmentOptions = path<CascaderSelectOptions>(
     currentPath,
     cascadeSelectOptions
   );
 
-  // if we couldn't find another segment at that path
+  // if we couldn't find the next segment options then
   // we're at the end of the road, so we're done
   if (!nextSegmentOptions) {
     return null;
   }
 
-  // otherwise add the next segment to the list of selected
+  const label = getFirstKey(nextSegmentOptions);
   const options = getFirstOptions(nextSegmentOptions);
 
-  // check that initial value is within the options
+  // check if the initial value is in the options
+  // if not, log it, but continue
   if (initialValue !== "" && !options.includes(initialValue)) {
-    throw new Error(
+    console.error(
       `Cannot create next selected: initial value ${initialValue} is not in the options ${options}`
     );
   }
 
-  const nextSegment: SelectedSegment = {
-    label: getFirstKey(nextSegmentOptions),
-    options: getFirstOptions(nextSegmentOptions),
+  return {
+    label,
+    options,
     value: initialValue,
   };
-
-  return nextSegment;
 }
 
 function handleSelectChange(segmentLevel: number, value: string): void {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -149,6 +149,7 @@ const getters = (state: SearchStoreState) => ({
     "date",
     "tag list",
     "text area",
+    "multiselect",
   ]),
 });
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -361,6 +361,10 @@ const actions = (state: SearchStoreState) => ({
           state.status.value = "success";
           state.sortOptions.value = res.sortableWidgets;
 
+          // update the boolean operator
+          state.filterBy.searchableFieldsOperator =
+            res.searchEntry.combineSpecificSearches;
+
           // set the collections list to the collections in the search entry
           state.filterBy.collectionIds =
             res.searchEntry.collection?.map((idStr) =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -345,6 +345,7 @@ export interface SearchEntry {
   fuzzySearch?: "0" | "1";
   sort?: string;
   specificFieldSearch?: SpecificFieldSearchItem[];
+  combineSpecificSearches: "OR" | "AND";
 }
 
 export interface SearchSortOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -474,29 +474,6 @@ export interface RawSortableField {
   type: WidgetType;
 }
 
-export interface SearchableField extends RawSortableField {
-  id: string;
-}
-
-export interface SearchableSelectField extends SearchableField {
-  type: "select";
-}
-
-export interface SearchableCheckboxField extends SearchableField {
-  type: "checkbox";
-}
-
-export interface SearchableFieldFilter {
-  id: string; // filter uuid not field id
-  fieldId: string;
-  value: string;
-  isFuzzy: boolean;
-}
-
-export interface SearchableCheckboxFieldFilter extends SearchableFieldFilter {
-  value: "boolean_true" | "boolean_false";
-}
-
 export interface ApiInstanceNavResponse {
   pages: Page[];
   userId: number | null;
@@ -656,4 +633,41 @@ export interface ApiGetCheckboxFieldInfoResponse
     boolean_true: string; // label for true
     boolean_false: string; // label for false
   };
+}
+
+export interface TreeNode {
+  [key: string]: TreeNode | string[];
+}
+
+export interface ApiGetMultiSelectFieldInfoResponse
+  extends ApiGetFieldInfoResponse {
+  type: "multiselect";
+  rawContent: TreeNode; // recursive tree of options
+}
+
+export interface SearchableField extends RawSortableField {
+  id: string;
+}
+
+export interface SearchableSelectField extends SearchableField {
+  type: "select";
+}
+
+export interface SearchableCheckboxField extends SearchableField {
+  type: "checkbox";
+}
+
+export interface SearchableMultiSelectField extends SearchableField {
+  type: "multiselect";
+}
+
+export interface SearchableFieldFilter {
+  id: string; // filter uuid not field id
+  fieldId: string;
+  value: string;
+  isFuzzy: boolean;
+}
+
+export interface SearchableCheckboxFieldFilter extends SearchableFieldFilter {
+  value: "boolean_true" | "boolean_false";
 }


### PR DESCRIPTION
Adds a cascade select component and multiselect field options to advanced search. Also fixes a bug where the search boolean wasn't set when we received search results.

<https://dev.elevator.umn.edu/defaultinstance/>

![ScreenShot 2023-06-06 at 13 05 11](https://github.com/UMN-LATIS/elevator-ui/assets/980170/bf3e79cf-c829-4916-8fed-82c827670219)


