### PR TITLE
Fix: multiselect widget does full reload on search instead of using vue-router

### DIFF
--- a/src/components/ClickToSearchLink/ClickToSearchLink.vue
+++ b/src/components/ClickToSearchLink/ClickToSearchLink.vue
@@ -1,11 +1,8 @@
 <template>
   <span v-if="props.widget.clickToSearch">
-    <button
-      class="text-blue-600 hover:text-blue-700 hover:underline"
-      @click="handleClick"
-    >
+    <a :href="linkUrl">
       <slot />
-    </button>
+    </a>
   </span>
   <span v-else>
     <slot />
@@ -13,54 +10,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick } from "vue";
+import { computed } from "vue";
 import { WidgetProps } from "@/types";
-import { useSearchStore } from "@/stores/searchStore";
-import { useRouter } from "vue-router";
+import { toClickToSearchUrl } from "@/helpers/displayUtils";
 
-const props = defineProps<{
+interface Props {
   linkText: string;
   widget: WidgetProps;
-}>();
-
-const searchStore = useSearchStore();
-
-const fieldId = computed((): string => props.widget.fieldTitle);
-const fieldValue = computed((): string => {
-  const cleanedLinkText = props.linkText
-    .trim()
-    .replace("?", "")
-    .replace("...", "");
-
-  return cleanedLinkText.split(" : ").join(",");
-});
-
-const router = useRouter();
-
-async function handleClick() {
-  // this async function will take awhile to run
-  // to give the appearance of a loading state
-  // we'll queue up the search on next tick
-  // and then navigate to a blank page while waiting for the search to complete
-  // once the search is complete, we'll navigate to the search page
-  nextTick(async () => {
-    // clear search
-    searchStore.reset();
-
-    // create a new searchable field filter
-    searchStore.addSearchableFieldFilter(fieldId.value, {
-      value: fieldValue.value,
-    });
-
-    // get the search id
-    const searchId = await searchStore.getSearchId();
-    searchStore.search(searchId);
-
-    // navigate to the search page
-    router.replace(`/search/s/${searchId}`);
-  });
-
-  // go to a blank page while waiting for the search to complete
-  router.push(`/blank`);
 }
+
+const props = defineProps<Props>();
+
+const linkUrl = computed((): string =>
+  toClickToSearchUrl(props.linkText, props.widget)
+);
 </script>

--- a/src/components/ClickToSearchLink/ClickToSearchLink.vue
+++ b/src/components/ClickToSearchLink/ClickToSearchLink.vue
@@ -1,8 +1,11 @@
 <template>
   <span v-if="props.widget.clickToSearch">
-    <a :href="linkUrl">
+    <button
+      class="text-blue-600 hover:text-blue-700 hover:underline"
+      @click="handleClick"
+    >
       <slot />
-    </a>
+    </button>
   </span>
   <span v-else>
     <slot />
@@ -10,18 +13,54 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, nextTick } from "vue";
 import { WidgetProps } from "@/types";
-import { toClickToSearchUrl } from "@/helpers/displayUtils";
+import { useSearchStore } from "@/stores/searchStore";
+import { useRouter } from "vue-router";
 
-interface Props {
+const props = defineProps<{
   linkText: string;
   widget: WidgetProps;
+}>();
+
+const searchStore = useSearchStore();
+
+const fieldId = computed((): string => props.widget.fieldTitle);
+const fieldValue = computed((): string => {
+  const cleanedLinkText = props.linkText
+    .trim()
+    .replace("?", "")
+    .replace("...", "");
+
+  return cleanedLinkText.split(" : ").join(",");
+});
+
+const router = useRouter();
+
+async function handleClick() {
+  // this async function will take awhile to run
+  // to give the appearance of a loading state
+  // we'll queue up the search on next tick
+  // and then navigate to a blank page while waiting for the search to complete
+  // once the search is complete, we'll navigate to the search page
+  nextTick(async () => {
+    // clear search
+    searchStore.reset();
+
+    // create a new searchable field filter
+    searchStore.addSearchableFieldFilter(fieldId.value, {
+      value: fieldValue.value,
+    });
+
+    // get the search id
+    const searchId = await searchStore.getSearchId();
+    searchStore.search(searchId);
+
+    // navigate to the search page
+    router.replace(`/search/s/${searchId}`);
+  });
+
+  // go to a blank page while waiting for the search to complete
+  router.push(`/blank`);
 }
-
-const props = defineProps<Props>();
-
-const linkUrl = computed((): string =>
-  toClickToSearchUrl(props.linkText, props.widget)
-);
 </script>

--- a/src/components/Widget/MultiSelectWidget/MultiSelectItem.vue
+++ b/src/components/Widget/MultiSelectWidget/MultiSelectItem.vue
@@ -2,11 +2,11 @@
   <ul>
     <template v-for="category in organizedSelectCategories" :key="category">
       <li v-if="content.fieldContents[category]">
-        <ClickToSearchLink
+        <MultiSelectSearchLink
           :widget="widget"
           :linkText="contentsUpToCategory(category)"
           >{{ content.fieldContents[category] }}
-        </ClickToSearchLink>
+        </MultiSelectSearchLink>
       </li>
     </template>
   </ul>
@@ -16,7 +16,7 @@
 import { recursiveSort, uniqueValues } from "./MultiSelectWidget";
 import { computed } from "vue";
 import { MultiSelectWidgetContent, MultiSelectWidgetProps } from "@/types";
-import ClickToSearchLink from "@/components/ClickToSearchLink/ClickToSearchLink.vue";
+import MultiSelectSearchLink from "./MultiSelectSearchLink.vue";
 
 interface Props {
   widget: MultiSelectWidgetProps;

--- a/src/components/Widget/MultiSelectWidget/MultiSelectSearchLink.vue
+++ b/src/components/Widget/MultiSelectWidget/MultiSelectSearchLink.vue
@@ -1,0 +1,66 @@
+<template>
+  <span v-if="props.widget.clickToSearch">
+    <button
+      class="text-blue-600 hover:text-blue-700 hover:underline"
+      @click="handleClick"
+    >
+      <slot />
+    </button>
+  </span>
+  <span v-else>
+    <slot />
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick } from "vue";
+import { WidgetProps } from "@/types";
+import { useSearchStore } from "@/stores/searchStore";
+import { useRouter } from "vue-router";
+
+const props = defineProps<{
+  linkText: string;
+  widget: WidgetProps;
+}>();
+
+const searchStore = useSearchStore();
+
+const fieldId = computed((): string => props.widget.fieldTitle);
+const fieldValue = computed((): string => {
+  const cleanedLinkText = props.linkText
+    .trim()
+    .replace("?", "")
+    .replace("...", "");
+
+  return cleanedLinkText.split(" : ").join(",");
+});
+
+const router = useRouter();
+
+async function handleClick() {
+  // this async function will take awhile to run
+  // to give the appearance of a loading state
+  // we'll queue up the search on next tick
+  // and then navigate to a blank page while waiting for the search to complete
+  // once the search is complete, we'll navigate to the search page
+  nextTick(async () => {
+    // clear search
+    searchStore.reset();
+
+    // create a new searchable field filter
+    searchStore.addSearchableFieldFilter(fieldId.value, {
+      value: fieldValue.value,
+    });
+
+    // get the search id
+    const searchId = await searchStore.getSearchId();
+    searchStore.search(searchId);
+
+    // navigate to the search page
+    router.replace(`/search/s/${searchId}`);
+  });
+
+  // go to a blank page while waiting for the search to complete
+  router.push(`/blank`);
+}
+</script>

--- a/src/pages/BlankPage/BlankPage.vue
+++ b/src/pages/BlankPage/BlankPage.vue
@@ -1,0 +1,7 @@
+<template>
+  <DefaultLayout />
+</template>
+<script setup lang="ts">
+import DefaultLayout from "@/layouts/DefaultLayout.vue";
+</script>
+<style scoped></style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,6 +12,7 @@ import AllDrawersPage from "@/pages/AllDrawersPage/AllDrawersPage.vue";
 import DrawerViewPage from "./pages/DrawerViewPage/DrawerViewPage.vue";
 import CreateAssetPage from "./pages/CreateAssetPage/CreateAssetPage.vue";
 import { useErrorStore } from "./stores/errorStore";
+import BlankPage from "@/pages/BlankPage/BlankPage.vue";
 
 function parseIntFromParam(
   param: string | string[] | undefined
@@ -96,6 +97,13 @@ const router = createRouter({
       props: (route) => ({
         drawerId: parseIntFromParam(route.params.drawerId),
       }),
+    },
+    {
+      // used as an interstitial page to show while we're
+      // waiting for the searchId from the api
+      name: "blank",
+      path: "/blank",
+      component: BlankPage,
     },
     {
       name: "search",

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -534,11 +534,20 @@ const actions = (state: SearchStoreState) => ({
     filter.isFuzzy = isFuzzy;
   },
 
+  clearQuery() {
+    state.query.value = "";
+  },
+
   clearAllFilters() {
     this.clearCollectionIdFilters();
     this.clearSearchableFieldsFilters();
     state.filterBy.searchableFieldsOperator = "AND";
     state.filterBy.includeHiddenAssets = false;
+  },
+
+  reset() {
+    this.clearAllFilters();
+    this.clearQuery();
   },
 
   async getSearchId(): Promise<string> {


### PR DESCRIPTION
Part of:
- #104 

Previously, clicking on a multiselect widget within an asset would trigger a full page reload. Additionally, on the results load, the correct filters weren't set. This modifies links in the multiselect widget to do an advanced search when clicked, which resolves both issues.

The `<ClickToSearchLink>` component is left unmodified for now. As other widgets are using it (and probably have similar issues).

### Screenshots

Before: Advanced search value is for Greater Location field is blank
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/e2e38a19-b27f-43b5-a46e-4fae9ca2c190" width="500" alt="before" />

After: Multiselect for Greater Location is properly set
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/2baf1664-7801-4ce7-b91d-987d677c8343" width=500 alt="before" />
