### PR TITLE
fix: search results don't update when sort changes

### DIFF
--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -295,11 +295,11 @@ const getters = (state: SearchStoreState) => ({
 const actions = (state: SearchStoreState) => ({
   async setSortOption(option: keyof SearchSortOptions) {
     state.sort.value = option;
+    // get the search ID for this sort option
+    state.searchId.value = await this.getSearchId();
 
-    // refresh search results
-    if (state.searchId.value) {
-      return this.search(state.searchId.value);
-    }
+    // update search results
+    return this.search(state.searchId.value);
   },
 
   addCollectionIdFilter(collectionId: number) {


### PR DESCRIPTION
This fixes a regression (introduced in 17fdc62) where the results on the search page don't update after a user changes the sort order. After updating the searchStore's state with the new sort option, we need to get first get the new searchId, and then use the searchId to grab the results.

Previously, we weren't getting a new searchId after the sort changes.