### PR TITLE
Add `Any Date` to Advanced Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fontsource/material-icons": "^5.0.1",
     "@fontsource/open-sans": "^5.0.1",
     "@fontsource/work-sans": "^5.0.1",
+    "@headlessui-float/vue": "^0.11.2",
     "@headlessui/vue": "^1.7.13",
     "@knight-lab/timelinejs": "^3.9.2",
     "@mdx-js/react": "^2.3.0",

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -16,10 +16,8 @@ import type {
   ApiInstanceNavResponse,
   SearchRequestOptions,
   LocalLoginResponse,
-  SearchableFieldFilter,
   ApiGetFieldInfoResponse,
-  SearchableSelectField,
-  SearchableField,
+  SearchableSpecificField,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -243,7 +241,7 @@ export async function loginAsGuest({
 }
 
 export async function fetchSearchableFieldInfo<T = ApiGetFieldInfoResponse>(
-  field: SearchableField
+  field: SearchableSpecificField
 ) {
   const formdata = new FormData();
   formdata.append("fieldTitle", field.id);

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -158,24 +158,23 @@ export async function fetchSearchId(
   query: string,
   opts: Omit<SearchRequestOptions, "searchText"> = {}
 ): Promise<string> {
-  const params = new URLSearchParams();
-  const searchQuery: SearchRequestOptions = { searchText: query };
+  const { collection, ...rest } = opts;
+  const searchQuery: SearchRequestOptions = {
+    searchText: query,
+    ...rest,
+  };
 
+  // only add collection if it's defined
+  if (collection) {
+    searchQuery.collection = collection.map(String);
+  }
+
+  // only add sort if it's defined
   if (opts.sort) {
     searchQuery.sort = opts.sort;
   }
 
-  if (opts.collection) {
-    searchQuery.collection = opts.collection.map(String);
-  }
-
-  if (opts.specificFieldSearch) {
-    searchQuery.specificFieldSearch = opts.specificFieldSearch;
-
-    // default to AND combine operator
-    searchQuery.combineSpecificSearches = opts.combineSpecificSearches ?? "AND";
-  }
-
+  const params = new URLSearchParams();
   params.append("searchQuery", JSON.stringify(searchQuery));
 
   // this param gets searchID without all the results

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,7 +10,7 @@ import {
   ApiGetSelectFieldInfoResponse,
   ApiGetCheckboxFieldInfoResponse,
   ApiGetMultiSelectFieldInfoResponse,
-  SearchableField,
+  SearchableSpecificField,
   SearchableSelectField,
   SearchableCheckboxField,
   SearchableMultiSelectField,
@@ -174,7 +174,7 @@ async function getStaticPage(pageId: number): Promise<ApiStaticPageResponse> {
 }
 
 async function getSearchableFieldInfo<T extends ApiGetFieldInfoResponse>(
-  field: SearchableField
+  field: SearchableSpecificField
 ): Promise<T | null> {
   const fieldKey = `${field.id}-${field.template}`;
 

--- a/src/components/AdvancedSearchForm/AdvSearchDropDown.vue
+++ b/src/components/AdvancedSearchForm/AdvSearchDropDown.vue
@@ -6,9 +6,7 @@
     chevronClass="!w-4 !h-4"
     alignment="left"
   >
-    <div class="max-h-[20vh] overflow-y-auto">
-      <slot />
-    </div>
+    <slot />
   </DropDown>
 </template>
 <script setup lang="ts">

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
@@ -4,7 +4,7 @@
     class="bg-white rounded-3xl shadow-md"
     @submit.prevent="$emit('submit')"
   >
-    <div class="p-2">
+    <div class="p-2 max-h-[90vh] overflow-y-auto">
       <h1 class="sr-only">Advanced Search</h1>
 
       <SearchTextInputGroup class="mb-4" @moreOptionClick="$emit('close')" />

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
@@ -4,7 +4,7 @@
     class="bg-white rounded-3xl shadow-md"
     @submit.prevent="$emit('submit')"
   >
-    <div class="p-2 max-h-[90vh] overflow-y-auto">
+    <div class="p-2">
       <h1 class="sr-only">Advanced Search</h1>
 
       <SearchTextInputGroup class="mb-4" @moreOptionClick="$emit('close')" />
@@ -14,9 +14,10 @@
         >
           Filter By
         </h2>
-
-        <FilterByCollectionsSection />
-        <FilterByFieldsSection />
+        <div class="max-h-[60vh] overflow-y-auto">
+          <FilterByCollectionsSection />
+          <FilterByFieldsSection />
+        </div>
       </div>
     </div>
     <div

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.vue
@@ -14,7 +14,7 @@
         >
           Filter By
         </h2>
-        <div class="max-h-[60vh] overflow-y-auto">
+        <div class="max-h-[60vh] overflow-y-auto px-2">
           <FilterByCollectionsSection />
           <FilterByFieldsSection />
         </div>

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -32,10 +32,10 @@
       class="flex-1 text-sm"
       inputClass="!bg-white !border !border-neutral-200"
       :label="currentField.label"
-      :value="filter.value"
+      :modelValue="filter.value"
       :labelHidden="true"
       :placeholder="`Type your ${currentField.label.toLowerCase()}...`"
-      @input="handleFilterValueChange"
+      @update:modelValue="handleFilterValueChange"
     />
 
     <SelectFieldOptions
@@ -57,7 +57,7 @@
     />
 
     <label
-      class="text-xs font-bold uppercase text-center cursor-pointer leading-none text-orient-sideways sm:text-orient-normal"
+      class="text-xs font-bold uppercase text-center cursor-pointer leading-none"
       :class="{
         'text-blue-600': filter.isFuzzy,
         'text-neutral-300': !filter.isFuzzy,
@@ -69,7 +69,10 @@
         :checked="filter.isFuzzy"
         @change="handleIsFuzzyChange"
       />
-      Fuzzy
+      <span class="md:hidden">FZY</span>
+      <span class="hidden md:inline-block" aria-label="Fuzzy Search"
+        >Fuzzy</span
+      >
     </label>
 
     <button
@@ -155,9 +158,8 @@ function handleFieldChange(event: Event) {
   searchStore.updateSearchableFieldFilterValue(props.filter.id, "");
 }
 
-function handleFilterValueChange(event: Event) {
-  const target = event.target as HTMLInputElement | HTMLSelectElement;
-  searchStore.updateSearchableFieldFilterValue(props.filter.id, target.value);
+function handleFilterValueChange(value: string) {
+  searchStore.updateSearchableFieldFilterValue(props.filter.id, value);
 }
 
 function handleIsFuzzyChange(event: Event) {

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -1,11 +1,13 @@
 <template>
-  <div class="flex items-baseline gap-2">
+  <div
+    class="filter-row"
+    :class="{
+      'filter-row--is-only-row': searchStore.totalFieldFilterCount === 1,
+      'filter-row--is-first-row': rowIndex === 0,
+    }"
+  >
     <Button
-      class="text-xs w-6 !ml-0"
-      :class="{
-        invisible: rowIndex === 0,
-        hidden: searchStore.totalFieldFilterCount === 1,
-      }"
+      class="text-xs filter-row__operator"
       variant="tertiary"
       type="button"
       @click="handleSearchOperatorClick"
@@ -13,7 +15,7 @@
       {{ searchOperator }}
     </Button>
     <select
-      class="rounded-md w-1/4 text-sm"
+      class="rounded-md text-sm filter-row__name w-full"
       :value="currentField.id"
       @change="handleFieldChange"
     >
@@ -26,38 +28,40 @@
       </option>
     </select>
 
-    <InputGroup
-      v-if="['text', 'date', 'text area'].includes(currentField.type)"
-      :id="filter.id"
-      class="flex-1 text-sm"
-      inputClass="!bg-white !border !border-neutral-200"
-      :label="currentField.label"
-      :modelValue="filter.value"
-      :labelHidden="true"
-      :placeholder="`Type your ${currentField.label.toLowerCase()}...`"
-      @update:modelValue="handleFilterValueChange"
-    />
+    <div class="filter-row__value">
+      <InputGroup
+        v-if="['text', 'date', 'text area'].includes(currentField.type)"
+        :id="filter.id"
+        class="text-sm"
+        inputClass="!bg-white !border !border-neutral-200"
+        :label="currentField.label"
+        :modelValue="filter.value"
+        :labelHidden="true"
+        :placeholder="`Type your ${currentField.label.toLowerCase()}...`"
+        @update:modelValue="handleFilterValueChange"
+      />
 
-    <SelectFieldOptions
-      v-if="['select', 'tag list'].includes(currentField.type)"
-      class="flex-1 text-sm"
-      :filter="filter"
-    />
+      <SelectFieldOptions
+        v-if="['select', 'tag list'].includes(currentField.type)"
+        class="flex-1 text-sm"
+        :filter="filter"
+      />
 
-    <CheckboxFieldOptions
-      v-if="currentField.type === 'checkbox'"
-      class="flex-1 text-sm"
-      :filter="(filter as SearchableCheckboxFieldFilter)"
-    />
+      <CheckboxFieldOptions
+        v-if="currentField.type === 'checkbox'"
+        class="flex-1 text-sm"
+        :filter="(filter as SearchableCheckboxFieldFilter)"
+      />
 
-    <MultiSelectFieldOptions
-      v-if="currentField.type === 'multiselect'"
-      class="flex-1 text-sm"
-      :filter="filter"
-    />
+      <MultiSelectFieldOptions
+        v-if="currentField.type === 'multiselect'"
+        class="flex-1 text-sm"
+        :filter="filter"
+      />
+    </div>
 
     <label
-      class="text-xs font-bold uppercase text-center cursor-pointer leading-none"
+      class="text-xs font-bold uppercase text-center cursor-pointer leading-none filter-row__is-fuzzy block"
       :class="{
         'text-blue-600': filter.isFuzzy,
         'text-neutral-300': !filter.isFuzzy,
@@ -69,15 +73,12 @@
         :checked="filter.isFuzzy"
         @change="handleIsFuzzyChange"
       />
-      <span class="md:hidden">FZY</span>
-      <span class="hidden md:inline-block" aria-label="Fuzzy Search"
-        >Fuzzy</span
-      >
+      <span aria-label="Fuzzy Search">Fuzzy</span>
     </label>
 
     <button
       type="button"
-      class="self-start p-2 mt-[0.1rem]"
+      class="filter-row__remove py-2 self-start w-full flex items-center justify-center mt-[0.125rem]"
       @click="handleRemoveFilter"
     >
       <CircleXIcon class="w-5 h-5" />
@@ -181,5 +182,51 @@ select {
   background-size: 1rem;
   padding-right: 2.5rem;
   border-color: #e5e5e5;
+}
+
+.filter-row {
+  display: grid;
+  grid-template-areas: "operator name value is-fuzzy remove";
+  grid-template-columns: 2rem 1fr 2fr 3rem 2rem;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+@media (max-width: 30rem) {
+  .filter-row {
+    grid-template-areas:
+      "operator name is-fuzzy remove"
+      ". value . .";
+    grid-template-columns: 2rem 1fr 3rem 2rem;
+  }
+}
+
+.filter-row--is-only-row {
+  grid-template-areas: "name value is-fuzzy remove";
+  grid-template-columns: 1fr 2fr 3rem 3rem;
+}
+
+.filter-row--is-first-row .filter-row__operator {
+  display: none;
+}
+
+.filter-row__operator {
+  grid-area: operator;
+}
+.filter-row__name {
+  grid-area: name;
+}
+
+.filter-row__value {
+  grid-area: value;
+}
+
+.filter-row__is-fuzzy {
+  grid-area: is-fuzzy;
+}
+
+.filter-row__remove {
+  grid-area: remove;
+  justify-self: end;
 }
 </style>

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -43,19 +43,19 @@
 
       <SelectFieldOptions
         v-if="['select', 'tag list'].includes(currentField.type)"
-        class="flex-1 text-sm"
+        class="w-full text-sm"
         :filter="filter"
       />
 
       <CheckboxFieldOptions
         v-if="currentField.type === 'checkbox'"
-        class="flex-1 text-sm"
+        class="w-full text-sm"
         :filter="(filter as SearchableCheckboxFieldFilter)"
       />
 
       <MultiSelectFieldOptions
         v-if="currentField.type === 'multiselect'"
-        class="flex-1 text-sm"
+        class="w-full text-sm"
         :filter="filter"
       />
     </div>

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -4,7 +4,7 @@
       class="text-xs w-6 !ml-0"
       :class="{
         invisible: rowIndex === 0,
-        hidden: searchStore.fieldFilters.length === 1,
+        hidden: searchStore.specificFieldFilters.length === 1,
       }"
       variant="tertiary"
       type="button"
@@ -18,7 +18,7 @@
       @change="handleFieldChange"
     >
       <option
-        v-for="supportedField in supportedSearchableFields"
+        v-for="supportedField in supportedSpecificFields"
         :key="supportedField.id"
         :value="supportedField.id"
       >
@@ -95,20 +95,20 @@ import SelectFieldOptions from "./SelectFieldOptions.vue";
 import CheckboxFieldOptions from "./CheckboxFieldOptions.vue";
 import MultiSelectFieldOptions from "./MultiSelectFieldOptions.vue";
 import type {
-  SearchableFieldFilter,
-  SearchableField,
+  SearchableSpecificFieldFilter,
+  SearchableSpecificField,
   SearchableCheckboxFieldFilter,
 } from "@/types";
 
 const props = defineProps<{
-  filter: SearchableFieldFilter;
+  filter: SearchableSpecificFieldFilter;
   rowIndex: number;
 }>();
 
 const instanceStore = useInstanceStore();
 const searchStore = useSearchStore();
 
-const currentField = computed((): SearchableField => {
+const currentField = computed((): SearchableSpecificField => {
   const field = instanceStore.getSearchableField(props.filter.fieldId);
 
   if (!field) {
@@ -119,9 +119,9 @@ const currentField = computed((): SearchableField => {
   return field;
 });
 
-const supportedSearchableFields = computed(() => {
+const supportedSpecificFields = computed(() => {
   return instanceStore.searchableFields.filter((field) =>
-    searchStore.supportedSearchableFieldTypes.includes(field.type)
+    searchStore.supportedSpecificFieldTypes.includes(field.type)
   );
 });
 

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -4,7 +4,7 @@
       class="text-xs w-6 !ml-0"
       :class="{
         invisible: rowIndex === 0,
-        hidden: searchStore.specificFieldFilters.length === 1,
+        hidden: searchStore.totalFieldFilterCount === 1,
       }"
       variant="tertiary"
       type="button"

--- a/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsRow.vue
@@ -33,11 +33,11 @@
         v-if="['text', 'date', 'text area'].includes(currentField.type)"
         :id="filter.id"
         class="text-sm"
-        inputClass="!bg-white !border !border-neutral-200"
+        inputClass="!bg-white !border !border-neutral-200 placeholder:capitalize"
         :label="currentField.label"
         :modelValue="filter.value"
         :labelHidden="true"
-        :placeholder="`Type your ${currentField.label.toLowerCase()}...`"
+        :placeholder="currentField.label"
         @update:modelValue="handleFilterValueChange"
       />
 

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -44,16 +44,11 @@
           </div>
           <div>
             <AdvSearchDropDownItem
-              class="flex items-center justify-between cursor-pointer aria-disabled:opacity-25"
+              class="flex items-center cursor-pointer aria-disabled:opacity-25"
               :disabled="searchStore.hasDateRangeFilter"
               @click="searchStore.addDateRangeFilter()"
             >
-              <span class="flex-1">Any Date</span>
-            </AdvSearchDropDownItem>
-            <AdvSearchDropDownItem
-              class="flex items-center justify-between cursor-pointer"
-            >
-              <span class="flex-1">Any Location</span>
+              Any Date
             </AdvSearchDropDownItem>
           </div>
         </div>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -23,7 +23,7 @@
         :filter="filter"
         :rowIndex="index"
       />
-      <div v-if="searchStore.hasDateRangeFilter">Date Range Row</div>
+      <FilterByGlobalDateRow v-if="searchStore.hasDateRangeFilter" />
     </div>
 
     <div class="flex justify-between items-baseline">
@@ -75,6 +75,7 @@ import AdvSearchDropDown from "./AdvSearchDropDown.vue";
 import AdvSearchDropDownItem from "./AdvSearchDropDownItem.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import FilterByFieldsRow from "./FilterByFieldsRow.vue";
+import FilterByGlobalDateRow from "./FilterByGlobalDateRow.vue";
 
 const instanceStore = useInstanceStore();
 const searchStore = useSearchStore();

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -44,7 +44,7 @@
           </div>
           <div>
             <AdvSearchDropDownItem
-              class="flex items-center justify-between cursor-pointer"
+              class="flex items-center justify-between cursor-pointer aria-disabled:opacity-25"
               :disabled="searchStore.hasDateRangeFilter"
               @click="searchStore.addDateRangeFilter()"
             >

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -30,17 +30,36 @@
         v-if="supportedSearchableFields.length"
         label="Add Field"
       >
-        <AdvSearchDropDownItem
-          v-for="field in supportedSearchableFields"
-          :key="field.id"
-          class="flex items-center justify-between cursor-pointer"
-          @click="searchStore.addSearchableFieldFilter(field.id)"
-        >
-          <span class="flex-1">{{ field.label }}</span>
-          <span class="text-xs text-neutral-300 capitalize">{{
-            field.type
-          }}</span>
-        </AdvSearchDropDownItem>
+        <div class="divide-y divide-neutral-200">
+          <div>
+            <AdvSearchDropDownItem
+              v-for="field in supportedSearchableFields"
+              :key="field.id"
+              class="flex items-center justify-between cursor-pointer"
+              @click="searchStore.addSearchableFieldFilter(field.id)"
+            >
+              <span class="flex-1">{{ field.label }}</span>
+            </AdvSearchDropDownItem>
+          </div>
+          <div>
+            <AdvSearchDropDownItem
+              class="flex items-center justify-between cursor-pointer"
+            >
+              <span class="flex-1">Date</span>
+              <span class="text-xs text-neutral-300 capitalize">
+                All Dates
+              </span>
+            </AdvSearchDropDownItem>
+            <AdvSearchDropDownItem
+              class="flex items-center justify-between cursor-pointer"
+            >
+              <span class="flex-1">Location</span>
+              <span class="text-xs text-neutral-300 capitalize">
+                All Locations
+              </span>
+            </AdvSearchDropDownItem>
+          </div>
+        </div>
       </AdvSearchDropDown>
     </div>
   </section>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -15,7 +15,7 @@
 
     <div
       v-if="searchStore.hasFieldFiltersApplied"
-      class="p-2 bg-transparent-black-50 rounded-md mb-4 flex flex-col gap-2"
+      class="p-4 bg-transparent-black-50 rounded-md flex flex-col gap-4 sm:gap-2 my-4"
     >
       <div v-for="(filter, index) in sortedFilterRows" :key="filter.id">
         <FilterByGlobalDateRow
@@ -48,18 +48,12 @@
               :disabled="searchStore.hasDateRangeFilter"
               @click="searchStore.addDateRangeFilter()"
             >
-              <span class="flex-1">Date</span>
-              <span class="text-xs text-neutral-300 capitalize">
-                All Dates
-              </span>
+              <span class="flex-1">Any Date</span>
             </AdvSearchDropDownItem>
             <AdvSearchDropDownItem
               class="flex items-center justify-between cursor-pointer"
             >
-              <span class="flex-1">Location</span>
-              <span class="text-xs text-neutral-300 capitalize">
-                All Locations
-              </span>
+              <span class="flex-1">Any Location</span>
             </AdvSearchDropDownItem>
           </div>
         </div>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -18,7 +18,7 @@
       class="p-2 bg-transparent-black-50 rounded-md mb-4 flex flex-col gap-2"
     >
       <FilterByFieldsRow
-        v-for="(filter, index) in searchStore.fieldFilters"
+        v-for="(filter, index) in searchStore.specificFieldFilters"
         :key="filter.id"
         :filter="filter"
         :rowIndex="index"
@@ -82,7 +82,7 @@ const searchStore = useSearchStore();
 
 const supportedSearchableFields = computed(() => {
   return instanceStore.searchableFields.filter((field) =>
-    searchStore.supportedSearchableFieldTypes.includes(field.type)
+    searchStore.supportedSpecificFieldTypes.includes(field.type)
   );
 });
 </script>

--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -4,7 +4,7 @@
       <header class="flex items-baseline gap-2 mb-2">
         <h3 class="font-bold">Fields</h3>
         <Button
-          v-if="searchStore.filterBy.searchableFieldsMap.size"
+          v-if="searchStore.hasFieldFiltersApplied"
           variant="tertiary"
           @click="searchStore.clearSearchableFieldsFilters"
         >
@@ -14,7 +14,7 @@
     </div>
 
     <div
-      v-if="searchStore.fieldFilters.length"
+      v-if="searchStore.hasFieldFiltersApplied"
       class="p-2 bg-transparent-black-50 rounded-md mb-4 flex flex-col gap-2"
     >
       <FilterByFieldsRow
@@ -23,6 +23,7 @@
         :filter="filter"
         :rowIndex="index"
       />
+      <div v-if="searchStore.hasDateRangeFilter">Date Range Row</div>
     </div>
 
     <div class="flex justify-between items-baseline">
@@ -44,6 +45,8 @@
           <div>
             <AdvSearchDropDownItem
               class="flex items-center justify-between cursor-pointer"
+              :disabled="searchStore.hasDateRangeFilter"
+              @click="searchStore.addDateRangeFilter()"
             >
               <span class="flex-1">Date</span>
               <span class="text-xs text-neutral-300 capitalize">

--- a/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
@@ -2,6 +2,10 @@
   <div class="flex items-baseline gap-2 group">
     <Button
       class="text-xs w-6 !ml-0"
+      :class="{
+        invisible: rowIndex === 0,
+        hidden: searchStore.totalFieldFilterCount === 1,
+      }"
       variant="tertiary"
       type="button"
       @click="handleSearchOperatorClick"
@@ -10,11 +14,11 @@
     </Button>
     <p class="text-sm w-1/4">Date Range</p>
 
-    <div class="flex-1 flex flex-col md:flex-row gap-2">
+    <div class="flex-1 grid grid-cols-2 gap-2">
       <InputGroup
-        v-if="searchStore.filterBy.dateRange"
+        v-if="searchStore.filterBy.globalDateRange"
         id="filter-by-date-range-start-date"
-        v-model="searchStore.filterBy.dateRange.startDate"
+        v-model="searchStore.filterBy.globalDateRange.startDate"
         class="text-sm"
         inputClass="!bg-white !border !border-neutral-200"
         label="Start Date"
@@ -22,9 +26,9 @@
         placeholder="Start Date"
       />
       <InputGroup
-        v-if="searchStore.filterBy.dateRange"
+        v-if="searchStore.filterBy.globalDateRange"
         id="filter-by-date-range-end-date"
-        v-model="searchStore.filterBy.dateRange.endDate"
+        v-model="searchStore.filterBy.globalDateRange.endDate"
         class="text-sm"
         inputClass="!bg-white !border !border-neutral-200"
         label="End Date"
@@ -49,6 +53,10 @@ import Button from "@/components/Button/Button.vue";
 import { CircleXIcon } from "@/icons";
 import { useSearchStore } from "@/stores/searchStore";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
+
+defineProps<{
+  rowIndex: number;
+}>();
 
 const searchStore = useSearchStore();
 

--- a/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
@@ -1,20 +1,22 @@
 <template>
-  <div class="flex items-baseline gap-2 group">
+  <div
+    class="filter-row"
+    :class="{
+      'filter-row--is-only-row': searchStore.totalFieldFilterCount === 1,
+      'filter-row--is-first-row': rowIndex === 0,
+    }"
+  >
     <Button
-      class="text-xs w-6 !ml-0"
-      :class="{
-        invisible: rowIndex === 0,
-        hidden: searchStore.totalFieldFilterCount === 1,
-      }"
+      class="text-xs filter-row__operator"
       variant="tertiary"
       type="button"
       @click="handleSearchOperatorClick"
     >
       {{ searchOperator }}
     </Button>
-    <p class="text-sm w-1/4">Date Range</p>
+    <p class="filter-row__name text-sm p-2">Any Date</p>
 
-    <div class="flex-1 grid grid-cols-2 gap-2">
+    <div class="filter-row__value flex flex-col sm:flex-row gap-1">
       <InputGroup
         v-if="searchStore.filterBy.globalDateRange"
         id="filter-by-date-range-start-date"
@@ -38,11 +40,11 @@
     </div>
 
     <button
+      class="filter-row__remove py-2 self-start w-full flex items-center justify-center"
       type="button"
-      class="self-start p-2 mt-[0.1rem]"
       @click="handleRemoveFilter"
     >
-      <CircleXIcon class="w-5 h-5" />
+      <CircleXIcon class="!w-5 !h-5" />
     </button>
   </div>
 </template>
@@ -74,12 +76,49 @@ function handleRemoveFilter() {
 }
 </script>
 <style scoped>
-select {
-  background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23111' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5' /%3E%3C/svg%3E");
-  background-position: right 0.75rem center;
-  background-repeat: no-repeat;
-  background-size: 1rem;
-  padding-right: 2.5rem;
-  border-color: #e5e5e5;
+.filter-row {
+  display: grid;
+  grid-template-areas: "operator name value is-fuzzy remove";
+  grid-template-columns: 2rem 1fr 2fr 3rem 2rem;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+@media (max-width: 30rem) {
+  .filter-row {
+    grid-template-areas:
+      "operator name is-fuzzy remove"
+      ". value . .";
+    grid-template-columns: 2rem 1fr 3rem 2rem;
+  }
+}
+
+.filter-row--is-only-row {
+  grid-template-areas: "name value is-fuzzy remove";
+  grid-template-columns: 1fr 2fr 3rem 2rem;
+}
+
+.filter-row--is-first-row .filter-row__operator {
+  display: none;
+}
+
+.filter-row__operator {
+  grid-area: operator;
+}
+.filter-row__name {
+  grid-area: name;
+}
+
+.filter-row__value {
+  grid-area: value;
+}
+
+.filter-row__is-fuzzy {
+  grid-area: is-fuzzy;
+}
+
+.filter-row__remove {
+  grid-area: remove;
+  justify-self: end;
 }
 </style>

--- a/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="flex items-baseline gap-2 group">
+    <Button
+      class="text-xs w-6 !ml-0"
+      variant="tertiary"
+      type="button"
+      @click="handleSearchOperatorClick"
+    >
+      {{ searchOperator }}
+    </Button>
+    <p class="text-sm w-1/4">Date Range</p>
+
+    <div class="flex-1 flex flex-col md:flex-row gap-2">
+      <InputGroup
+        v-if="searchStore.filterBy.dateRange"
+        id="filter-by-date-range-start-date"
+        v-model="searchStore.filterBy.dateRange.startDate"
+        class="text-sm"
+        inputClass="!bg-white !border !border-neutral-200"
+        label="Start Date"
+        :labelHidden="true"
+        placeholder="Start Date"
+      />
+      <InputGroup
+        v-if="searchStore.filterBy.dateRange"
+        id="filter-by-date-range-end-date"
+        v-model="searchStore.filterBy.dateRange.endDate"
+        class="text-sm"
+        inputClass="!bg-white !border !border-neutral-200"
+        label="End Date"
+        :labelHidden="true"
+        :placeholder="`End Date`"
+        @input="handleFilterValueChange"
+      />
+    </div>
+
+    <button
+      type="button"
+      class="self-start p-2 mt-[0.1rem]"
+      @click="handleRemoveFilter"
+    >
+      <CircleXIcon class="w-5 h-5" />
+    </button>
+  </div>
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import Button from "@/components/Button/Button.vue";
+import { CircleXIcon } from "@/icons";
+import { useSearchStore } from "@/stores/searchStore";
+import InputGroup from "@/components/InputGroup/InputGroup.vue";
+
+const searchStore = useSearchStore();
+
+const searchOperator = computed(
+  () => searchStore.filterBy.searchableFieldsOperator
+);
+
+function handleSearchOperatorClick() {
+  const currentOperator = searchStore.filterBy.searchableFieldsOperator;
+  const newOperator = currentOperator === "AND" ? "OR" : "AND";
+  searchStore.updateSearchableFieldsOperator(newOperator);
+}
+
+function handleFilterValueChange(event: Event) {
+  console.log("filter value changed");
+}
+
+function handleRemoveFilter() {
+  // searchStore.removeSearchableFieldFilter(props.filter.id);
+  console.log("remove filter");
+}
+</script>
+<style scoped>
+select {
+  background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23111' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5' /%3E%3C/svg%3E");
+  background-position: right 0.75rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  padding-right: 2.5rem;
+  border-color: #e5e5e5;
+}
+</style>

--- a/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
@@ -34,7 +34,6 @@
         label="End Date"
         :labelHidden="true"
         :placeholder="`End Date`"
-        @input="handleFilterValueChange"
       />
     </div>
 
@@ -70,13 +69,8 @@ function handleSearchOperatorClick() {
   searchStore.updateSearchableFieldsOperator(newOperator);
 }
 
-function handleFilterValueChange(event: Event) {
-  console.log("filter value changed");
-}
-
 function handleRemoveFilter() {
-  // searchStore.removeSearchableFieldFilter(props.filter.id);
-  console.log("remove filter");
+  searchStore.removeDateRangeFilter();
 }
 </script>
 <style scoped>

--- a/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import api from "@/api";
 import {
-  SearchableFieldFilter,
+  SearchableSpecificFieldFilter,
   SearchableMultiSelectField,
   TreeNode,
 } from "@/types";
@@ -24,7 +24,7 @@ import { useInstanceStore } from "@/stores/instanceStore";
 import CascadeSelect from "@/components/CascadeSelect/CascadeSelect.vue";
 
 const props = defineProps<{
-  filter: SearchableFieldFilter;
+  filter: SearchableSpecificFieldFilter;
 }>();
 
 const searchStore = useSearchStore();

--- a/src/components/AdvancedSearchForm/SelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/SelectFieldOptions.vue
@@ -1,7 +1,7 @@
 <template>
   <select
     :value="selectedOption"
-    class="rounded-md"
+    class="rounded-md w-full"
     @change="handleSelectChange"
   >
     <option v-for="opt in options" :key="opt" :value="opt">

--- a/src/components/AdvancedSearchForm/SelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/SelectFieldOptions.vue
@@ -11,13 +11,13 @@
 </template>
 <script setup lang="ts">
 import api from "@/api";
-import { SearchableFieldFilter, SearchableSelectField } from "@/types";
+import { SearchableSpecificFieldFilter, SearchableSelectField } from "@/types";
 import { ref, watch, computed } from "vue";
 import { useSearchStore } from "@/stores/searchStore";
 import { useInstanceStore } from "@/stores/instanceStore";
 
 const props = defineProps<{
-  filter: SearchableFieldFilter;
+  filter: SearchableSpecificFieldFilter;
 }>();
 
 // adding a ref for selected value so that we can reactively

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -11,6 +11,7 @@
     v-bind="$attrs"
     :to="componentType === RouterLink ? to : undefined"
     :href="resolvedHref"
+    :type="componentType === 'button' ? type : undefined"
   >
     <slot />
   </component>
@@ -24,11 +25,13 @@ const props = withDefaults(
     href?: string;
     to?: RouteLocationRaw;
     variant?: "primary" | "secondary" | "tertiary";
+    type?: "button" | "submit" | "reset";
   }>(),
   {
     variant: "secondary",
     href: undefined,
     to: undefined,
+    type: "button",
   }
 );
 

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -12,6 +12,7 @@
       </label>
       <select
         :class="['rounded-md', selectClass]"
+        :style="{ width: '100%' }"
         :value="selected.value"
         @change="
           handleSelectChange(

--- a/src/components/DropDown/DropDown.vue
+++ b/src/components/DropDown/DropDown.vue
@@ -1,20 +1,10 @@
 <template>
-  <Menu as="div" class="relative inline-block text-left">
-    <MenuButton
-      class="inline-flex w-full justify-center rounded-md items-center focus:outline-none focus:ring-2 p-2 placeholder:focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100"
-      :class="labelClass"
-    >
-      <slot name="label">
-        {{ label }}
-      </slot>
-      <ChevronDownIcon
-        v-if="showChevron"
-        :class="['xl:block m-1', chevronClass]"
-        aria-hidden="true"
-      />
-    </MenuButton>
-
-    <transition
+  <Menu as="div" class="inline-block text-left">
+    <Float
+      :placement="alignment === 'left' ? 'bottom-start' : 'bottom-end'"
+      shift
+      :offset="4"
+      zIndex="99"
       enterActiveClass="transition ease-out duration-100"
       enterFromClass="transform opacity-0 scale-95"
       enterToClass="transform opacity-100 scale-100"
@@ -22,12 +12,30 @@
       leaveFromClass="transform opacity-100 scale-100"
       leaveToClass="transform opacity-0 scale-95"
     >
+      <MenuButton
+        class="inline-flex w-full justify-center rounded-md items-center focus:outline-none focus:ring-2 p-2 placeholder:focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100"
+        :class="labelClass"
+      >
+        <slot name="label">
+          {{ label }}
+        </slot>
+        <ChevronDownIcon
+          v-if="showChevron"
+          :class="['xl:block m-1', chevronClass]"
+          aria-hidden="true"
+        />
+      </MenuButton>
+
+      <!-- <transition
+        enterActiveClass="transition ease-out duration-100"
+        enterFromClass="transform opacity-0 scale-95"
+        enterToClass="transform opacity-100 scale-100"
+        leaveActiveClass="transition ease-in duration-75"
+        leaveFromClass="transform opacity-100 scale-100"
+        leaveToClass="transform opacity-0 scale-95"
+      > -->
       <MenuItems
-        class="absolute z-10 mt-1 w-64 origin-top-right top-full divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
-        :class="{
-          'left-0': alignment === 'left',
-          'right-0': alignment === 'right',
-        }"
+        class="w-64 divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
       >
         <slot name="header" />
         <div class="py-1">
@@ -35,13 +43,15 @@
         </div>
         <slot name="footer" />
       </MenuItems>
-    </transition>
+      <!-- </transition> -->
+    </Float>
   </Menu>
 </template>
 
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItems } from "@headlessui/vue";
 import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
+import { Float } from "@headlessui-float/vue";
 
 withDefaults(
   defineProps<{

--- a/src/components/DropDown/DropDown.vue
+++ b/src/components/DropDown/DropDown.vue
@@ -3,14 +3,16 @@
     <Float
       :placement="alignment === 'left' ? 'bottom-start' : 'bottom-end'"
       shift
-      :offset="4"
+      flip
       zIndex="99"
-      enterActiveClass="transition ease-out duration-100"
-      enterFromClass="transform opacity-0 scale-95"
-      enterToClass="transform opacity-100 scale-100"
-      leaveActiveClass="transition ease-in duration-75"
-      leaveFromClass="transform opacity-100 scale-100"
-      leaveToClass="transform opacity-0 scale-95"
+      :offset="4"
+      enter="transition ease-out duration-100"
+      enterFrom="transform opacity-0 scale-95"
+      enterTo="transform opacity-100 scale-100"
+      leave="transition ease-in duration-75"
+      leaveFrom="transform opacity-100 scale-100"
+      leaveTo="transform opacity-0 scale-95"
+      tailwindcssOriginClass
     >
       <MenuButton
         class="inline-flex w-full justify-center rounded-md items-center focus:outline-none focus:ring-2 p-2 placeholder:focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100"
@@ -25,17 +27,8 @@
           aria-hidden="true"
         />
       </MenuButton>
-
-      <!-- <transition
-        enterActiveClass="transition ease-out duration-100"
-        enterFromClass="transform opacity-0 scale-95"
-        enterToClass="transform opacity-100 scale-100"
-        leaveActiveClass="transition ease-in duration-75"
-        leaveFromClass="transform opacity-100 scale-100"
-        leaveToClass="transform opacity-0 scale-95"
-      > -->
       <MenuItems
-        class="w-64 divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+        class="w-64 divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none max-h-[50vh] overflow-y-auto"
       >
         <slot name="header" />
         <div class="py-1">
@@ -43,7 +36,6 @@
         </div>
         <slot name="footer" />
       </MenuItems>
-      <!-- </transition> -->
     </Float>
   </Menu>
 </template>

--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -18,7 +18,7 @@
         :id="id"
         :type="type"
         :name="id"
-        :value="value"
+        :value="modelValue"
         class="block w-full rounded-md border border-transparent focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-2 sm:text-sm py-2 bg-transparent-black-100 placeholder-transparent-black-400 px-4"
         :class="[
           {
@@ -30,7 +30,9 @@
         v-bind="$attrs"
         @focus="$emit('focus', $event)"
         @blur="$emit('blur', $event)"
-        @input="$emit('input', $event)"
+        @input="
+          $emit('update:modelValue', ($event.target as HTMLInputElement).value)
+        "
       />
       <div
         v-if="$slots.append"
@@ -49,7 +51,7 @@ withDefaults(
     id: string;
     label: string;
     labelHidden?: boolean;
-    value: string;
+    modelValue: string;
     type?: string;
     inputClass?: CSSClass;
   }>(),
@@ -63,7 +65,7 @@ withDefaults(
 defineEmits<{
   (eventName: "focus", event: FocusEvent): void;
   (eventName: "blur", event: FocusEvent): void;
-  (eventName: "input", event: InputEvent): void;
+  (eventName: "update:modelValue", value: string): void;
 }>();
 </script>
 <style scoped></style>

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -34,13 +34,14 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import AdvancedSearchForm from "@/components/AdvancedSearchForm/AdvancedSearchForm.vue";
 import { useSearchStore } from "@/stores/searchStore";
 import { useRouter } from "vue-router";
 import SearchTextInputGroup from "./SearchTextInputGroup.vue";
 import TransitionFade from "@/components/TransitionFade/TransitionFade.vue";
+import { useScrollLock } from "@vueuse/core";
 
 const inputGroup = ref<InstanceType<typeof InputGroup> | null>(null);
 const isAdvancedSearchModalOpen = ref(false);
@@ -83,6 +84,13 @@ function removeFocusOnEscape(event: KeyboardEvent) {
 
 document.addEventListener("keydown", focusInputOnCommandK);
 document.addEventListener("keydown", removeFocusOnEscape);
+
+// setup body scroll lock when advanced search modal is open
+// const body = document.querySelector("body");
+// const isLocked = useScrollLock(body);
+// watch(isAdvancedSearchModalOpen, () => {
+//   isLocked.value = isAdvancedSearchModalOpen.value;
+// });
 </script>
 <style scoped>
 @media (min-width: 640px) {

--- a/src/components/SearchBar/SearchTextInputGroup.vue
+++ b/src/components/SearchBar/SearchTextInputGroup.vue
@@ -2,14 +2,13 @@
   <InputGroup
     id="search"
     ref="inputGroup"
+    v-model="searchStore.query"
     label="Search"
     :labelHidden="true"
     placeholder="Search"
-    :value="searchStore.query"
     inputClass="!rounded-full"
     @focus="searchInputHasFocus = true"
     @blur="searchInputHasFocus = false"
-    @input="searchStore.query = ($event.target as HTMLInputElement).value"
   >
     <template #append>
       <div class="flex gap-1 items-center">

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -24,3 +24,11 @@ export const SORT_KEYS = {
   LAST_MODIFIED_DESC: "lastModified.desc",
   LAST_MODIFIED_ASC: "lastModified.asc",
 } as const;
+
+// these are ids for searchable fields that don't actually exist
+// in the api, but we want to treat them like they do for the sake
+// of the UI
+export const GLOBAL_FIELD_IDS = {
+  DATE_RANGE: "GLOBAL_DATE_RANGE",
+  LOCATION: "GLOBAL_LOCATION",
+} as const;

--- a/src/helpers/parseDateString.test.ts
+++ b/src/helpers/parseDateString.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "@jest/globals";
+import { parseDateString } from "./parseDateString";
+
+describe("parseDateString", () => {
+  it("should return unix epoch seconds for valid dates", () => {
+    expect(parseDateString("2020-01-01")).toBe("1577836800");
+  });
+
+  it("should return negative unix epoch seconds for old dates", () => {
+    expect(parseDateString("01/01/500")).toBe("-46388678400");
+  });
+
+  it("should return the number of seconds since the Unix Epoch for BC dates", () => {
+    expect(parseDateString("1000 BCE")).toBe("-93723993000");
+    expect(parseDateString("2 century BCE")).toBe("-68478473000");
+  });
+
+  it("should return null for invalid dates", () => {
+    expect(parseDateString("Invalid Date")).toBeNull();
+  });
+
+  it("should return null for empty dates", () => {
+    expect(parseDateString("")).toBeNull();
+  });
+});

--- a/src/helpers/parseDateString.ts
+++ b/src/helpers/parseDateString.ts
@@ -1,0 +1,30 @@
+/**
+ * get a unix timestamp for a date string with some handling of BC dates
+ */
+export function parseDateString(dateString: string): string | null {
+  if (!dateString) return null;
+
+  const date = Date.parse(dateString + " UTC");
+  if (!isNaN(date)) {
+    return (date / 1000).toString();
+  }
+
+  // handle BC dates and centuries
+  if (dateString.toLowerCase().indexOf("bc") != -1) {
+    dateString = dateString.replace(/,/g, "");
+    const pattern = /[0-9]+/g;
+    const matches = dateString.match(pattern);
+
+    if (matches && matches.length > 0) {
+      let yearsAgo = parseInt(matches[0]);
+      if (dateString.toLowerCase().indexOf("century") != -1) {
+        yearsAgo = yearsAgo * 100;
+      }
+
+      const bceDate = -1 * yearsAgo * 31556900 - 1970 * 31556900; // seconds in a year
+      return bceDate.toString();
+    }
+  }
+
+  return null;
+}

--- a/src/pages/LocalLoginPage/LocalLoginPage.vue
+++ b/src/pages/LocalLoginPage/LocalLoginPage.vue
@@ -23,14 +23,13 @@
             <div>
               <InputGroup
                 id="username"
-                :value="username"
+                v-model="username"
                 label="Username"
                 :inputClass="{
                   '!border-red-500 !bg-red-50': !!errors.username,
                 }"
                 type="string"
                 aria-required="true"
-                @input="username = ($event.target as HTMLInputElement).value"
               />
               <p
                 v-if="errors.username"
@@ -42,14 +41,13 @@
             <div>
               <InputGroup
                 id="password"
+                v-model="password"
                 label="Password"
-                :value="password"
                 :inputClass="{
                   '!border-red-500 !bg-red-50': !!errors.password,
                 }"
                 :type="showPassword ? 'text' : 'password'"
                 aria-required="true"
-                @input="password = ($event.target as HTMLInputElement).value"
               >
                 <template #append>
                   <button class="border-none" type="button">

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -9,7 +9,7 @@ import {
   ElevatorInstance,
   User,
   AssetCollection,
-  SearchableField,
+  SearchableSpecificField,
 } from "@/types";
 import {
   toCollectionIndex,
@@ -22,7 +22,7 @@ const createState = () => ({
   currentUser: ref<User | null>(null),
   pages: ref<Page[]>([]),
   collections: ref<AssetCollection[]>([]),
-  searchableFields: ref<SearchableField[]>([]),
+  searchableFields: ref<SearchableSpecificField[]>([]),
   instance: ref<ElevatorInstance>({
     id: null,
     name: "Elevator",
@@ -64,9 +64,9 @@ const getters = (state: ReturnType<typeof createState>) => ({
     }
   },
 
-  getSearchableField<T extends SearchableField = SearchableField>(
-    fieldId: string
-  ): T | null {
+  getSearchableField<
+    T extends SearchableSpecificField = SearchableSpecificField
+  >(fieldId: string): T | null {
     return (
       (state.searchableFields.value.find((f) => f.id === fieldId) as T) ?? null
     );

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -32,8 +32,8 @@ export interface SearchStoreState {
     searchableFieldsMap: Map<string, SearchableFieldFilter>;
     searchableFieldsOperator: "AND" | "OR";
     dateRange: null | {
-      startDate: string | null;
-      endDate: string | null;
+      startDate: string;
+      endDate: string;
     };
   };
 
@@ -200,8 +200,8 @@ const actions = (state: SearchStoreState) => ({
 
   addDateRangeFilter() {
     state.filterBy.dateRange = {
-      startDate: null,
-      endDate: null,
+      startDate: "",
+      endDate: "",
     };
   },
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -14,6 +14,7 @@ import {
 } from "@/types";
 import { GLOBAL_FIELD_IDS, SORT_KEYS } from "@/constants/constants";
 import { useInstanceStore } from "./instanceStore";
+import { parseDateString } from "@/helpers/parseDateString";
 
 export interface SearchStoreState {
   searchId: Ref<string | undefined>;
@@ -187,6 +188,11 @@ const getters = (state: SearchStoreState) => ({
         fuzzy: filter.isFuzzy,
       }));
 
+    const startDateText =
+      state.filterBy.globalDateRange?.startDate.toString() ?? "";
+    const endDateText =
+      state.filterBy.globalDateRange?.endDate.toString() ?? "";
+
     return {
       sort: state.sort.value,
       collection: state.filterBy.collectionIds.length
@@ -194,6 +200,10 @@ const getters = (state: SearchStoreState) => ({
         : undefined,
       combineSpecificSearches: state.filterBy.searchableFieldsOperator,
       specificFieldSearch,
+      startDateText,
+      startDate: parseDateString(startDateText) ?? "",
+      endDateText,
+      endDate: parseDateString(endDateText) ?? "",
     };
   }),
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -271,6 +271,10 @@ const actions = (state: SearchStoreState) => ({
     };
   },
 
+  removeDateRangeFilter() {
+    state.filterBy.globalDateRange = null;
+  },
+
   getSearchableFieldFilter(
     filterId: string
   ): SearchableSpecificFieldFilter | null {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -253,6 +253,7 @@ const actions = (state: SearchStoreState) => ({
       value: "",
       isFuzzy: false,
       id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
       ...initialProps,
     };
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -492,6 +492,17 @@ const actions = (state: SearchStoreState) => ({
             });
           }
 
+          // set the global date range if included
+          if (res.searchEntry.startDateText || res.searchEntry.endDateText) {
+            state.filterBy.globalDateRange = {
+              startDate: res.searchEntry?.startDateText ?? "",
+              endDate: res.searchEntry?.endDateText ?? "",
+              createdAt: new Date().toISOString(),
+            };
+          } else {
+            state.filterBy.globalDateRange = null;
+          }
+
           // set query to the search text if it's not already set
           // to something. This handles the case when a user enters
           // the search results page with a search id in the url, but

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -31,6 +31,10 @@ export interface SearchStoreState {
     collectionIds: number[];
     searchableFieldsMap: Map<string, SearchableFieldFilter>;
     searchableFieldsOperator: "AND" | "OR";
+    dateRange: null | {
+      startDate: string | null;
+      endDate: string | null;
+    };
   };
 
   matches: Ref<SearchResultMatch[]>;
@@ -62,6 +66,7 @@ const createState = (): SearchStoreState => ({
     collectionIds: [],
     searchableFieldsMap: new Map<string, SearchableFieldFilter>(),
     searchableFieldsOperator: "AND",
+    dateRange: null,
   }),
   matches: ref([]),
   totalResults: ref(undefined),
@@ -81,10 +86,22 @@ const getters = (state: SearchStoreState) => ({
     return state.matches.value.length < (state.totalResults.value ?? 0);
   }),
 
+  hasDateRangeFilter: computed(() => {
+    return state.filterBy.dateRange !== null;
+  }),
+
   filteredByCount: computed((): number => {
     return (
       state.filterBy.collectionIds.length +
-      state.filterBy.searchableFieldsMap.size
+      state.filterBy.searchableFieldsMap.size +
+      (getters(state).hasDateRangeFilter.value ? 1 : 0)
+    );
+  }),
+
+  hasFieldFiltersApplied: computed((): boolean => {
+    return (
+      state.filterBy.searchableFieldsMap.size > 0 ||
+      getters(state).hasDateRangeFilter.value
     );
   }),
 
@@ -181,6 +198,13 @@ const actions = (state: SearchStoreState) => ({
     state.filterBy.collectionIds = [];
   },
 
+  addDateRangeFilter() {
+    state.filterBy.dateRange = {
+      startDate: null,
+      endDate: null,
+    };
+  },
+
   getSearchableFieldFilter(filterId: string): SearchableFieldFilter | null {
     return state.filterBy.searchableFieldsMap.get(filterId) ?? null;
   },
@@ -254,6 +278,8 @@ const actions = (state: SearchStoreState) => ({
 
   clearSearchableFieldsFilters() {
     state.filterBy.searchableFieldsMap.clear();
+    state.filterBy.searchableFieldsOperator = "AND";
+    state.filterBy.dateRange = null;
   },
 
   updateFilterFieldId(filterId: string, fieldId: string) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -667,6 +667,7 @@ export interface SearchableSpecificFieldFilter {
   fieldId: string;
   value: string;
   isFuzzy: boolean;
+  createdAt: string;
 }
 
 export interface SearchableCheckboxFieldFilter

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -511,7 +511,7 @@ export interface InstanceStoreState {
   currentUser: User | null;
   instance: ElevatorInstance;
   collections: AssetCollection[];
-  searchableFields: SearchableField[];
+  searchableFields: SearchableSpecificField[];
 }
 
 export interface ElevatorInstance {
@@ -646,29 +646,30 @@ export interface ApiGetMultiSelectFieldInfoResponse
   rawContent: TreeNode; // recursive tree of options
 }
 
-export interface SearchableField extends RawSortableField {
+export interface SearchableSpecificField extends RawSortableField {
   id: string;
 }
 
-export interface SearchableSelectField extends SearchableField {
+export interface SearchableSelectField extends SearchableSpecificField {
   type: "select";
 }
 
-export interface SearchableCheckboxField extends SearchableField {
+export interface SearchableCheckboxField extends SearchableSpecificField {
   type: "checkbox";
 }
 
-export interface SearchableMultiSelectField extends SearchableField {
+export interface SearchableMultiSelectField extends SearchableSpecificField {
   type: "multiselect";
 }
 
-export interface SearchableFieldFilter {
+export interface SearchableSpecificFieldFilter {
   id: string; // filter uuid not field id
   fieldId: string;
   value: string;
   isFuzzy: boolean;
 }
 
-export interface SearchableCheckboxFieldFilter extends SearchableFieldFilter {
+export interface SearchableCheckboxFieldFilter
+  extends SearchableSpecificFieldFilter {
   value: "boolean_true" | "boolean_false";
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -346,6 +346,10 @@ export interface SearchEntry {
   sort?: string;
   specificFieldSearch?: SpecificFieldSearchItem[];
   combineSpecificSearches: "OR" | "AND";
+  startDateText?: string;
+  startDate?: string; // unix timestamp
+  endDateText?: string;
+  endDate?: string; // unix timestamp
 }
 
 export interface SearchSortOptions {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -670,6 +670,8 @@ export interface SearchableSpecificFieldFilter {
   createdAt: string;
 }
 
+export type GlobalSearchableFieldFilter = SearchableSpecificFieldFilter;
+
 export interface SearchableCheckboxFieldFilter
   extends SearchableSpecificFieldFilter {
   value: "boolean_true" | "boolean_false";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,26 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.41.0.tgz#080321c3b68253522f7646b55b577dd99d2950b3"
   integrity sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==
 
+"@floating-ui/core@^1.0.0", "@floating-ui/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
+  integrity sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==
+
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.2.1":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.9.tgz#b9ed1c15d30963419a6736f1b7feb350dd49c603"
+  integrity sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==
+  dependencies:
+    "@floating-ui/core" "^1.2.6"
+
+"@floating-ui/vue@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/vue/-/vue-0.2.1.tgz#a52b66e020897ad0535d0d0d3b09932446fc6231"
+  integrity sha512-HE+EIeakID7wI6vUwF0yMpaW48bNaPj8QtnQaRMkaQFhQReVBA4bY6fmJ3J7X+dqVgDbMhyfCG0fBJfdQMdWxQ==
+  dependencies:
+    "@floating-ui/dom" "^1.2.1"
+    vue-demi "^0.13.11"
+
 "@fontsource/inter@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@fontsource/inter/-/inter-5.0.1.tgz#43fd31988734fe3abbe6864923ad43ede34038c2"
@@ -1623,6 +1643,15 @@
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
+"@headlessui-float/vue@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@headlessui-float/vue/-/vue-0.11.2.tgz#6ecf6bedd6bbce3aebcc74f5c2c2dcf7c108289b"
+  integrity sha512-9yWN6LHeaXZKyU9y/rj6SmujCzkRxxf4bhg7nRs2RSwfSRI9E+JPvM/Tl7AA2lFQAJegWTRcElt3dSJ0Nkth0Q==
+  dependencies:
+    "@floating-ui/core" "^1.0.0"
+    "@floating-ui/dom" "^1.0.0"
+    "@floating-ui/vue" "^0.2.0"
 
 "@headlessui/vue@^1.7.13":
   version "1.7.13"
@@ -13216,6 +13245,11 @@ vue-demi@>=0.14.5:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.5.tgz#676d0463d1a1266d5ab5cba932e043d8f5f2fbd9"
   integrity sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==
+
+vue-demi@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.11.tgz#7d90369bdae8974d87b1973564ad390182410d99"
+  integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
 
 vue-docgen-api@^4.44.15:
   version "4.52.0"


### PR DESCRIPTION
This lets a user search by `Any Date` in the advanced search.

### Background:
- Any Date is a special global search field, not a specific field like other fields like "Title" or "Author". It doesn't have a real `fieldId`, it isn't returned with other fields with `getInstanceNav`, and it's values shouldn't be included with other specific fields in the search query.  
- We want it to appear like it's just another specific field filter to the user in the UI. That is, we want the user to be able to select it from the dropdown with other fields, and update it's values like other fields.
- The solution should accommodate other general fields. There's an Any Location filter too, which will need to use a similar pattern.

### The Approach

We keep the data for the any date filter in the searchStore in `filterBy.globalDateRange` and not mixed it in with `specificFieldsMap` to make it a bit easier to differentiate from real specific fields.

When generating the list of filter rows in the UI, it's handy to have the date range filter data in the same shape as the other specific filters. So, the `searchStore.globalDateRangeAsFilter` getter will take care of this, assigning a special id and field id `GLOBAL_FIELD_IDS.DATE_RANGE`. 

Once the specific filters and the global Any Date filter are the same shape, we can merge the filters together into one list of rows and then [loop through that list](https://github.com/UMN-LATIS/elevator-ui/compare/feature/adv-search-any-date?expand=1#diff-e22e9d1962eaafa9255bf430af5673d605a11042465846ae73aeef9a80a790e6R20-R26). Specific field filters are still handled by the `<FilterByFieldsRow>`.  Meanwhile the global Any Date filter is handled by the `<FilterByGlobalDateRow>` component. 

The components are very similar, but have different actions on update and delete (and don't allow field changes).

We need some way to make sure the merge specific and global filters are listed in the order the user added.  (Previously we didn't have to do anything, since the specific fields were coming from the same Map interable).  So, we've added a new `createdAt` property to each created filter, and then sort the filters by their `createdAt` date.

### Related updates

#### InputGroup `v-model`

It's handy to just use `v-model` on the Any Date filter's start and end date, so `<InputGroup>` was updated to use `modelValue` instead `value`.

#### Dates as Unix timestamps

The `parseDateString` function was ported over from the legacy UI and some tests were added to check the math matched the datetimes that the legacy ui was generating (especially dates pre-1970).

#### Filter counts and clearing

filter count and clear functions were updated so that the globalDateRange was included. (globalLocation was also added, but globalLocation UI stuff isn't included with this PR).

#### Filter UI Layout changes

With two different row components with different field types (select, input, cascade select), there was a lot of opportunity for misaligned UI elements.

I moved from `flexbox` to `grid`. And fixed some issues with smaller screensizes:

Advanced search at multiple screen width:

<img width="800" alt="ScreenShot 2023-06-09 at 10 05 16@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/d70bba84-5235-4dad-8b6d-e786a24c2a61">

<img width="500" alt="ScreenShot 2023-06-09 at 10 03 36@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/6f92404c-ee2e-4dcc-8c48-ccc68e7263c0">

<img width="300" alt="ScreenShot 2023-06-09 at 10 03 56@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/81c27734-e25f-44ce-985c-b5e39ac02039">

#### Scrolling with a large number of fields

I also updated the advanced search modal so that the filter by section will scroll when it gets too big.


#### Dropdown menu positioning with FloatingUI

CSS positioning of a dropdown within a scrollable positioned element gets tricky. We want the dropdown to be able to escape the container when opened, not just add more height to the scroll:

![ScreenShot 2023-06-09 at 10 10 17@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/534ca237-846d-43b1-9734-9546537aa62b)

Also we want the dropdown to flip if needed:
![ScreenShot 2023-06-09 at 10 14 23@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/822ab396-2ba7-46f3-bd97-ee1a3b4f460d)

This PR also pulls in the HeadlessUI Float package for smart dropdowns.

Why this package? 

Bootstrap uses PopperJS for handling their dropdown menu. Popper's latest version was rebranded as [Floating UI](https://floating-ui.com/) (I love their webpage) and has [integrations](https://github.com/ycs77/headlessui-float) with [HeadlessUI](https://headlessui.com/) (which we're using to create the accessible dropdown).

The `<Float>` element makes the work of smart dropdowns almost trivial.

On <https://dev.elevator.umn.edu/defaultinstance/> for testing.