### PR TITLE
restore bottom border of app header

### DIFF
--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -291,6 +291,5 @@ onMounted(async () => {
 
 .drawer-view-page .app-header {
   z-index: 30; /* keep app header dropdowns above tabs */
-  border-bottom-color: transparent !important;
 }
 </style>

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -280,6 +280,5 @@ watch(
 
 .search-results-page .app-header {
   z-index: 30; /* keep app header dropdowns above tabs */
-  border-bottom-color: transparent !important;
 }
 </style>


### PR DESCRIPTION
This reverts a change to the bottom border on the search result and drawer view pages based on feedback. Previously, the border was transparent to improve visability of the tabs by adding more contrasting whitespace around them. However, the appearing/disappearing app border when navigating could be distracting for some users.

Before: no bottom border on app header
<img width="400" alt="ScreenShot 2023-07-19 at 12 50 29@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/85d15d40-52de-4795-b908-101e235b8475"> 

After: bottom border on app header
<img width="400" alt="ScreenShot 2023-07-19 at 12 50 10@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/ece0474d-a4e7-49fe-8318-4cf0742e0eef">