### PR TITLE
add custom sort type

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "vue": "^3.3.4",
     "vue-router": "4",
     "vue-toasted": "^1.1.28",
-    "vue3-popper": "^1.5.0"
+    "vue3-popper": "^1.5.0",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -401,3 +401,18 @@ export async function setDrawerSortBy(
 
   return res.data;
 }
+
+export async function setCustomDrawerOrder(
+  drawerId: number,
+  assetIds: string[]
+) {
+  const formdata = new FormData();
+  formdata.append("orderArray", JSON.stringify(assetIds));
+
+  const res = await axios.post(
+    `${BASE_URL}/drawers/setCustomOrder/${drawerId}`,
+    formdata
+  );
+
+  return res.data;
+}

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -3,7 +3,7 @@
  * any caching should happen in API getters.
  */
 
-import axios, { AxiosError, AxiosRequestConfig } from "axios";
+import axios, { AxiosError } from "axios";
 import { omit } from "ramda";
 import config from "@/config";
 import type {
@@ -25,6 +25,7 @@ import type {
   ApiAddAssetToDrawerResponse,
   ApiRemoveAssetFromDrawerResponse,
   CustomAxiosRequestConfig,
+  DrawerSortOptions,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -387,5 +388,16 @@ export async function removeAssetFromDrawer({
   const res = await axios.post<ApiRemoveAssetFromDrawerResponse>(
     `${BASE_URL}/drawers/removeFromDrawer/${drawerId}/${assetId}/true`
   );
+  return res.data;
+}
+
+export async function setDrawerSortBy(
+  drawerId: number,
+  sortBy: DrawerSortOptions
+) {
+  const res = await axios.post(
+    `${BASE_URL}/drawers/setSortOrder/${drawerId}/${sortBy}/true`
+  );
+
   return res.data;
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -356,6 +356,18 @@ export async function setDrawerSortBy(
   return data;
 }
 
+export async function setCustomDrawerOrder(
+  drawerId: number,
+  assetIds: string[]
+) {
+  const data = await fetchers.setCustomDrawerOrder(drawerId, assetIds);
+
+  // clear the drawer cache
+  drawerDetails.delete(drawerId);
+
+  return data;
+}
+
 const api = {
   getAsset,
   getAssetWithTemplate,
@@ -384,6 +396,7 @@ const api = {
   addAssetListToDrawer,
   removeAssetFromDrawer,
   setDrawerSortBy,
+  setCustomDrawerOrder,
 };
 
 export default api;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,6 +21,7 @@ import {
   ApiRemoveAssetFromDrawerResponse,
   ApiCreateDrawerResponse,
   CustomAxiosRequestConfig,
+  DrawerSortOptions,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import * as fetchers from "@/api/fetchers";
@@ -343,6 +344,18 @@ export async function deleteDrawer(
   return data;
 }
 
+export async function setDrawerSortBy(
+  drawerId: number,
+  sortBy: DrawerSortOptions
+) {
+  const data = await fetchers.setDrawerSortBy(drawerId, sortBy);
+
+  // clear the drawer cache
+  drawerDetails.delete(drawerId);
+
+  return data;
+}
+
 const api = {
   getAsset,
   getAssetWithTemplate,
@@ -370,6 +383,7 @@ const api = {
   addAssetToDrawer,
   addAssetListToDrawer,
   removeAssetFromDrawer,
+  setDrawerSortBy,
 };
 
 export default api;

--- a/src/components/MediaCard/MediaCard.vue
+++ b/src/components/MediaCard/MediaCard.vue
@@ -21,6 +21,7 @@
 
     <component
       :is="to ? Link : 'div'"
+      :to="to"
       class="flex-1 p-4 media-card__body hover:no-underline"
     >
       <slot />

--- a/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
+++ b/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="bg-white w-6 h-6 text-neutral-500 inline-flex justify-center items-center rounded-full shadow-sm hover:bg-neutral-900 hover:text-neutral-200 transition-all"
+    class="bg-white w-6 h-6 text-neutral-500 inline-flex justify-center items-center rounded-full shadow-sm border border-neutral-200 hover:bg-neutral-900 hover:text-neutral-200 transition-all"
     title="Remove"
     v-bind="$attrs"
     @click="isConfirmModalOpen = true"

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="relative search-result-card border-2 border-transparent rounded-lg"
-  >
+  <div class="relative search-result-card rounded-lg">
     <RemoveFromDrawerButton
       v-if="drawerId && instanceStore.currentUser?.canManageDrawers"
       class="absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 remove-from-drawer-btn"
@@ -14,6 +12,7 @@
       :imgAlt="title"
       :to="assetUrl"
       class="search-result-card flex w-full h-full relative transition-colors"
+      :class="mediaCardClass"
     >
       <Chip
         v-if="searchMatch.fileAssets && searchMatch.fileAssets > 1"
@@ -59,13 +58,13 @@ import { getAssetUrl, getThumbURL, stripTags } from "@/helpers/displayUtils";
 import { computed } from "vue";
 import MediaCard from "../MediaCard/MediaCard.vue";
 import Chip from "../Chip/Chip.vue";
-import AddToDrawerButton from "../AddToDrawerButton/AddToDrawerButton.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import RemoveFromDrawerButton from "@/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue";
 
 const props = defineProps<{
   searchMatch: SearchResultMatch;
   drawerId?: number;
+  mediaCardClass?: string | string[] | Record<string, boolean>;
 }>();
 
 const instanceStore = useInstanceStore();

--- a/src/components/SearchResultRow/SearchResultRow.vue
+++ b/src/components/SearchResultRow/SearchResultRow.vue
@@ -1,50 +1,46 @@
 <template>
   <Link
     :to="getAssetUrl(searchMatch.objectId)"
-    class="group hover:no-underline relative text-inherit group focus:outline-blue-700 focus:outline-offset-2 focus-within:outline-solid"
+    class="group hover:no-underline relative text-inherit group focus:outline-blue-600 focus:outline-offset-2 focus-within:outline-solid search-result-row flex bg-white p-2 sm:p-4 gap-4 group-hover:bg-blue-50 transition-all rounded-md border-2 border-transparent hover:border-blue-600 group-focus:bg-blue-50 group-focus:border-blue-600 items-center"
   >
-    <div
-      class="search-result-row flex bg-white p-2 sm:p-4 gap-4 group-hover:bg-blue-50 transition-all rounded-md border-2 border-transparent hover:border-blue-700 group-focus:bg-blue-50 group-focus:border-blue-700 items-center"
-    >
-      <LazyLoadImage
-        v-if="imgSrc"
-        :src="imgSrc"
-        :alt="title"
-        class="h-8 w-8 sm:h-16 sm:w-16 object-cover rounded-md overflow-hidden"
-      />
-      <div v-else class="h-8 w-8 sm:h-16 sm:w-16" />
-      <div class="flex-1">
-        <h1
-          class="font-bold text-md sm:text-lg leading-tight sm:mb-2 group-hover:text-blue-700 group-focus:text-blue-700"
-        >
-          {{ title }}
-        </h1>
-
-        <dl
-          v-if="props.searchMatch?.entries"
-          class="inline-flex items-baseline gap-x-4 sm:gap-y-2 flex-wrap m-0"
-        >
-          <div
-            v-for="(entry, index) in props.searchMatch.entries"
-            :key="index"
-            class="inline-flex items-baseline gap-x-2 flex-wrap text-neutral-400 group-hover:text-blue-700 group-focus:text-blue-700"
-          >
-            <dt class="text-xs uppercase">
-              {{ entry?.label || "Item" }}
-            </dt>
-            <dd class="text-sm">
-              {{ entry.entries?.join(", ") }}
-            </dd>
-          </div>
-        </dl>
-      </div>
-      <div
-        class="not-sr-only hidden sm:inline-flex self-center rounded-full w-10 h-10 items-center justify-center group-hover:bg-blue-700 transition-all"
+    <LazyLoadImage
+      v-if="imgSrc"
+      :src="imgSrc"
+      :alt="title"
+      class="h-8 w-8 sm:h-16 sm:w-16 object-cover rounded-md overflow-hidden"
+    />
+    <div v-else class="h-8 w-8 sm:h-16 sm:w-16" />
+    <div class="flex-1">
+      <h1
+        class="font-bold text-md sm:text-lg leading-tight sm:mb-2 group-hover:text-blue-700 group-focus:text-blue-700"
       >
-        <ArrowForwardIcon
-          class="text-neutral-900 group-hover:text-white transition-all"
-        />
-      </div>
+        {{ title }}
+      </h1>
+
+      <dl
+        v-if="props.searchMatch?.entries"
+        class="inline-flex items-baseline gap-x-4 sm:gap-y-2 flex-wrap m-0"
+      >
+        <div
+          v-for="(entry, index) in props.searchMatch.entries"
+          :key="index"
+          class="inline-flex items-baseline gap-x-2 flex-wrap text-neutral-400 group-hover:text-blue-700 group-focus:text-blue-700"
+        >
+          <dt class="text-xs uppercase">
+            {{ entry?.label || "Item" }}
+          </dt>
+          <dd class="text-sm">
+            {{ entry.entries?.join(", ") }}
+          </dd>
+        </div>
+      </dl>
+    </div>
+    <div
+      class="not-sr-only hidden sm:inline-flex self-center rounded-full w-10 h-10 items-center justify-center group-hover:bg-blue-700 transition-all"
+    >
+      <ArrowForwardIcon
+        class="text-neutral-900 group-hover:text-white transition-all"
+      />
     </div>
   </Link>
 </template>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -23,6 +23,7 @@ export const SORT_KEYS = {
   TITLE: "title.raw",
   LAST_MODIFIED_DESC: "lastModified.desc",
   LAST_MODIFIED_ASC: "lastModified.asc",
+  CUSTOM: "custom",
 } as const;
 
 // these are ids for searchable fields that don't actually exist

--- a/src/icons/DragIcon.vue
+++ b/src/icons/DragIcon.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M7 19v-2h2v2H7m4 0v-2h2v2h-2m4 0v-2h2v2h-2m-8-4v-2h2v2H7m4 0v-2h2v2h-2m4 0v-2h2v2h-2m-8-4V9h2v2H7m4 0V9h2v2h-2m4 0V9h2v2h-2M7 7V5h2v2H7m4 0V5h2v2h-2m4 0V5h2v2h-2Z"
+    />
+  </svg>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -11,6 +11,7 @@ export { default as CircleIcon } from "./CircleIcon.vue";
 export { default as CircleXIcon } from "./CircleXIcon.vue";
 export { default as DocumentIcon } from "./DocumentIcon.vue";
 export { default as DownloadIcon } from "./DownloadIcon.vue";
+export { default as DragIcon } from "./DragIcon.vue";
 export { default as ElevatorIcon } from "./ElevatorIcon.vue";
 export { default as ExitFullscreenIcon } from "./ExitFullscreenIcon.vue";
 export { default as EyeIcon } from "./EyeIcon.vue";

--- a/src/pages/DrawerViewPage/DrawerItemsGrid.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="containerRef">
+  <div class="drawer-items-grid">
     <Draggable
       v-model="clonedMatches"
       class="grid grid-cols-auto-md gap-4"
@@ -64,8 +64,6 @@ const emits = defineEmits<{
   (event: "loadMore");
   (event: "dragEnd", matches: SearchResultMatch[]);
 }>();
-
-const containerRef = ref<HTMLElement | null>(null);
 
 // Clone the matches so that we can use them with v-model
 // in the draggable component

--- a/src/pages/DrawerViewPage/DrawerItemsGrid.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsGrid.vue
@@ -11,10 +11,12 @@
       @end="emits('dragEnd', clonedMatches)"
     >
       <template #item="{ element }">
-        <div class="item-container relative rounded flex items-start group">
+        <div
+          class="item-container relative rounded flex items-start group shadow-sm"
+        >
           <div
             v-if="isDraggable"
-            class="drag-handle cursor-move h-full py-1 rounded-l border border-l-0 group-hover:bg-blue-600 group-hover:border-blue-600 group-hover:text-blue-100 transition-colors"
+            class="drag-handle cursor-move h-full py-1 rounded-l border border-r-0 group-hover:bg-blue-600 group-hover:border-blue-600 group-hover:text-blue-100 transition-colors"
           >
             <DragIcon />
           </div>
@@ -27,7 +29,7 @@
             class="search-result-card h-full flex-1 !rounded-l-none"
             :mediaCardClass="[
               'group-hover:bg-blue-50 group-hover:border-blue-600 group-hover:!text-blue-600',
-              isDraggable ? 'rounded-l-none border-l-none' : '',
+              isDraggable ? 'rounded-l-none !border-l-0 shadow-none' : '',
             ]"
           />
         </div>

--- a/src/pages/DrawerViewPage/DrawerItemsGrid.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsGrid.vue
@@ -1,0 +1,117 @@
+<template>
+  <div ref="containerRef">
+    <Draggable
+      v-model="clonedMatches"
+      class="grid grid-cols-auto-md gap-4"
+      itemKey="objectId"
+      handle=".drag-handle"
+      ghostClass="draggable-ghost"
+      dragClass="is-dragging"
+      :disabled="!isDraggable"
+      @end="emits('dragEnd', clonedMatches)"
+    >
+      <template #item="{ element }">
+        <div class="relative rounded">
+          <div
+            v-if="isDraggable"
+            class="drag-handle cursor-move absolute top-1 left-1 p-2 z-10 rounded-tl bg-transparent-black-50 hover:bg-neutral-900 hover:text-neutral-100"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+            >
+              <path
+                fill="currentColor"
+                d="M7 19v-2h2v2H7m4 0v-2h2v2h-2m4 0v-2h2v2h-2m-8-4v-2h2v2H7m4 0v-2h2v2h-2m4 0v-2h2v2h-2m-8-4V9h2v2H7m4 0V9h2v2h-2m4 0V9h2v2h-2M7 7V5h2v2H7m4 0V5h2v2h-2m4 0V5h2v2h-2Z"
+              />
+            </svg>
+          </div>
+
+          <SearchResultCard
+            :id="`object-${element.objectId}`"
+            :searchMatch="element"
+            :showDetails="false"
+            :drawerId="drawerId"
+            class="search-result-card h-full"
+          />
+        </div>
+      </template>
+    </Draggable>
+  </div>
+</template>
+<script setup lang="ts">
+import SearchResultCard from "@/components/SearchResultCard/SearchResultCard.vue";
+import { computed, watch, ref } from "vue";
+import { FetchStatus, SearchResultMatch } from "@/types";
+import { useScroll } from "@vueuse/core";
+import Draggable from "vuedraggable";
+
+const props = withDefaults(
+  defineProps<{
+    totalResults?: number;
+    matches: SearchResultMatch[];
+    status: FetchStatus;
+    drawerId?: number;
+    isDraggable?: boolean;
+  }>(),
+  {
+    totalResults: undefined,
+    drawerId: undefined,
+    isDraggable: false,
+  }
+);
+
+const emits = defineEmits<{
+  (event: "loadMore");
+  (event: "dragEnd", matches: SearchResultMatch[]);
+}>();
+
+const containerRef = ref<HTMLElement | null>(null);
+
+// Clone the matches so that we can use them with v-model
+// in the draggable component
+const clonedMatches = ref<SearchResultMatch[]>(props.matches);
+
+// Update the clonedMatches when the props.matches changes
+watch(
+  () => props.matches,
+  (matches) => {
+    clonedMatches.value = matches;
+  }
+);
+
+const { arrivedState } = useScroll(window, {
+  offset: { bottom: 100 },
+});
+
+watch(
+  arrivedState,
+  (arrived) => {
+    if (arrived.bottom && hasMoreResults.value && props.status !== "fetching") {
+      emits("loadMore");
+    }
+  },
+  { immediate: true }
+);
+
+const hasMoreResults = computed(() => {
+  return (props.totalResults ?? Infinity) > props.matches.length;
+});
+</script>
+<style scoped>
+.draggable-ghost {
+  opacity: 0.5;
+  background: var(--color-blue-100);
+  border-radius: 0.25rem;
+}
+
+.is-dragging .search-result-card {
+  background: #fff;
+}
+.is-dragging .drag-handle {
+  background: var(--color-neutral-900);
+  color: var(--color-neutral-100);
+}
+</style>

--- a/src/pages/DrawerViewPage/DrawerItemsGrid.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsGrid.vue
@@ -96,6 +96,11 @@ const hasMoreResults = computed(() => {
 });
 </script>
 <style scoped>
+.grid {
+  /* give all rows the same height to avoid height change with drag/drop */
+  grid-auto-rows: 1fr;
+}
+
 .drag-handle {
   background: white;
   border: var(--app-mediaCard-borderWidth) solid

--- a/src/pages/DrawerViewPage/DrawerItemsList.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsList.vue
@@ -90,13 +90,6 @@ const hasMoreResults = computed(() => {
 });
 </script>
 <style scoped>
-/* .drag-handle {
-  background: white;
-  border: var(--app-mediaCard-borderWidth) solid
-    var(--app-mediaCard-borderColor);
-  border-right: none;
-} */
-
 .draggable-ghost {
   opacity: 0.5;
   /* border-radius: 0.25rem; */

--- a/src/pages/DrawerViewPage/DrawerItemsList.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsList.vue
@@ -11,10 +11,10 @@
       @end="emits('dragEnd', clonedMatches)"
     >
       <template #item="{ element }">
-        <div class="item-container relative rounded flex group">
+        <div class="item-container relative rounded flex group shadow-sm">
           <div
             v-if="isDraggable"
-            class="drag-handle cursor-move py-1 rounded-l border border-l-0 group-hover:bg-blue-600 group-hover:border-blue-600 group-hover:text-blue-100 transition-colors"
+            class="drag-handle cursor-move py-1 rounded-l group-hover:bg-blue-600 group-hover:border-blue-600 group-hover:text-blue-100 transition-colors bg-white"
           >
             <DragIcon />
           </div>
@@ -90,12 +90,12 @@ const hasMoreResults = computed(() => {
 });
 </script>
 <style scoped>
-.drag-handle {
+/* .drag-handle {
   background: white;
   border: var(--app-mediaCard-borderWidth) solid
     var(--app-mediaCard-borderColor);
   border-right: none;
-}
+} */
 
 .draggable-ghost {
   opacity: 0.5;

--- a/src/pages/DrawerViewPage/DrawerItemsList.vue
+++ b/src/pages/DrawerViewPage/DrawerItemsList.vue
@@ -1,8 +1,8 @@
 <template>
-  <div ref="containerRef">
+  <div>
     <Draggable
       v-model="clonedMatches"
-      class="grid grid-cols-auto-md gap-4"
+      class="flex flex-col gap-2"
       itemKey="objectId"
       handle=".drag-handle"
       ghostClass="draggable-ghost"
@@ -11,24 +11,22 @@
       @end="emits('dragEnd', clonedMatches)"
     >
       <template #item="{ element }">
-        <div class="item-container relative rounded flex items-start group">
+        <div class="item-container relative rounded flex group">
           <div
             v-if="isDraggable"
-            class="drag-handle cursor-move h-full py-1 rounded-l border border-l-0 group-hover:bg-blue-600 group-hover:border-blue-600 group-hover:text-blue-100 transition-colors"
+            class="drag-handle cursor-move py-1 rounded-l border border-l-0 group-hover:bg-blue-600 group-hover:border-blue-600 group-hover:text-blue-100 transition-colors"
           >
             <DragIcon />
           </div>
-
-          <SearchResultCard
+          <SearchResultRow
             :id="`object-${element.objectId}`"
+            :key="element.objectId"
             :searchMatch="element"
             :showDetails="false"
-            :drawerId="drawerId"
-            class="search-result-card h-full flex-1 !rounded-l-none"
-            :mediaCardClass="[
-              'group-hover:bg-blue-50 group-hover:border-blue-600 group-hover:!text-blue-600',
-              isDraggable ? 'rounded-l-none border-l-none' : '',
-            ]"
+            class="search-result-row flex-1"
+            :class="{
+              'rounded-l-none border-l-none': isDraggable,
+            }"
           />
         </div>
       </template>
@@ -36,10 +34,10 @@
   </div>
 </template>
 <script setup lang="ts">
-import SearchResultCard from "@/components/SearchResultCard/SearchResultCard.vue";
 import { computed, watch, ref } from "vue";
 import { FetchStatus, SearchResultMatch } from "@/types";
 import { useScroll } from "@vueuse/core";
+import SearchResultRow from "@/components/SearchResultRow/SearchResultRow.vue";
 import Draggable from "vuedraggable";
 import { DragIcon } from "@/icons";
 
@@ -48,12 +46,10 @@ const props = withDefaults(
     totalResults?: number;
     matches: SearchResultMatch[];
     status: FetchStatus;
-    drawerId?: number;
     isDraggable?: boolean;
   }>(),
   {
     totalResults: undefined,
-    drawerId: undefined,
     isDraggable: false,
   }
 );
@@ -62,8 +58,6 @@ const emits = defineEmits<{
   (event: "loadMore");
   (event: "dragEnd", matches: SearchResultMatch[]);
 }>();
-
-const containerRef = ref<HTMLElement | null>(null);
 
 // Clone the matches so that we can use them with v-model
 // in the draggable component
@@ -124,7 +118,7 @@ const hasMoreResults = computed(() => {
   color: var(--color-blue-100);
 }
 
-.is-dragging .search-result-card {
+.is-dragging .search-result-row {
   background: #fff;
 }
 </style>

--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -1,65 +1,65 @@
 <template>
   <DefaultLayout class="drawer-view-page">
-    <Transition name="fade">
-      <div class="px-4">
-        <header class="my-8">
-          <Link
-            :to="`/drawers/listDrawers`"
-            class="flex items-center gap-1 mb-4 hover:no-underline"
-          >
-            <ArrowForwardIcon class="transform rotate-180 h-4 w-4" />
-            Back to Drawers
-          </Link>
-          <h2 class="text-4xl font-bold">{{ drawerTitle }}</h2>
-        </header>
-
-        <Tabs
-          labelsClass="drawer-view-page__tabs sticky top-14 z-20  -mx-4 px-4 border-b border-neutral-200 pt-4"
-          :activeTabId="activeTabId"
-          @tabChange="handleTabChange"
+    <div class="px-4">
+      <header class="my-8">
+        <Link
+          :to="`/drawers/listDrawers`"
+          class="flex items-center gap-1 mb-4 hover:no-underline"
         >
-          <div
-            class="bg-transparent-black-50 rounded-md mb-4 sm:flex justify-between items-center p-2"
-          >
-            <div>
-              <ResultsCount
-                v-if="drawer.contents"
-                class="mb-2 sm:mb-0"
-                :total="drawer.contents.totalResults"
-                :fetchStatus="fetchStatus"
-                :showingCount="drawer.contents.matches.length"
-                @loadMore="handleLoadMore"
-                @loadAll="handleLoadAll"
-              />
+          <ArrowForwardIcon class="transform rotate-180 h-4 w-4" />
+          Back to Drawers
+        </Link>
+        <h2 class="text-4xl font-bold">{{ drawerTitle }}</h2>
+      </header>
 
-              <div
-                v-else
-                class="flex items-center gap-2 text-neutral-500 text-sm"
-              >
-                <SpinnerIcon class="animate-spin h-5 w-5" />
-                Loading...
-              </div>
-            </div>
-            <div class="flex items-baseline gap-2">
-              <label for="location" class="sr-only">Sort</label>
-              <select
-                id="sort"
-                name="sort"
-                class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-neutral-900 ring-1 ring-inset ring-neutral-300 focus:ring-2 focus:ring-indigo-600 text-sm sm:leading-6 max-w-full bg-transparent-white-800"
-                :value="selectedSortOption"
-                @change="handleSortOptionChange"
-              >
-                <option
-                  v-for="(sortOptionLabel, sortOptionKey) in sortOptions"
-                  :key="sortOptionKey"
-                  :value="sortOptionKey"
-                >
-                  {{ sortOptionLabel }}
-                </option>
-              </select>
+      <Tabs
+        labelsClass="drawer-view-page__tabs sticky top-14 z-20  -mx-4 px-4 border-b border-neutral-200 pt-4"
+        :activeTabId="activeTabId"
+        @tabChange="handleTabChange"
+      >
+        <div
+          class="bg-transparent-black-50 rounded-md mb-4 sm:flex justify-between items-center p-2"
+        >
+          <div>
+            <ResultsCount
+              v-if="drawer.contents"
+              class="mb-2 sm:mb-0"
+              :total="drawer.contents.totalResults"
+              :fetchStatus="fetchStatus"
+              :showingCount="drawer.contents.matches.length"
+              @loadMore="handleLoadMore"
+              @loadAll="handleLoadAll"
+            />
+
+            <div
+              v-else
+              class="flex items-center gap-2 text-neutral-500 text-sm"
+            >
+              <SpinnerIcon class="animate-spin h-5 w-5" />
+              Loading...
             </div>
           </div>
-          <Tab id="grid" label="Grid">
+          <div class="flex items-baseline gap-2">
+            <label for="location" class="sr-only">Sort</label>
+            <select
+              id="sort"
+              name="sort"
+              class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-neutral-900 ring-1 ring-inset ring-neutral-300 focus:ring-2 focus:ring-indigo-600 text-sm sm:leading-6 max-w-full bg-transparent-white-800"
+              :value="selectedSortOption"
+              @change="handleSortOptionChange"
+            >
+              <option
+                v-for="(sortOptionLabel, sortOptionKey) in sortOptions"
+                :key="sortOptionKey"
+                :value="sortOptionKey"
+              >
+                {{ sortOptionLabel }}
+              </option>
+            </select>
+          </div>
+        </div>
+        <Tab id="grid" label="Grid">
+          <Transition name="fade">
             <DrawerItemsGrid
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
@@ -69,8 +69,10 @@
               :isDraggable="selectedSortOption === SORT_KEYS.CUSTOM"
               @dragEnd="handleDragEnd"
             />
-          </Tab>
-          <Tab id="list" label="List">
+          </Transition>
+        </Tab>
+        <Tab id="list" label="List">
+          <Transition name="fade">
             <DrawerItemsList
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
@@ -80,34 +82,40 @@
               :isDraggable="selectedSortOption === SORT_KEYS.CUSTOM"
               @dragEnd="handleDragEnd"
             />
-          </Tab>
-          <Tab id="timeline" label="Timeline">
+          </Transition>
+        </Tab>
+        <Tab id="timeline" label="Timeline">
+          <Transition name="fade">
             <SearchResultsTimeline
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
               :matches="drawer.contents.matches"
               :status="fetchStatus"
             />
-          </Tab>
-          <Tab id="map" label="Map">
+          </Transition>
+        </Tab>
+        <Tab id="map" label="Map">
+          <Transition name="fade">
             <SearchResultsMap
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
               :matches="drawer.contents.matches"
               :status="fetchStatus"
             />
-          </Tab>
-          <Tab id="gallery" label="Gallery">
+          </Transition>
+        </Tab>
+        <Tab id="gallery" label="Gallery">
+          <Transition name="fade">
             <SearchResultsGallery
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
               :matches="drawer.contents.matches"
               :status="fetchStatus"
             />
-          </Tab>
-        </Tabs>
-      </div>
-    </Transition>
+          </Transition>
+        </Tab>
+      </Tabs>
+    </div>
   </DefaultLayout>
 </template>
 <script setup lang="ts">

--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -71,11 +71,14 @@
             />
           </Tab>
           <Tab id="list" label="List">
-            <SearchResultsList
+            <DrawerItemsList
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
               :matches="drawer.contents.matches"
               :status="fetchStatus"
+              :drawerId="drawerId"
+              :isDraggable="selectedSortOption === SORT_KEYS.CUSTOM"
+              @dragEnd="handleDragEnd"
             />
           </Tab>
           <Tab id="timeline" label="Timeline">
@@ -133,6 +136,7 @@ import { SORT_KEYS } from "@/constants/constants";
 import { useErrorStore } from "@/stores/errorStore";
 import SpinnerIcon from "@/icons/SpinnerIcon.vue";
 import DrawerItemsGrid from "./DrawerItemsGrid.vue";
+import DrawerItemsList from "./DrawerItemsList.vue";
 
 const props = withDefaults(
   defineProps<{

--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -116,8 +116,6 @@ import { useRouter, useRoute } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import Tab from "@/components/Tabs/Tab.vue";
 import Tabs from "@/components/Tabs/Tabs.vue";
-import SearchResultsGrid from "@/components/SearchResultsGrid/SearchResultsGrid.vue";
-import SearchResultsList from "@/components/SearchResultsList/SearchResultsList.vue";
 import SearchResultsTimeline from "@/components/SearchResultsTimeline/SearchResultsTimeline.vue";
 import SearchResultsMap from "@/components/SearchResultsMap/SearchResultsMap.vue";
 import SearchResultsGallery from "@/components/SearchResultsGallery/SearchResultsGallery.vue";
@@ -144,11 +142,18 @@ const props = withDefaults(
     resultsView?: SearchResultsView;
   }>(),
   {
-    resultsView: undefined,
+    resultsView: "grid",
   }
 );
 
-const activeTabId = ref<SearchResultsView>("grid");
+const isValidResultsView = (view: string): view is SearchResultsView => {
+  return SEARCH_RESULTS_VIEWS.includes(view as SearchResultsView);
+};
+
+const initialTab = isValidResultsView(props.resultsView)
+  ? props.resultsView
+  : "grid";
+const activeTabId = ref<SearchResultsView>(initialTab);
 const fetchStatus = ref<FetchStatus>("idle");
 
 const drawerStore = useDrawerStore();

--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -60,12 +60,14 @@
             </div>
           </div>
           <Tab id="grid" label="Grid">
-            <SearchResultsGrid
+            <DrawerItemsGrid
               v-if="drawer.contents"
               :totalResults="drawer.contents.totalResults"
               :matches="drawer.contents.matches"
               :status="fetchStatus"
               :drawerId="drawerId"
+              :isDraggable="selectedSortOption === SORT_KEYS.CUSTOM"
+              @dragEnd="handleDragEnd"
             />
           </Tab>
           <Tab id="list" label="List">
@@ -119,12 +121,18 @@ import SearchResultsGallery from "@/components/SearchResultsGallery/SearchResult
 import ArrowForwardIcon from "@/icons/ArrowForwardIcon.vue";
 import Link from "@/components/Link/Link.vue";
 import ResultsCount from "@/components/ResultsCount/ResultsCount.vue";
-import { SearchResultsView, Tab as TabType, FetchStatus } from "@/types";
+import {
+  SearchResultsView,
+  Tab as TabType,
+  FetchStatus,
+  SearchResultMatch,
+} from "@/types";
 import { SEARCH_RESULTS_VIEWS } from "@/constants/constants";
 import { useDrawerStore } from "@/stores/drawerStore";
 import { SORT_KEYS } from "@/constants/constants";
 import { useErrorStore } from "@/stores/errorStore";
 import SpinnerIcon from "@/icons/SpinnerIcon.vue";
+import DrawerItemsGrid from "./DrawerItemsGrid.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -172,6 +180,10 @@ function handleTabChange(tab: TabType) {
       resultsView: tab.id,
     },
   });
+}
+
+function handleDragEnd(updatedListOfItems: SearchResultMatch[]) {
+  drawerStore.setDrawerItems(props.drawerId, updatedListOfItems);
 }
 
 function handleLoadMore() {

--- a/src/router.ts
+++ b/src/router.ts
@@ -95,6 +95,7 @@ const router = createRouter({
       component: DrawerViewPage,
       props: (route) => ({
         drawerId: parseIntFromParam(route.params.drawerId),
+        resultsView: route.query.resultsView ?? null,
       }),
     },
     {

--- a/src/stores/drawerStore.ts
+++ b/src/stores/drawerStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { Drawer } from "@/types";
+import { Drawer, DrawerSortOptions } from "@/types";
 import api from "@/api";
 import { useToastStore } from "./toastStore";
 import { useAssetStore } from "./assetStore";
@@ -101,6 +101,13 @@ export const useDrawerStore = defineStore("drawer", {
       const drawer = await api.getDrawer(drawerId);
       this.drawerRecords[drawerId] = drawer;
       return drawer;
+    },
+
+    async setDrawerSortBy(drawerId: number, sortBy: DrawerSortOptions) {
+      // clear the drawer contents
+      this.drawerRecords[drawerId].contents = undefined;
+      await api.setDrawerSortBy(drawerId, sortBy);
+      return this.refreshDrawer(drawerId);
     },
 
     async removeAssetFromDrawer({

--- a/src/stores/drawerStore.ts
+++ b/src/stores/drawerStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { Drawer, DrawerSortOptions } from "@/types";
+import { Drawer, DrawerSortOptions, SearchResultMatch } from "@/types";
 import api from "@/api";
 import { useToastStore } from "./toastStore";
 import { useAssetStore } from "./assetStore";
@@ -108,6 +108,20 @@ export const useDrawerStore = defineStore("drawer", {
       this.drawerRecords[drawerId].contents = undefined;
       await api.setDrawerSortBy(drawerId, sortBy);
       return this.refreshDrawer(drawerId);
+    },
+
+    async setDrawerItems(drawerId: number, items: SearchResultMatch[]) {
+      // optimistically update the drawer items
+      if (!this.drawerRecords[drawerId].contents) {
+        throw new Error(`Cannot set drawer items: drawer contents not found`);
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.drawerRecords[drawerId].contents!.matches = items;
+
+      const objectIds = items.map((item) => item.objectId);
+
+      api.setCustomDrawerOrder(drawerId, objectIds);
     },
 
     async removeAssetFromDrawer({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -706,7 +706,11 @@ export type GlobalSearchableFileType =
 export interface Drawer {
   id: number;
   title: string;
-  contents?: SearchResultsResponse;
+  contents?: {
+    matches: SearchResultMatch[];
+    sortBy: DrawerSortOptions | null;
+    totalResults: number;
+  };
 }
 
 export type ApiListDrawersResponse = Record<number, { title: string }>;
@@ -716,9 +720,15 @@ export interface ApiCreateDrawerResponse {
   drawerTitle: string;
 }
 
-export interface ApiGetDrawerResponse extends SearchResultsResponse {
+export type DrawerSortOptions = "title.raw" | "custom";
+
+export interface ApiGetDrawerResponse {
+  searchResults: string[];
+  matches: SearchResultMatch[];
+  totalResults: number;
   drawerId: number;
   drawerTitle: string;
+  sortBy: DrawerSortOptions | null; // this is persisted in the database
 }
 
 export interface ApiAddAssetToDrawerResponse {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12045,6 +12045,11 @@ sort-object@^3.0.3:
     sort-desc "^0.2.0"
     union-value "^1.0.1"
 
+sortablejs@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
+  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz"
@@ -13380,6 +13385,13 @@ vue@^3.3.4:
     "@vue/runtime-dom" "3.3.4"
     "@vue/server-renderer" "3.3.4"
     "@vue/shared" "3.3.4"
+
+vuedraggable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-4.1.0.tgz#edece68adb8a4d9e06accff9dfc9040e66852270"
+  integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
+  dependencies:
+    sortablejs "1.14.0"
 
 walker@^1.0.7, walker@^1.0.8, walker@~1.0.5:
   version "1.0.8"


### PR DESCRIPTION
This adds sorting to drawers, including drag-and-drop custom sort. VueDraggable is added as a dependency for drag and drop magic.

<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/3779d948-7ec8-402e-949a-ccc6092db0e7" width="500" />

Drawer browsing and sorting is very similar to normal search, but just different enough that I often just copied search components and then modified them slightly to work with drawers. Which is to say that there's a bit of duplicate code here that could probably use a refactor in the future. 