### PR TITLE
Add feature: Users can remove assets from drawers from the drawer results page

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -22,6 +22,9 @@ import type {
   ApiGetDrawerResponse,
   WidgetProps,
   ApiCreateDrawerResponse,
+  ApiAddAssetToDrawerResponse,
+  ApiRemoveAssetFromDrawerResponse,
+  CustomAxiosRequestConfig,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -33,10 +36,6 @@ import { toClickToSearchUrl } from "@/helpers/displayUtils";
 const BASE_URL = config.instance.base.url;
 
 axios.defaults.withCredentials = true;
-
-interface CustomAxiosRequestConfig extends AxiosRequestConfig {
-  skipErrorNotifications?: boolean;
-}
 
 // this interceptor is used to catch errors from the API
 // convert them into API errors and store them in the error store
@@ -362,9 +361,22 @@ export async function addAssetToDrawer({
   formdata.append("objectId", assetId);
   formdata.append("drawerList", String(drawerId));
 
-  const res = await axios.post(
+  const res = await axios.post<ApiAddAssetToDrawerResponse>(
     `${BASE_URL}/drawers/addToDrawer/true`,
     formdata
+  );
+  return res.data;
+}
+
+export async function removeAssetFromDrawer({
+  assetId,
+  drawerId,
+}: {
+  assetId: string;
+  drawerId: number;
+}) {
+  const res = await axios.post<ApiRemoveAssetFromDrawerResponse>(
+    `${BASE_URL}/drawers/removeFromDrawer/${drawerId}/${assetId}/true`
   );
   return res.data;
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,6 +17,10 @@ import {
   TreeNode,
   Drawer,
   ApiGetDrawerResponse,
+  ApiAddAssetToDrawerResponse,
+  ApiRemoveAssetFromDrawerResponse,
+  ApiCreateDrawerResponse,
+  CustomAxiosRequestConfig,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import * as fetchers from "@/api/fetchers";
@@ -36,6 +40,7 @@ const collectionSearchIds = new Map<number, string | null>();
 const staticPages = new Map<number, ApiStaticPageResponse | null>();
 const searchableFieldDetails = new Map<string, ApiGetFieldInfoResponse>();
 const drawerDetails = new Map<number, ApiGetDrawerResponse | null>();
+let listOfDrawers: null | Drawer[] = null;
 
 async function getAsset(assetId: string): Promise<Asset | null> {
   if (!assetId) return null;
@@ -235,7 +240,6 @@ async function getSearchableMultiSelectFieldValues(
   return data?.rawContent ?? {};
 }
 
-let listOfDrawers: null | Drawer[] = null;
 async function getDrawers({
   refresh = false,
 }: {
@@ -270,6 +274,60 @@ export async function getDrawer(id: number): Promise<ApiGetDrawerResponse> {
   return data;
 }
 
+export async function addAssetToDrawer({
+  drawerId,
+  assetId,
+}: {
+  assetId: string;
+  drawerId: number;
+}): Promise<ApiAddAssetToDrawerResponse> {
+  const data = await fetchers.addAssetToDrawer({ drawerId, assetId });
+
+  // clear the cache for this drawer
+  drawerDetails.delete(drawerId);
+
+  return data;
+}
+
+export async function removeAssetFromDrawer({
+  assetId,
+  drawerId,
+}: {
+  assetId: string;
+  drawerId: number;
+}): Promise<ApiRemoveAssetFromDrawerResponse> {
+  const data = await fetchers.removeAssetFromDrawer({ drawerId, assetId });
+
+  // clear the cache for this drawer
+  drawerDetails.delete(drawerId);
+
+  return data;
+}
+
+export async function createDrawer(
+  drawerTitle: string,
+  customConfig: CustomAxiosRequestConfig = {}
+): Promise<ApiCreateDrawerResponse> {
+  const data = await fetchers.createDrawer(drawerTitle, customConfig);
+
+  // clear the list of drawers cache
+  listOfDrawers = null;
+
+  return data;
+}
+
+export async function deleteDrawer(
+  drawerId: number,
+  customConfig: CustomAxiosRequestConfig = {}
+): Promise<unknown> {
+  const data = await fetchers.deleteDrawer(drawerId, customConfig);
+
+  // clear the list of drawers cache
+  listOfDrawers = null;
+
+  return data;
+}
+
 const api = {
   getAsset,
   getAssetWithTemplate,
@@ -292,9 +350,10 @@ const api = {
   getSearchableMultiSelectFieldValues,
   getDrawers,
   getDrawer,
-  createDrawer: fetchers.createDrawer,
-  deleteDrawer: fetchers.deleteDrawer,
-  addAssetToDrawer: fetchers.addAssetToDrawer,
+  createDrawer,
+  deleteDrawer,
+  addAssetToDrawer,
+  removeAssetFromDrawer,
 };
 
 export default api;

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -1,9 +1,10 @@
 <template>
   <div
-    class="relative search-result-card border border-transparent rounded-md transition-colors"
+    class="relative search-result-card border-2 border-transparent rounded-md"
   >
     <button
-      class="bg-white w-6 h-6 text-neutral-300 inline-flex justify-center items-center absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 rounded-full shadow-sm hover:bg-neutral-900 hover:text-neutral-200 remove-from-drawer-btn group"
+      class="bg-white w-6 h-6 text-neutral-300 inline-flex justify-center items-center absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 rounded-full shadow-sm hover:bg-neutral-900 hover:text-neutral-200 remove-from-drawer-btn transition-all"
+      title="Remove from drawer"
     >
       <span class="sr-only">Remove from drawer</span>
       &times;
@@ -46,12 +47,6 @@
               </div>
             </dl>
           </div>
-          <div
-            class="absolute w-10 h-10 bottom-0 right-0 inline-flex justify-center items-center rounded-full group-hover:!bg-blue-700 group-hover:!text-white transition-colors"
-          >
-            <ArrowForwardIcon />
-            <span class="sr-only">View Asset</span>
-          </div>
         </div>
       </MediaCard>
     </Link>
@@ -65,7 +60,6 @@ import { computed, ref } from "vue";
 import MediaCard from "../MediaCard/MediaCard.vue";
 import Link from "@/components/Link/Link.vue";
 import Chip from "../Chip/Chip.vue";
-import { ArrowForwardIcon } from "@/icons";
 
 const props = defineProps<{
   searchMatch: SearchResultMatch;

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -1,8 +1,9 @@
 <template>
   <div
-    class="relative search-result-card border-2 border-transparent rounded-md"
+    class="relative search-result-card border-2 border-transparent rounded-lg"
   >
     <button
+      v-if="drawerId && instanceStore.currentUser?.canManageDrawers"
       class="bg-white w-6 h-6 text-neutral-300 inline-flex justify-center items-center absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 rounded-full shadow-sm hover:bg-neutral-900 hover:text-neutral-200 remove-from-drawer-btn transition-all"
       title="Remove from drawer"
     >
@@ -16,7 +17,7 @@
       <MediaCard
         :imgSrc="thumbnailImgSrc"
         :imgAlt="title"
-        class="search-result-card flex w-full h-full group-hover:bg-blue-50 group-hover:outline-offset-2 group-hover:text-blue-700 relative transition-colors"
+        class="search-result-card flex w-full h-full group-hover:bg-blue-50 group-hover:outline-offset-2 group-hover:text-blue-700 group-hover:border-blue-700 relative transition-colors"
       >
         <Chip
           v-if="searchMatch.fileAssets && searchMatch.fileAssets > 1"
@@ -60,12 +61,15 @@ import { computed, ref } from "vue";
 import MediaCard from "../MediaCard/MediaCard.vue";
 import Link from "@/components/Link/Link.vue";
 import Chip from "../Chip/Chip.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
 
 const props = defineProps<{
   searchMatch: SearchResultMatch;
+  drawerId?: number;
 }>();
 
 const cardContents = ref<HTMLElement | null>(null);
+const instanceStore = useInstanceStore();
 
 const title = computed(() => {
   if (Array.isArray(props.searchMatch.title)) {

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -1,51 +1,61 @@
 <template>
-  <Link
-    :to="getAssetUrl(searchMatch.objectId)"
-    class="group hover:no-underline relative"
+  <div
+    class="relative search-result-card border border-transparent rounded-md transition-colors"
   >
-    <MediaCard
-      :imgSrc="thumbnailImgSrc"
-      :imgAlt="title"
-      class="search-result-card flex w-full h-full group-hover:bg-blue-50 group-hover:border-blue-700 group-hover:outline-offset-2 group-hover:text-blue-700 relative transition-colors"
+    <button
+      class="bg-white w-6 h-6 text-neutral-300 inline-flex justify-center items-center absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 rounded-full shadow-sm hover:bg-neutral-900 hover:text-neutral-200 remove-from-drawer-btn group"
     >
-      <Chip
-        v-if="searchMatch.fileAssets && searchMatch.fileAssets > 1"
-        class="absolute top-1 right-1 z-10 !bg-neutral-900 !text-neutral-200 border !border-neutral-900 group-hover:!border-blue-700 group-hover:!bg-blue-100 group-hover:!text-blue-700 transition-colors"
+      <span class="sr-only">Remove from drawer</span>
+      &times;
+    </button>
+    <Link
+      :to="getAssetUrl(searchMatch.objectId)"
+      class="group hover:no-underline relative"
+    >
+      <MediaCard
+        :imgSrc="thumbnailImgSrc"
+        :imgAlt="title"
+        class="search-result-card flex w-full h-full group-hover:bg-blue-50 group-hover:outline-offset-2 group-hover:text-blue-700 relative transition-colors"
       >
-        {{ searchMatch.fileAssets }} files
-      </Chip>
-      <div ref="cardContents" class="relative h-full">
-        <h1
-          class="search-result-card__title font-bold leading-tight mb-2 group-hover:text-blue-700 transition-colors"
+        <Chip
+          v-if="searchMatch.fileAssets && searchMatch.fileAssets > 1"
+          class="absolute top-1 right-1 z-10 !bg-neutral-900 !text-neutral-200 border !border-neutral-900 group-hover:!border-blue-700 group-hover:!bg-blue-100 group-hover:!text-blue-700 transition-colors"
         >
-          {{ title }}
-        </h1>
-        <div
-          v-if="props.searchMatch?.entries"
-          class="search-result-card__contents max-h-[15rem] overflow-y-auto overflow-x-hidden"
-        >
-          <dl class="text-sm group-hover:text-blue-700 transition-colors">
-            <div
-              v-for="(entry, index) in props.searchMatch.entries"
-              :key="index"
-              class="mb-2"
-            >
-              <dt class="font-bold text-xs uppercase">
-                {{ entry?.label ?? "Item" }}
-              </dt>
-              <dd>{{ entry.entries?.join(", ") }}</dd>
-            </div>
-          </dl>
+          {{ searchMatch.fileAssets }} files
+        </Chip>
+        <div ref="cardContents" class="relative h-full">
+          <h1
+            class="search-result-card__title font-bold leading-tight mb-2 group-hover:text-blue-700 transition-colors"
+          >
+            {{ title }}
+          </h1>
+          <div
+            v-if="props.searchMatch?.entries"
+            class="search-result-card__contents max-h-[15rem] overflow-y-auto overflow-x-hidden"
+          >
+            <dl class="text-sm group-hover:text-blue-700 transition-colors">
+              <div
+                v-for="(entry, index) in props.searchMatch.entries"
+                :key="index"
+                class="mb-2"
+              >
+                <dt class="font-bold text-xs uppercase">
+                  {{ entry?.label ?? "Item" }}
+                </dt>
+                <dd>{{ entry.entries?.join(", ") }}</dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="absolute w-10 h-10 bottom-0 right-0 inline-flex justify-center items-center rounded-full group-hover:!bg-blue-700 group-hover:!text-white transition-colors"
+          >
+            <ArrowForwardIcon />
+            <span class="sr-only">View Asset</span>
+          </div>
         </div>
-        <div
-          class="absolute w-10 h-10 bottom-0 right-0 inline-flex justify-center items-center rounded-full group-hover:!bg-blue-700 group-hover:!text-white transition-colors"
-        >
-          <ArrowForwardIcon />
-          <span class="sr-only">View Asset</span>
-        </div>
-      </div>
-    </MediaCard>
-  </Link>
+      </MediaCard>
+    </Link>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -83,6 +93,10 @@ const thumbnailImgSrc = computed(() => {
 <style scoped>
 .search-result-card__title {
   color: var(--app-mediaCard-title-textColor);
+}
+
+.search-result-card:has(.remove-from-drawer-btn:hover) {
+  border-color: var(--neutral-900);
 }
 
 img {

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -3,11 +3,12 @@
     class="relative search-result-card border-2 border-transparent rounded-lg"
   >
     <button
-      v-if="drawerId && instanceStore.currentUser?.canManageDrawers"
+      v-if="showRemoveButton"
       class="bg-white w-6 h-6 text-neutral-300 inline-flex justify-center items-center absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 rounded-full shadow-sm hover:bg-neutral-900 hover:text-neutral-200 remove-from-drawer-btn transition-all"
-      title="Remove from drawer"
+      title="Remove"
+      @click="$emit('remove')"
     >
-      <span class="sr-only">Remove from drawer</span>
+      <span class="sr-only">Remove</span>
       &times;
     </button>
     <Link
@@ -61,15 +62,17 @@ import { computed, ref } from "vue";
 import MediaCard from "../MediaCard/MediaCard.vue";
 import Link from "@/components/Link/Link.vue";
 import Chip from "../Chip/Chip.vue";
-import { useInstanceStore } from "@/stores/instanceStore";
 
 const props = defineProps<{
   searchMatch: SearchResultMatch;
-  drawerId?: number;
+  showRemoveButton: boolean;
+}>();
+
+defineEmits<{
+  (eventName: "remove"): void;
 }>();
 
 const cardContents = ref<HTMLElement | null>(null);
-const instanceStore = useInstanceStore();
 
 const title = computed(() => {
   if (Array.isArray(props.searchMatch.title)) {

--- a/src/components/SearchResultsGrid/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid/SearchResultsGrid.vue
@@ -7,6 +7,7 @@
         :key="match.objectId"
         :searchMatch="match"
         :showDetails="false"
+        :drawerId="drawerId"
       />
       <SkeletonCard
         v-for="i in Math.min(30, (totalResults ?? Infinity) - matches.length)"
@@ -27,6 +28,7 @@ const props = defineProps<{
   totalResults?: number;
   matches: SearchResultMatch[];
   status: FetchStatus;
+  drawerId?: number;
 }>();
 
 const emits = defineEmits<{

--- a/src/components/SearchResultsGrid/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid/SearchResultsGrid.vue
@@ -7,7 +7,8 @@
         :key="match.objectId"
         :searchMatch="match"
         :showDetails="false"
-        :drawerId="drawerId"
+        :showRemoveButton="showRemoveButton"
+        @remove="$emit('remove', match.objectId)"
       />
       <SkeletonCard
         v-for="i in Math.min(30, (totalResults ?? Infinity) - matches.length)"
@@ -24,15 +25,24 @@ import { computed, watch } from "vue";
 import { FetchStatus, SearchResultMatch } from "@/types";
 import { useScroll } from "@vueuse/core";
 
-const props = defineProps<{
-  totalResults?: number;
-  matches: SearchResultMatch[];
-  status: FetchStatus;
-  drawerId?: number;
-}>();
+const props = withDefaults(
+  defineProps<{
+    totalResults?: number;
+    matches: SearchResultMatch[];
+    status: FetchStatus;
+    drawerId?: number;
+    showRemoveButton?: boolean;
+  }>(),
+  {
+    totalResults: undefined,
+    drawerId: undefined,
+    showRemoveButton: false,
+  }
+);
 
 const emits = defineEmits<{
   (event: "loadMore");
+  (event: "remove", objectId: string);
 }>();
 
 const { arrivedState } = useScroll(window, {

--- a/src/components/ToastRoot/ToastRoot.vue
+++ b/src/components/ToastRoot/ToastRoot.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="notification-root fixed bottom-0 sm:top-0 right-0 z-50 p-4 w-full max-w-sm pointer-events-none flex flex-col items-end gap-1"
+    class="notification-root fixed top-12 right-0 z-50 p-4 w-full max-w-sm pointer-events-none flex flex-col items-end gap-1"
   >
     <TransitionGroup name="fade">
       <Toast

--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -33,6 +33,7 @@
               :totalResults="results.length"
               :matches="results"
               :status="fetchStatus"
+              :drawerId="drawerId"
             />
           </Tab>
           <Tab id="list" label="List">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
 import type { Ref } from "vue";
 import { SEARCH_RESULTS_VIEWS, SORT_KEYS } from "@/constants/constants";
+import { AxiosRequestConfig } from "axios";
+
 export * from "./TimelineJSTypes";
 
 export interface AppConfig {
@@ -715,8 +717,19 @@ export interface ApiGetDrawerResponse extends SearchResultsResponse {
 
 export type ApiCreateDrawerResponse = ApiGetDrawerResponse;
 
+export interface ApiAddAssetToDrawerResponse {
+  success?: boolean;
+  error?: string;
+}
+
+export type ApiRemoveAssetFromDrawerResponse = ApiAddAssetToDrawerResponse;
+
 export interface Toast {
   id: string;
   message: string;
   duration?: number;
+}
+
+export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+  skipErrorNotifications?: boolean;
 }


### PR DESCRIPTION
This adds a remove button to the assets listed on a drawer view page so that a user can remove the asset from the drawer:

![ScreenShot 2023-07-03 at 17 40 22](https://github.com/UMN-LATIS/elevator-ui/assets/980170/f2379886-4d12-48ee-a54a-d0c00b6306fd)

Also fixes some cache-busting issues when mutating drawers.