### PR TITLE
Fix: only show add to drawers if users can add to drawers

### DIFF
--- a/src/components/ActiveFileViewToolbar/ActiveFileViewToolbar.vue
+++ b/src/components/ActiveFileViewToolbar/ActiveFileViewToolbar.vue
@@ -5,7 +5,7 @@
         <MoreFileInfoButton />
         <DownloadFileButton />
         <ShareButton />
-        <AddToDrawerButton />
+        <AddToDrawerButton v-if="instanceStore.currentUser?.canManageDrawers" />
         <AddToEmbeddedPluginButton
           v-if="isInEmbedMode"
           :fileHandlerId="fileHandlerId"
@@ -21,11 +21,13 @@ import ShareButton from "./ShareButton.vue";
 import AddToDrawerButton from "@/components/AddToDrawerButton/AddToDrawerButton.vue";
 import AddToEmbeddedPluginButton from "../AddToEmbeddedPluginButton/AddToEmbeddedPluginButton.vue";
 import { useElevatorSessionStorage } from "@/helpers/useElevatorSessionStorage";
+import { useInstanceStore } from "@/stores/instanceStore";
 
 defineProps<{
   fileHandlerId: string | null;
 }>();
 
+const instanceStore = useInstanceStore();
 const { isInEmbedMode } = useElevatorSessionStorage();
 </script>
 <style scoped></style>


### PR DESCRIPTION
This fixes an issue where the Add to Drawers button would show up for all users – whether they can add to drawers or not.  (I must have accidentally dropped the check when I moved the "Add to Drawers" button to the fileview toolbar.)
