### PR TITLE
Clear search filters on static pages

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -34,14 +34,13 @@
   </div>
 </template>
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { ref } from "vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import AdvancedSearchForm from "@/components/AdvancedSearchForm/AdvancedSearchForm.vue";
 import { useSearchStore } from "@/stores/searchStore";
 import { useRouter } from "vue-router";
 import SearchTextInputGroup from "./SearchTextInputGroup.vue";
 import TransitionFade from "@/components/TransitionFade/TransitionFade.vue";
-import { useScrollLock } from "@vueuse/core";
 
 const inputGroup = ref<InstanceType<typeof InputGroup> | null>(null);
 const isAdvancedSearchModalOpen = ref(false);
@@ -52,7 +51,7 @@ async function handleSubmit() {
   // close advanced search modal if open
   isAdvancedSearchModalOpen.value = false;
 
-  const searchId = await searchStore.search();
+  const searchId = await searchStore.getSearchId();
   if (!searchId) {
     router.push({
       name: "error",
@@ -84,13 +83,6 @@ function removeFocusOnEscape(event: KeyboardEvent) {
 
 document.addEventListener("keydown", focusInputOnCommandK);
 document.addEventListener("keydown", removeFocusOnEscape);
-
-// setup body scroll lock when advanced search modal is open
-// const body = document.querySelector("body");
-// const isLocked = useScrollLock(body);
-// watch(isAdvancedSearchModalOpen, () => {
-//   isLocked.value = isAdvancedSearchModalOpen.value;
-// });
 </script>
 <style scoped>
 @media (min-width: 640px) {

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -88,10 +88,13 @@ const route = useRoute();
 
 watch(
   route,
-  (to) => {
-    // make sure the search query and filters are cleared
-    // if not on the search or asset page
-    if (!["search", "asset"].includes(to.name as string)) {
+  (to, from) => {
+    const isNewRoute = to.name !== from?.name;
+    const isNotSearchOrAssetPage = !["search", "asset"].includes(
+      to.name as string
+    );
+
+    if (isNewRoute && isNotSearchOrAssetPage) {
       searchStore.query = "";
       searchStore.clearAllFilters();
     }

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -34,11 +34,11 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import AdvancedSearchForm from "@/components/AdvancedSearchForm/AdvancedSearchForm.vue";
 import { useSearchStore } from "@/stores/searchStore";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import SearchTextInputGroup from "./SearchTextInputGroup.vue";
 import TransitionFade from "@/components/TransitionFade/TransitionFade.vue";
 
@@ -83,6 +83,21 @@ function removeFocusOnEscape(event: KeyboardEvent) {
 
 document.addEventListener("keydown", focusInputOnCommandK);
 document.addEventListener("keydown", removeFocusOnEscape);
+
+const route = useRoute();
+
+watch(
+  route,
+  (to) => {
+    // make sure the search query and filters are cleared
+    // if not on the search or asset page
+    if (!["search", "asset"].includes(to.name as string)) {
+      searchStore.query = "";
+      searchStore.clearAllFilters();
+    }
+  },
+  { immediate: true }
+);
 </script>
 <style scoped>
 @media (min-width: 640px) {

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -92,7 +92,7 @@
 </template>
 <script setup lang="ts">
 import { watch, computed, onMounted, nextTick, ref } from "vue";
-import { useRouter, useRoute, onBeforeRouteLeave } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useSearchStore } from "@/stores/searchStore";
 import BrowseCollectionHeader from "./BrowseCollectionHeader.vue";
@@ -144,17 +144,10 @@ searchStore.onAfterNewSearch(() => {
   isNewSearchReadyForDisplay.value = true;
 });
 
-// if search with this id is not currently in flight,
-// then kick it off
+// load search results
 watch(
   () => props.searchId,
-  () => {
-    if (searchStore.searchId === props.searchId) {
-      isNewSearchReadyForDisplay.value = true;
-      return;
-    }
-    searchStore.search(props.searchId);
-  },
+  () => searchStore.search(props.searchId),
   { immediate: true }
 );
 

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -251,12 +251,6 @@ watch(
   },
   { immediate: true }
 );
-
-// clear the search query when leaving this page
-onBeforeRouteLeave(() => {
-  searchStore.query = "";
-  searchStore.clearAllFilters();
-});
 </script>
 <style scoped></style>
 <style>

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -23,7 +23,7 @@
           >
             <ResultsCount class="mb-2 sm:mb-0" />
             <SearchResultsSortSelect
-              v-if="!['map', 'timline'].includes(searchStore.resultsView)"
+              v-if="!['map', 'timeline'].includes(searchStore.resultsView)"
               :sortOptions="searchStore.sortOptions"
               :selectedSortOption="searchStore.sort"
               :searchQuery="

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -17,8 +17,6 @@ import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { ref, watch } from "vue";
 import { ApiStaticPageResponse } from "@/types";
 import api from "@/api";
-import { onBeforeRouteUpdate } from "vue-router";
-import { useSearchStore } from "@/stores/searchStore";
 
 const props = defineProps<{
   pageId: number;
@@ -33,12 +31,6 @@ watch(
   },
   { immediate: true }
 );
-
-const searchStore = useSearchStore();
-onBeforeRouteUpdate(() => {
-  searchStore.query = "";
-  searchStore.clearAllFilters();
-});
 </script>
 <style scoped>
 .static-page__content {

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -17,6 +17,8 @@ import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { ref, watch } from "vue";
 import { ApiStaticPageResponse } from "@/types";
 import api from "@/api";
+import { onBeforeRouteUpdate } from "vue-router";
+import { useSearchStore } from "@/stores/searchStore";
 
 const props = defineProps<{
   pageId: number;
@@ -31,6 +33,12 @@ watch(
   },
   { immediate: true }
 );
+
+const searchStore = useSearchStore();
+onBeforeRouteUpdate(() => {
+  searchStore.query = "";
+  searchStore.clearAllFilters();
+});
 </script>
 <style scoped>
 .static-page__content {

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,7 @@ import SearchResultsPage from "./pages/SearchResultsPage/SearchResultsPage.vue";
 import LocalLoginPage from "./pages/LocalLoginPage/LocalLoginPage.vue";
 import StaticContentPage from "@/pages/StaticContentPage/StaticContentPage.vue";
 import ErrorPage from "@/pages/ErrorPage/ErrorPage.vue";
+import { useSearchStore } from "./stores/searchStore";
 
 function parseIntFromParam(
   param: string | string[] | undefined
@@ -65,6 +66,7 @@ const router = createRouter({
       // import("@/pages/AllCollectionsPage/AllCollectionsPage.vue"),
     },
     {
+      name: "browseCollection",
       path: "/collections/browseCollection/:collectionId",
       alias: "/collections/:collectionId",
       component: BrowseCollectionPage,
@@ -96,7 +98,7 @@ const router = createRouter({
       }),
     },
     {
-      name: "StaticContentPage",
+      name: "staticContentPage",
       path: "/page/view/:pageId",
       component: StaticContentPage,
       // component: () =>
@@ -115,6 +117,7 @@ const router = createRouter({
       }),
     },
     {
+      name: "catchall",
       path: "/:pathMatch(.*)",
       component: ErrorPage,
       // component: () => import("@/pages/ErrorPage/ErrorPage.vue"),
@@ -132,6 +135,19 @@ router.beforeResolve((to, from, next) => {
     next(path);
   }
   next();
+});
+
+router.beforeEach((to, from) => {
+  // reset the search query and filters unless we're
+  // on the search or asset pages
+  console.log(to.name, from.name);
+  if (["search", "asset"].includes(to.name as string)) {
+    return;
+  }
+
+  const searchStore = useSearchStore();
+  searchStore.query = "";
+  searchStore.clearAllFilters();
 });
 
 export default router;

--- a/src/router.ts
+++ b/src/router.ts
@@ -137,17 +137,4 @@ router.beforeResolve((to, from, next) => {
   next();
 });
 
-router.beforeEach((to, from) => {
-  // reset the search query and filters unless we're
-  // on the search or asset pages
-  console.log(to.name, from.name);
-  if (["search", "asset"].includes(to.name as string)) {
-    return;
-  }
-
-  const searchStore = useSearchStore();
-  searchStore.query = "";
-  searchStore.clearAllFilters();
-});
-
 export default router;


### PR DESCRIPTION
This fixes an issue where search filters would clear when navigating back to the search results page from an asset page.

1. Instead of always clearing the search filters when leaving the search results page, the filters when be cleared whenever arriving on a page other than the search results page or asset view page. (Some route names are added to `router.ts` to make route checking more readable.)

2. We always do a `searchStore.search` when arriving on a page. 

Previously, we would do a check if the search was already in flight, and then skip running a `searchStore.search` to prevent double search requests. The double request was caused by the search submit handler kicking off a search and then redirecting to the results page. But also arriving on the results page would also kick off a search, unless we checked if a search was already in flight.

To allow us to always do a search while also preventing double-requests, this splits up the search responsibilities into two functions:
- `getSearchId` for getting the search ID ,
- `search(searchId)` for getting results given an id. 

The search form submit handler was changed to only get the searchId and redirect to the results page. And the results page will now always get the results given the search id.

I've left in place caching `search` results for a given ID at the API layer.

Resolves #157 

Also:
- fixed a typo `timline` instead of `timeline`
- removed some unused imports and commented out code blocks.