### PR TITLE
Fix: undefined file meta data causes More Info modal to be blank

### DIFF
--- a/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
+++ b/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
@@ -17,16 +17,17 @@
 
       <section v-if="fileMetaData?.exif" class="flex flex-col gap-6">
         <Tuple label="File Type">
-          {{ fileMetaData.exif.File.FileType }}
+          {{ fileMetaData.exif?.File?.FileType ?? "Unknown" }}
         </Tuple>
         <Tuple label="Original Name">
-          {{ fileMetaData.sourcefile }}
+          {{ fileMetaData.sourcefile ?? "Unknown" }}
         </Tuple>
         <Tuple label="File Size">
-          {{ fileMetaData.exif.File.FileSize }}
+          {{ fileMetaData.exif?.File?.FileSize ?? "Unknown" }}
         </Tuple>
         <Tuple label="Image Size">
-          {{ fileMetaData.width }}x{{ fileMetaData.height }}
+          {{ fileMetaData.width ?? "Unknown" }} x
+          {{ fileMetaData.height ?? "Unknonwn" }}
         </Tuple>
         <Tuple v-if="fileMetaData.coordinates" label="Location">
           <div class="bg-neutral-200 p-4 rounded-xl">
@@ -50,27 +51,10 @@
         </Tuple>
 
         <h2 class="text-xl font-bold mt-6 border-t pt-6">EXIF Details</h2>
-        <Accordion
-          v-for="(exifSectionProps, exifSectionLabel) in fileMetaData.exif"
-          :key="exifSectionLabel"
-          :label="exifSectionLabel"
-          class="border mt-6"
-        >
-          <Tuple
-            v-for="(value, key) in exifSectionProps"
-            :key="key"
-            :label="key"
-          >
-            {{ value }}
-          </Tuple>
-        </Accordion>
+        <pre>{{ fileMetaData.exif }}</pre>
       </section>
       <section v-else>
-        <div v-for="(value, key) in fileMetaData" :key="key" class="my-6">
-          <Tuple :label="key">
-            {{ value }}
-          </Tuple>
-        </div>
+        <pre>{{ fileMetaData }}</pre>
       </section>
     </div>
   </Modal>
@@ -85,7 +69,6 @@ import { useAssetStore } from "@/stores/assetStore";
 import Skeleton from "../Skeleton/Skeleton.vue";
 import { computed } from "vue";
 import Tuple from "../Tuple/Tuple.vue";
-import Accordion from "../Accordion/Accordion.vue";
 import config from "@/config";
 import InfoIcon from "@/icons/InfoIcon.vue";
 

--- a/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
+++ b/src/components/ActiveFileViewToolbar/MoreFileInfoButton.vue
@@ -5,58 +5,56 @@
   <Modal
     label="File Info"
     :isOpen="isFileInfoOpen"
-    class="max-w-4xl m-auto"
+    class="max-w-4xl m-auto h-[75vh]"
     @close="isFileInfoOpen = false"
   >
-    <div v-if="!isFileMetaDataReady">
-      <Skeleton v-for="index in 10" :key="index" />
-    </div>
+    <Transition name="fade">
+      <div v-if="isFileMetaDataReady">
+        <span v-if="!fileMetaData">No meta data found.</span>
 
-    <div v-if="isFileMetaDataReady">
-      <span v-if="!fileMetaData">No meta data found.</span>
+        <section v-if="fileMetaData?.exif" class="flex flex-col gap-6">
+          <Tuple label="File Type">
+            {{ fileMetaData.exif?.File?.FileType ?? "Unknown" }}
+          </Tuple>
+          <Tuple label="Original Name">
+            {{ fileMetaData.sourcefile ?? "Unknown" }}
+          </Tuple>
+          <Tuple label="File Size">
+            {{ fileMetaData.exif?.File?.FileSize ?? "Unknown" }}
+          </Tuple>
+          <Tuple label="Image Size">
+            {{ fileMetaData.width ?? "Unknown" }} x
+            {{ fileMetaData.height ?? "Unknonwn" }}
+          </Tuple>
+          <Tuple v-if="fileMetaData.coordinates" label="Location">
+            <div class="bg-neutral-200 p-4 rounded-xl">
+              <Map
+                :center="{
+                  lng: fileMetaData.coordinates[0],
+                  lat: fileMetaData.coordinates[1],
+                }"
+                :zoom="10"
+                mapStyle="streets"
+                :apiKey="config.arcgis.apiKey"
+                mapContainerClass="!h-[50vh]"
+              >
+                <MapMarker
+                  id="more-info-location-map-marker"
+                  :lng="fileMetaData.coordinates[0]"
+                  :lat="fileMetaData.coordinates[1]"
+                />
+              </Map>
+            </div>
+          </Tuple>
 
-      <section v-if="fileMetaData?.exif" class="flex flex-col gap-6">
-        <Tuple label="File Type">
-          {{ fileMetaData.exif?.File?.FileType ?? "Unknown" }}
-        </Tuple>
-        <Tuple label="Original Name">
-          {{ fileMetaData.sourcefile ?? "Unknown" }}
-        </Tuple>
-        <Tuple label="File Size">
-          {{ fileMetaData.exif?.File?.FileSize ?? "Unknown" }}
-        </Tuple>
-        <Tuple label="Image Size">
-          {{ fileMetaData.width ?? "Unknown" }} x
-          {{ fileMetaData.height ?? "Unknonwn" }}
-        </Tuple>
-        <Tuple v-if="fileMetaData.coordinates" label="Location">
-          <div class="bg-neutral-200 p-4 rounded-xl">
-            <Map
-              :center="{
-                lng: fileMetaData.coordinates[0],
-                lat: fileMetaData.coordinates[1],
-              }"
-              :zoom="10"
-              mapStyle="streets"
-              :apiKey="config.arcgis.apiKey"
-              mapContainerClass="!h-[50vh]"
-            >
-              <MapMarker
-                id="more-info-location-map-marker"
-                :lng="fileMetaData.coordinates[0]"
-                :lat="fileMetaData.coordinates[1]"
-              />
-            </Map>
-          </div>
-        </Tuple>
-
-        <h2 class="text-xl font-bold mt-6 border-t pt-6">EXIF Details</h2>
-        <pre>{{ fileMetaData.exif }}</pre>
-      </section>
-      <section v-else>
-        <pre>{{ fileMetaData }}</pre>
-      </section>
-    </div>
+          <h2 class="text-xl font-bold mt-6 border-t pt-6">EXIF Details</h2>
+          <pre>{{ fileMetaData.exif }}</pre>
+        </section>
+        <section v-else>
+          <pre>{{ fileMetaData }}</pre>
+        </section>
+      </div>
+    </Transition>
   </Modal>
 </template>
 <script setup lang="ts">
@@ -66,7 +64,6 @@ import Modal from "../Modal/Modal.vue";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import api from "@/api";
 import { useAssetStore } from "@/stores/assetStore";
-import Skeleton from "../Skeleton/Skeleton.vue";
 import { computed } from "vue";
 import Tuple from "../Tuple/Tuple.vue";
 import config from "@/config";

--- a/src/types/FileMetaDataTypes.ts
+++ b/src/types/FileMetaDataTypes.ts
@@ -1,23 +1,23 @@
 export interface FileMetaData {
-  exif: Exif;
-  width: number;
-  height: number;
-  filesize: number;
-  rotation: number;
-  coordinates: number[];
-  creationDate: string;
-  sourcefile: string;
+  exif?: Exif;
+  width?: number;
+  height?: number;
+  filesize?: number;
+  rotation?: number;
+  coordinates?: number[];
+  creationDate?: string;
+  sourcefile?: string;
 }
 
 export interface Exif {
-  MPF: Mpf;
-  EXIF: EXIFClass;
-  File: File;
-  JFIF: Jfif;
-  ExifTool: ExifTool;
-  Composite: Composite;
-  MakerNotes: MakerNotes;
-  ICC_Profile: ICCProfile;
+  MPF?: Partial<Mpf>;
+  EXIF?: Partial<EXIFClass>;
+  File?: Partial<File>;
+  JFIF?: Partial<Jfif>;
+  ExifTool?: Partial<ExifTool>;
+  Composite?: Partial<Composite>;
+  MakerNotes?: Partial<MakerNotes>;
+  ICC_Profile?: Partial<ICCProfile>;
 }
 
 export interface Composite {


### PR DESCRIPTION
This resolves #83 where sometimes the meta data modal would be completely blank if some of the meta data is undefined.

Changes:
- Use "Unknown" in the main meta data section if metadata is nullish.
- Just show the plain json under details (previously, we were using an accordion to show details).
- use fade transition instead of skeleton on content load

<img width="500" alt="ScreenShot 2023-06-20 at 13 25 45@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/44a6dd7c-e153-44a2-99b0-7ed8758dc859">

This was an example of an item which previously caused issues:
<https://dev.elevator.umn.edu/defaultinstance/asset/viewAsset/575ee4c0ba98a87472f3df29>
