### PR TITLE
updates to drawer store and api requests

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -396,7 +396,7 @@ export async function setDrawerSortBy(
   sortBy: DrawerSortOptions
 ) {
   const res = await axios.post(
-    `${BASE_URL}/drawers/setSortOrder/${drawerId}/${sortBy}/true`
+    `${BASE_URL}/drawers/setSortOrder/${drawerId}/${sortBy}`
   );
 
   return res.data;

--- a/src/stores/drawerStore.ts
+++ b/src/stores/drawerStore.ts
@@ -154,23 +154,18 @@ export const useDrawerStore = defineStore("drawer", {
         );
       }
 
-      // drawer contents should exist at this point
-      if (!this.drawerRecords[drawerId].contents) {
+      const drawer = this.drawerRecords[drawerId];
+
+      if (!drawer.contents) {
         throw new Error(
           `Cannot remove asset from drawer: drawer contents not found`
         );
       }
 
       // optimistically remove the asset from the drawer
-      const previousMatches = this.drawerRecords[drawerId].contents?.matches;
-
-      if (previousMatches) {
-        const updatedMatches = previousMatches.filter(
-          (match) => match.objectId !== assetId
-        );
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.drawerRecords[drawerId].contents!.matches = updatedMatches;
-      }
+      drawer.contents.matches = drawer.contents.matches.filter(
+        (match) => match.objectId !== assetId
+      );
 
       await api.removeAssetFromDrawer({
         assetId,

--- a/src/stores/drawerStore.ts
+++ b/src/stores/drawerStore.ts
@@ -9,6 +9,10 @@ export interface DrawerStoreState {
   isReady: boolean;
 }
 
+const arraysEqual = (arr1: string[], arr2: string[]) =>
+  arr1.length === arr2.length &&
+  arr1.every((value, index) => value === arr2[index]);
+
 export const useDrawerStore = defineStore("drawer", {
   state: (): DrawerStoreState => ({
     drawerRecords: {},
@@ -122,7 +126,7 @@ export const useDrawerStore = defineStore("drawer", {
       const newOrder = items.map((item) => item.objectId);
 
       // if nothing has changed, don't make a request
-      if (currentOrder.join(",") === newOrder.join(",")) {
+      if (arraysEqual(currentOrder, newOrder)) {
         return;
       }
 


### PR DESCRIPTION
A few updates to the drawer store and api:
- In `drawerStore.setDrawerItems`, if the order of objectIds doesn't change, we skip making an API request to `api.setSortOrder`
-  removes`/true` on the `setSortOrder` api request since the endpoint now always returns json. See: UMN-LATIS/elevator#144
- simplified `drawerStore.removeAssetFromDrawer` to use `this` less, similar to `drawerStore.setDrawerItems`.
	
	TS's flow analysis will show errors that `this.drawerRecords[x].contents` may be undefined (even after we check that it's defined) presumably because the `this` object could be potentially mutated elsewhere in way TS can't follow. By creating a reference with `const drawer = this.drawerRecords[x]`, we can  skip the non-null assertion with the `!` in `this.drawerRecords[x].contents!.matches` remove the `eslint-disable`, and simplify the part where we update matches.


