### PR TITLE
Fix tags showing up in confirm modal

### DIFF
--- a/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
+++ b/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
@@ -26,6 +26,7 @@
 import { ref, computed } from "vue";
 import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import { useDrawerStore } from "@/stores/drawerStore";
+import { getAssetTitle, stripTags } from "@/helpers/displayUtils";
 
 const props = defineProps<{
   drawerId: number;
@@ -42,7 +43,9 @@ const object = computed(() =>
 
 const isConfirmModalOpen = ref(false);
 const objectTitle = computed(() => {
-  return object.value?.title;
+  const rawTitle = object.value?.title;
+  if (!rawTitle) return null;
+  return Array.isArray(rawTitle) ? stripTags(rawTitle[0]) : stripTags(rawTitle);
 });
 
 const drawerTitle = computed(() => {

--- a/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
+++ b/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
@@ -26,7 +26,7 @@
 import { ref, computed } from "vue";
 import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import { useDrawerStore } from "@/stores/drawerStore";
-import { getAssetTitle, stripTags } from "@/helpers/displayUtils";
+import { stripTags } from "@/helpers/displayUtils";
 
 const props = defineProps<{
   drawerId: number;


### PR DESCRIPTION
Strips any tags from the object title within the confirm modal.

Resolves #189

<img width="400" alt="ScreenShot 2023-07-06 at 09 51 12@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/ec0f32de-b780-4f09-a22f-4f2c7c8e30b5">
