### PR TITLE
Fix some type errors

### DIFF
--- a/src/__mocks__/mockSearchResults.ts
+++ b/src/__mocks__/mockSearchResults.ts
@@ -1,4 +1,4 @@
-import { SearchResultsResponse } from "@/types";
+import { SearchResultsResponse, SpecificFieldSearchItem } from "@/types";
 
 const mockSearch: SearchResultsResponse = {
   searchResults: [
@@ -35,6 +35,30 @@ const mockSearch: SearchResultsResponse = {
   ],
   totalResults: 11311,
   searchId: "bb15c171-15dd-4f74-b5e4-d7ac9dffc4dc",
+  sortableWidgets: {
+    "0": "Best Match",
+    "lastModified.desc": "Modified Date (newest to oldest)",
+    "lastModified.asc": "Modified Date (oldest to newest)",
+    "title.raw": "Default Title",
+    collection: "Collection",
+    template: "Template",
+    "author_1.raw": "Author",
+    "cascadeselect_1.raw": "Cascade Select",
+    "copyright_1.raw": "Copyright",
+    "course_1.raw": "Course",
+    "dateCache.startDate.desc": "Subject Date (newest to oldest)",
+    "dateCache.startDate.asc": "Subject Date (oldest to newest)",
+    "geneds_1.raw": "GenEds",
+    "instructor_1.raw": "Instructor",
+    "itemtype_1.raw": "Item Type",
+    "location_1.raw": "Location",
+    "samplemultiselect_1.raw": "Sample Multiselect",
+    "system_1.raw": "System",
+    "tags_1.raw": "Tags",
+    "title_1.raw": "Title",
+    "transcript_1.raw": "Transcript",
+    "work_1.raw": "Work",
+  },
   matches: [
     {
       dates: [
@@ -785,15 +809,13 @@ const mockSearch: SearchResultsResponse = {
     fuzzySearch: "0",
     searchText: "",
     sort: "lastModified.desc",
-    specificSearchField: [""],
-    specificSearchText: [""],
-    specificSearchFuzzy: [""],
-    specificFieldSearch: [],
+    specificFieldSearch: [] as SpecificFieldSearchItem[],
     searchDate: {
       date: "2022-08-15 18:38:35.316883",
       timezone_type: 3,
       timezone: "UTC",
     },
+    combineSpecificSearches: "AND",
   },
 };
 

--- a/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
+++ b/src/components/ActiveFileViewToolbar/DownloadFileButton.vue
@@ -38,7 +38,6 @@ import DownloadIcon from "@/icons/DownloadIcon.vue";
 import api from "@/api";
 import Modal from "@/components/Modal/Modal.vue";
 import Chip from "@/components/Chip/Chip.vue";
-import { getColorClassesForString } from "@/helpers/getColorClassesForString";
 
 const assetStore = useAssetStore();
 const isOpen = ref(false);

--- a/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
+++ b/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
@@ -41,6 +41,7 @@
               class=""
             >
               <MapMarker
+                id="more-info-location-map-marker"
                 :lng="fileMetaData.coordinates[0]"
                 :lat="fileMetaData.coordinates[1]"
               />

--- a/src/components/Map/Map.vue
+++ b/src/components/Map/Map.vue
@@ -64,7 +64,7 @@ import { Point } from "geojson";
 const props = withDefaults(
   defineProps<{
     center: LngLat;
-    bounds: BoundingBox;
+    bounds?: BoundingBox;
     zoom: number;
     apiKey: string;
     labelsClass?: string;

--- a/src/components/Widget/LocationWidget/LocationItem.vue
+++ b/src/components/Widget/LocationWidget/LocationItem.vue
@@ -32,7 +32,11 @@
       :apiKey="config.arcgis.apiKey"
       class="bg-neutral-100 p-1 rounded"
     >
-      <MapMarker :lng="mapCenter.lng" :lat="mapCenter.lat" />
+      <MapMarker
+        :id="`locationItem-${locationLabel}`"
+        :lng="mapCenter.lng"
+        :lat="mapCenter.lat"
+      />
     </Map>
     <div class="w-min flex gap-4 my-4">
       <Tuple label="Latitude" class="w-auto">{{ latStr }}</Tuple>

--- a/src/helpers/selectCurrentUserFromResponse.ts
+++ b/src/helpers/selectCurrentUserFromResponse.ts
@@ -15,7 +15,6 @@ export function selectCurrentUserFromResponse(
     userCanManageAssets,
     userIsAdmin,
     userIsSuperAdmin,
-    userCanSearchAndBrowse,
   } = instanceNav;
 
   // check the userId to see if a current user is logged in
@@ -28,6 +27,5 @@ export function selectCurrentUserFromResponse(
     isSuperAdmin: userIsSuperAdmin,
     canManageAssets: userCanManageAssets,
     canManageDrawers: userCanCreateDrawers,
-    canSearchAndBrowse: userCanSearchAndBrowse,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -652,10 +652,6 @@ export interface ApiGetMultiSelectFieldInfoResponse
 
 export interface SearchableSpecificField extends RawSortableField {
   id: string;
-  label: string;
-  template: number;
-  type: WidgetType;
-  isPsuedoField?: boolean;
 }
 
 export interface SearchableSelectField extends SearchableSpecificField {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -653,7 +653,7 @@ export interface ApiGetMultiSelectFieldInfoResponse
 export interface SearchableSpecificField extends RawSortableField {
   id: string;
   label: string;
-  template: number | null;
+  template: number;
   type: WidgetType;
   isPsuedoField?: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -652,6 +652,10 @@ export interface ApiGetMultiSelectFieldInfoResponse
 
 export interface SearchableSpecificField extends RawSortableField {
   id: string;
+  label: string;
+  template: number | null;
+  type: WidgetType;
+  isPsuedoField?: boolean;
 }
 
 export interface SearchableSelectField extends SearchableSpecificField {


### PR DESCRIPTION
This fixes some type errors found by `vue-tsc`:
- mock search results needs a widget list and a few other props to satisfy search results type
- map markers need an id
- map bounds prop can be optional
- removed `userCanSearchAndBrowse` prop from user object to satisfy type check. (This was moved from the user object to the instance object awhile back since we need this prop at the instance level to know whether to show/hide search bar even if the user isn't logged in)

