### PR TITLE
Prevent Home Page layout shift on page load

### DIFF
--- a/src/components/FeaturedAssetCard/FeaturedAssetCard.vue
+++ b/src/components/FeaturedAssetCard/FeaturedAssetCard.vue
@@ -1,29 +1,32 @@
 <template>
   <Link :to="getAssetUrl(assetId)" class="group hover:no-underline relative">
-    <article
-      class="media-card flex flex-col overflow-hidden rounded-md shadow-sm max-w-xs group-hover:border-blue-700"
-    >
-      <div
-        class="placeholder-image aspect-video flex items-center justify-center w-full overflow-hidden bg-transparent-black-200 p-4"
+    <Transition name="fade">
+      <article
+        v-if="asset"
+        class="media-card flex flex-col overflow-hidden rounded-md shadow-sm max-w-xs group-hover:border-blue-700"
       >
-        <LazyLoadImage
-          v-if="imgSrc"
-          :src="imgSrc"
-          :alt="title || 'Untitled'"
-          loading="lazy"
-          class="object-contain w-full h-full !bg-transparent"
-        />
-        <DocumentIcon v-else />
-      </div>
-      <div class="flex-1 p-4 flex justify-between items-center">
-        <h1
-          class="search-result-card__title font-bold leading-tight group-hover:text-blue-700 text-center"
+        <div
+          class="placeholder-image aspect-video flex items-center justify-center w-full overflow-hidden bg-transparent-black-200 p-4"
         >
-          <SanitizedHTML :html="title" />
-        </h1>
-        <ArrowForwardIcon class="group-hover:text-blue-700" />
-      </div>
-    </article>
+          <LazyLoadImage
+            v-if="imgSrc"
+            :src="imgSrc"
+            :alt="title || 'Untitled'"
+            loading="lazy"
+            class="object-contain w-full h-full !bg-transparent"
+          />
+          <DocumentIcon v-else />
+        </div>
+        <div class="flex-1 p-4 flex justify-between items-center">
+          <h1
+            class="search-result-card__title font-bold leading-tight group-hover:text-blue-700 text-center"
+          >
+            <SanitizedHTML :html="title" />
+          </h1>
+          <ArrowForwardIcon class="group-hover:text-blue-700" />
+        </div>
+      </article>
+    </Transition>
   </Link>
 </template>
 

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -9,11 +9,14 @@
         'md:grid-cols-3': featuredAssetId,
       }"
     >
-      <article v-if="page" class="page-content-block col-span-2 p-4 lg:p-8">
-        <SanitizedHTML
-          :html="page.content ?? ''"
-          class="prose prose-neutral mx-auto"
-        />
+      <article class="page-content-block col-span-2 p-4 lg:p-8">
+        <Transition name="fade">
+          <SanitizedHTML
+            v-if="page"
+            :html="page.content ?? ''"
+            class="prose prose-neutral mx-auto"
+          />
+        </Transition>
       </article>
       <aside
         v-if="featuredAssetId"


### PR DESCRIPTION
If the homepage has a featured asset, there can be a layout shift while page content loads.

Before the Featured Asset starts left, and then shifts right once the page content is loaded. (Cumulative layout shift: ~0.4s)

After moving the `v-if=page` from the container to the `<SanitizedHTML>` element and wrapping with a `<Transition>`, layout stops shifting. (Cumulative Layout Shift = ~0s)

<https://dev.elevator.umn.edu/defaultinstance/>

Resolves #143.