### PR TITLE
Fix: Widgets using `<ClickToSearchLink>` component do a full page refresh

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -160,7 +160,8 @@ export async function fetchSearchIdForClickToSearch(
   widgetProps: WidgetProps
 ): Promise<string> {
   const url = toClickToSearchUrl(linkText, widgetProps);
-  const res = await axios.get<{ searchId: string }>(url);
+  // add `/true` to the url to get the searchId as JSON
+  const res = await axios.get<{ searchId: string }>(`${url}/true`);
   return res.data.searchId;
 }
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -20,12 +20,14 @@ import type {
   SearchableSpecificField,
   ApiListDrawersResponse,
   ApiGetDrawerResponse,
+  WidgetProps,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
 import { getExtensionFromFilename } from "@/helpers/getExtensionFromFilename";
 import { ApiError } from "./ApiError";
 import { useErrorStore } from "@/stores/errorStore";
+import { toClickToSearchUrl } from "@/helpers/displayUtils";
 
 const BASE_URL = config.instance.base.url;
 
@@ -150,6 +152,15 @@ export async function fetchSearchIdForCollection(
     params
   );
 
+  return res.data.searchId;
+}
+
+export async function fetchSearchIdForClickToSearch(
+  linkText: string,
+  widgetProps: WidgetProps
+): Promise<string> {
+  const url = toClickToSearchUrl(linkText, widgetProps);
+  const res = await axios.get<{ searchId: string }>(url);
   return res.data.searchId;
 }
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -160,6 +160,7 @@ export async function fetchSearchIdForClickToSearch(
   widgetProps: WidgetProps
 ): Promise<string> {
   const url = toClickToSearchUrl(linkText, widgetProps);
+
   // add `/true` to the url to get the searchId as JSON
   const res = await axios.get<{ searchId: string }>(`${url}/true`);
   return res.data.searchId;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -278,6 +278,7 @@ const api = {
   fetchInstanceNav: fetchers.fetchInstanceNav,
   getSearchId: fetchers.fetchSearchId,
   getSearchIdForCollection,
+  getSearchIdForClickToSearch: fetchers.fetchSearchIdForClickToSearch,
   getSearchResultsById,
   getStaticPage,
   deleteAsset: fetchers.deleteAsset,

--- a/src/components/ClickToSearchLink/ClickToSearchLink.vue
+++ b/src/components/ClickToSearchLink/ClickToSearchLink.vue
@@ -1,8 +1,11 @@
 <template>
   <span v-if="props.widget.clickToSearch">
-    <a :href="linkUrl">
+    <button
+      class="text-blue-600 hover:text-blue-700 hover:underline"
+      @click="handleClick"
+    >
       <slot />
-    </a>
+    </button>
   </span>
   <span v-else>
     <slot />
@@ -10,9 +13,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { useRouter } from "vue-router";
 import { WidgetProps } from "@/types";
-import { toClickToSearchUrl } from "@/helpers/displayUtils";
+import api from "@/api";
 
 interface Props {
   linkText: string;
@@ -20,8 +23,14 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const router = useRouter();
 
-const linkUrl = computed((): string =>
-  toClickToSearchUrl(props.linkText, props.widget)
-);
+async function handleClick() {
+  const searchId = await api.getSearchIdForClickToSearch(
+    props.linkText,
+    props.widget
+  );
+
+  router.push(`/search/s/${searchId}`);
+}
 </script>

--- a/src/components/ClickToSearchLink/ClickToSearchLink.vue
+++ b/src/components/ClickToSearchLink/ClickToSearchLink.vue
@@ -1,11 +1,12 @@
 <template>
   <span v-if="props.widget.clickToSearch">
-    <button
+    <a
+      :href="clickToSearchUrl"
       class="text-blue-600 hover:text-blue-700 hover:underline"
-      @click="handleClick"
+      @click.prevent="handleClick"
     >
       <slot />
-    </button>
+    </a>
   </span>
   <span v-else>
     <slot />
@@ -13,10 +14,12 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { WidgetProps } from "@/types";
 import { useSearchStore } from "@/stores/searchStore";
 import api from "@/api";
+import { toClickToSearchUrl } from "@/helpers/displayUtils";
 
 interface Props {
   linkText: string;
@@ -26,6 +29,9 @@ interface Props {
 const props = defineProps<Props>();
 const router = useRouter();
 const searchStore = useSearchStore();
+const clickToSearchUrl = computed(() => {
+  return toClickToSearchUrl(props.linkText, props.widget);
+});
 
 async function handleClick() {
   // clear search store

--- a/src/components/ClickToSearchLink/ClickToSearchLink.vue
+++ b/src/components/ClickToSearchLink/ClickToSearchLink.vue
@@ -15,6 +15,7 @@
 <script setup lang="ts">
 import { useRouter } from "vue-router";
 import { WidgetProps } from "@/types";
+import { useSearchStore } from "@/stores/searchStore";
 import api from "@/api";
 
 interface Props {
@@ -24,8 +25,12 @@ interface Props {
 
 const props = defineProps<Props>();
 const router = useRouter();
+const searchStore = useSearchStore();
 
 async function handleClick() {
+  // clear search store
+  searchStore.reset();
+
   const searchId = await api.getSearchIdForClickToSearch(
     props.linkText,
     props.widget

--- a/src/components/ClickToSearchLink/ClickToSearchLink.vue
+++ b/src/components/ClickToSearchLink/ClickToSearchLink.vue
@@ -5,11 +5,11 @@
       class="text-blue-600 hover:text-blue-700 hover:underline"
       @click.prevent="handleClick"
     >
-      <slot />
+      <slot :isClickable="true" />
     </a>
   </span>
   <span v-else>
-    <slot />
+    <slot :isClickable="false" />
   </span>
 </template>
 

--- a/src/components/Widget/TagWidget/TagWidget.vue
+++ b/src/components/Widget/TagWidget/TagWidget.vue
@@ -3,8 +3,19 @@
     <li v-for="(content, key) in contents" :key="key">
       <ul class="flex gap-2">
         <li v-for="(tag, index) in content.tags" :key="index">
-          <ClickToSearchLink :linkText="tag" :widget="widget">
-            <Chip>{{ tag }}</Chip>
+          <ClickToSearchLink
+            v-slot="{ isClickable }"
+            :linkText="tag"
+            :widget="widget"
+          >
+            <Chip
+              :class="{
+                'chip--is-clickable border border-blue-700  bg-blue-100 text-blue-700 cursor-pointer hover:bg-blue-700 hover:text-white transition-colors ease-in-out':
+                  isClickable,
+              }"
+            >
+              {{ tag }}
+            </Chip>
           </ClickToSearchLink>
         </li>
       </ul>

--- a/src/components/Widget/TagWidget/TagWidget.vue
+++ b/src/components/Widget/TagWidget/TagWidget.vue
@@ -3,9 +3,9 @@
     <li v-for="(content, key) in contents" :key="key">
       <ul class="flex gap-2">
         <li v-for="(tag, index) in content.tags" :key="index">
-          <Chip :href="toClickToSearchUrl(tag, widget)">
-            {{ tag }}
-          </Chip>
+          <ClickToSearchLink :linkText="tag" :widget="widget">
+            <Chip>{{ tag }}</Chip>
+          </ClickToSearchLink>
         </li>
       </ul>
     </li>
@@ -14,8 +14,8 @@
 
 <script setup lang="ts">
 import { TagListWidgetProps, TagListWidgetContent } from "@/types";
-import { toClickToSearchUrl } from "@/helpers/displayUtils";
 import Chip from "@/components/Chip/Chip.vue";
+import ClickToSearchLink from "@/components/ClickToSearchLink/ClickToSearchLink.vue";
 
 defineProps<{
   widget: TagListWidgetProps;

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -132,7 +132,7 @@ export function toClickToSearchUrl(
     return (
       config.instance.base.url +
       "/search/querySearch/" +
-      stripTags(cleanedLinkText)
+      encodeURIComponent(stripTags(cleanedLinkText))
     );
   }
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -534,11 +534,20 @@ const actions = (state: SearchStoreState) => ({
     filter.isFuzzy = isFuzzy;
   },
 
+  clearQuery() {
+    state.query.value = "";
+  },
+
   clearAllFilters() {
     this.clearCollectionIdFilters();
     this.clearSearchableFieldsFilters();
     state.filterBy.searchableFieldsOperator = "AND";
     state.filterBy.includeHiddenAssets = false;
+  },
+
+  reset() {
+    this.clearAllFilters();
+    this.clearQuery();
   },
 
   async getSearchId(): Promise<string> {
@@ -550,6 +559,7 @@ const actions = (state: SearchStoreState) => ({
   },
 
   async search(searchId: string): Promise<string | void> {
+    const instanceStore = useInstanceStore();
     // call all registered before handlers
     state.beforeNewSearchHandlers.forEach((fn) => fn());
 
@@ -586,6 +596,14 @@ const actions = (state: SearchStoreState) => ({
             state.filterBy.specificFieldsMap.clear();
 
             res.searchEntry.specificFieldSearch?.forEach((searchField) => {
+              // if the searchable field doesn't exist in our list of fields,
+              // then ignore it
+              if (!instanceStore.getSearchableField(searchField.field)) {
+                console.log("skipping search entry field", searchField.field);
+                return;
+              }
+
+              console.log("adding search entry field", searchField.field);
               actions(state).addSearchableFieldFilter(searchField.field, {
                 value: searchField.text,
                 isFuzzy: searchField.fuzzy,


### PR DESCRIPTION
This resolves an issue where widgets using `<ClickToSearchLink>` would do a full page refresh on click. Now`<ClickToSearch>` will now grab the searchID when clicked, and redirect to the search. 

The Tag widget is changed to wrap `<Chip>` with `<ClickToSearch>`  rather than pass a plain href to the `<Chip>` component.

This also encodes search text in the URI, resolving an issue with some click to search text  (`Africa & Asia`).

- Complements UMN-LATIS/elevator#139
- Resolves #104
- Supersedes #180

<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/c5405d05-3c4e-42af-8992-2d792ec5a1bb" width="500" />