### PR TITLE
Reset app stores and api cache after login/logout

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -429,3 +429,8 @@ export async function startDrawerDownload(drawerId: number) {
   );
   return res.data;
 }
+
+export async function logout() {
+  const res = await axios.post(`${BASE_URL}/loginManager/logout`);
+  return res.data;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -385,6 +385,7 @@ const api = {
   getStaticPage,
   deleteAsset: fetchers.deleteAsset,
   loginAsGuest: fetchers.loginAsGuest,
+  logout: fetchers.logout,
   getSearchableSelectFieldValues,
   getSearchableCheckboxFieldValues,
   getSearchableMultiSelectFieldValues,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -26,29 +26,39 @@ import {
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import * as fetchers from "@/api/fetchers";
 
-// caches for api results
-const assets = new Map<string, Asset | null>();
-const templates = new Map<string, Template | null>();
-const moreLikeThisMatches = new Map<string, SearchResultMatch[]>();
-const fileMetaData = new Map<string, FileMetaData>();
-const fileDownloadResponses = new Map<string, FileDownloadNormalized[]>();
-const paginatedSearchResults = new Map<
-  string,
-  Record<number, SearchResultsResponse>
->();
-const collectionDescriptions = new Map<number, string | null>();
-const collectionSearchIds = new Map<number, string | null>();
-const staticPages = new Map<number, ApiStaticPageResponse | null>();
-const searchableFieldDetails = new Map<string, ApiGetFieldInfoResponse>();
-const drawerDetails = new Map<number, ApiGetDrawerResponse | null>();
-let listOfDrawers: null | Drawer[] = null;
+function createCache() {
+  return {
+    assets: new Map<string, Asset | null>(),
+    templates: new Map<string, Template | null>(),
+    moreLikeThisMatches: new Map<string, SearchResultMatch[]>(),
+    fileMetaData: new Map<string, FileMetaData>(),
+    fileDownloadResponses: new Map<string, FileDownloadNormalized[]>(),
+    paginatedSearchResults: new Map<
+      string,
+      Record<number, SearchResultsResponse>
+    >(),
+    collectionDescriptions: new Map<number, string | null>(),
+    collectionSearchIds: new Map<number, string | null>(),
+    staticPages: new Map<number, ApiStaticPageResponse | null>(),
+    searchableFieldDetails: new Map<string, ApiGetFieldInfoResponse>(),
+    drawerDetails: new Map<number, ApiGetDrawerResponse | null>(),
+    listOfDrawers: null as null | Drawer[],
+  };
+}
+
+let cache = createCache();
+
+export function clearCache() {
+  cache = createCache();
+}
 
 async function getAsset(assetId: string): Promise<Asset | null> {
   if (!assetId) return null;
 
   // load asset and cache it in the store
-  const asset = assets.get(assetId) || (await fetchers.fetchAsset(assetId));
-  assets.set(assetId, asset);
+  const asset =
+    cache.assets.get(assetId) || (await fetchers.fetchAsset(assetId));
+  cache.assets.set(assetId, asset);
 
   return asset;
 }
@@ -61,26 +71,28 @@ async function getAssetWithTemplate(
   }
 
   // load asset and cache it in the store
-  const asset = assets.get(assetId) || (await fetchers.fetchAsset(assetId));
-  assets.set(assetId, asset);
+  const asset =
+    cache.assets.get(assetId) || (await fetchers.fetchAsset(assetId));
+  cache.assets.set(assetId, asset);
 
   if (!asset) return { asset: null, template: null };
 
   // load template and cache it in the store
   const templateId = String(asset.templateId);
   const template =
-    templates.get(templateId) || (await fetchers.fetchTemplate(templateId));
-  templates.set(templateId, template);
+    cache.templates.get(templateId) ||
+    (await fetchers.fetchTemplate(templateId));
+  cache.templates.set(templateId, template);
 
   return { asset, template };
 }
 
 async function getCollectionDescription(id: number): Promise<string | null> {
   const description =
-    collectionDescriptions.get(id) ||
+    cache.collectionDescriptions.get(id) ||
     (await fetchers.fetchCollectionDescription(id));
 
-  collectionDescriptions.set(id, description);
+  cache.collectionDescriptions.set(id, description);
 
   return description;
 }
@@ -91,11 +103,11 @@ async function getMoreLikeThis(
   if (!assetId) return [];
 
   const matches =
-    moreLikeThisMatches.get(assetId) ||
+    cache.moreLikeThisMatches.get(assetId) ||
     (await fetchers.fetchMoreLikeThis(assetId));
 
   // cache matches
-  moreLikeThisMatches.set(assetId, matches);
+  cache.moreLikeThisMatches.set(assetId, matches);
   return matches;
 }
 
@@ -105,10 +117,11 @@ async function getFileMetaData(
   if (!fileId) return null;
 
   const metadata =
-    fileMetaData.get(fileId) || (await fetchers.fetchFileMetaData(fileId));
+    cache.fileMetaData.get(fileId) ||
+    (await fetchers.fetchFileMetaData(fileId));
 
   // cache metadata
-  fileMetaData.set(fileId, metadata);
+  cache.fileMetaData.set(fileId, metadata);
   return metadata;
 }
 
@@ -120,10 +133,10 @@ async function getFileDownloadInfo(
 
   const key = `${fileId}.${parentObjectId}`;
   const fileDownloadInfo =
-    fileDownloadResponses.get(key) ||
+    cache.fileDownloadResponses.get(key) ||
     (await fetchers.fetchFileDownloadInfo(fileId, parentObjectId));
 
-  fileDownloadResponses.set(key, fileDownloadInfo);
+  cache.fileDownloadResponses.set(key, fileDownloadInfo);
 
   return fileDownloadInfo;
 }
@@ -136,11 +149,11 @@ async function getEmbedPluginInterstitial(): Promise<ApiInterstitialResponse> {
 async function getSearchIdForCollection(collectionId: number): Promise<string> {
   // check the cache first before making the request
   const searchId =
-    collectionSearchIds.get(collectionId) ||
+    cache.collectionSearchIds.get(collectionId) ||
     (await fetchers.fetchSearchIdForCollection(collectionId));
 
   // update cache
-  collectionSearchIds.set(collectionId, searchId);
+  cache.collectionSearchIds.set(collectionId, searchId);
 
   // return the searchId
   return searchId;
@@ -152,7 +165,7 @@ async function getSearchResultsById(
   loadAll = false
 ): Promise<SearchResultsResponse> {
   // check the cache first
-  const searchMap = paginatedSearchResults.get(searchId);
+  const searchMap = cache.paginatedSearchResults.get(searchId);
   if (searchMap && searchMap[page]) {
     return searchMap[page];
   }
@@ -164,7 +177,7 @@ async function getSearchResultsById(
   );
 
   // cache the results
-  paginatedSearchResults.set(searchId, {
+  cache.paginatedSearchResults.set(searchId, {
     ...(searchMap || {}), // add to existing cache if it exists
     [page]: searchResults,
   });
@@ -174,10 +187,10 @@ async function getSearchResultsById(
 async function getStaticPage(pageId: number): Promise<ApiStaticPageResponse> {
   // check the cache first
   const page =
-    staticPages.get(pageId) || (await fetchers.fetchStaticPage(pageId));
+    cache.staticPages.get(pageId) || (await fetchers.fetchStaticPage(pageId));
 
   // cache the page
-  staticPages.set(pageId, page);
+  cache.staticPages.set(pageId, page);
 
   return page;
 }
@@ -188,8 +201,8 @@ async function getSearchableFieldInfo<T extends ApiGetFieldInfoResponse>(
   const fieldKey = `${field.id}-${field.template}`;
 
   // return cached data if it exists
-  if (searchableFieldDetails.has(fieldKey)) {
-    const cachedResponse = searchableFieldDetails.get(fieldKey) as T;
+  if (cache.searchableFieldDetails.has(fieldKey)) {
+    const cachedResponse = cache.searchableFieldDetails.get(fieldKey) as T;
     return cachedResponse ?? null;
   }
 
@@ -197,7 +210,7 @@ async function getSearchableFieldInfo<T extends ApiGetFieldInfoResponse>(
   const data = await fetchers.fetchSearchableFieldInfo<T>(field);
 
   // cache the response
-  searchableFieldDetails.set(fieldKey, data);
+  cache.searchableFieldDetails.set(fieldKey, data);
 
   // and return the values
   return data;
@@ -247,8 +260,8 @@ async function getDrawers({
   refresh?: boolean;
 } = {}): Promise<Drawer[]> {
   // return cached data if it exists
-  if (listOfDrawers && !refresh) {
-    return listOfDrawers;
+  if (cache.listOfDrawers && !refresh) {
+    return cache.listOfDrawers;
   }
 
   // otherwise fetch it
@@ -256,21 +269,21 @@ async function getDrawers({
 
   // the data is an object, so we need to convert it to an array
   // and add the key as the id
-  listOfDrawers = Object.entries(data)
+  cache.listOfDrawers = Object.entries(data)
     .map(([key, value]) => ({
       id: Number.parseInt(key),
       ...value,
     }))
     .sort((a, b) => a.title.localeCompare(b.title));
 
-  return listOfDrawers;
+  return cache.listOfDrawers;
 }
 
 export async function getDrawer(id: number): Promise<Drawer> {
-  const data = drawerDetails.get(id) ?? (await fetchers.fetchDrawer(id));
+  const data = cache.drawerDetails.get(id) ?? (await fetchers.fetchDrawer(id));
 
   // cache the response
-  drawerDetails.set(id, data);
+  cache.drawerDetails.set(id, data);
 
   const { drawerId, drawerTitle, ...contents } = data;
 
@@ -288,7 +301,7 @@ export async function addAssetToDrawer(
   const data = await fetchers.addAssetToDrawer(assetId, drawerId);
 
   // clear the cache for this drawer
-  drawerDetails.delete(drawerId);
+  cache.drawerDetails.delete(drawerId);
 
   return data;
 }
@@ -300,7 +313,7 @@ export async function addAssetListToDrawer(
   const data = await fetchers.addAssetListToDrawer(assetIds, drawerId);
 
   // clear the cache for this drawer
-  drawerDetails.delete(drawerId);
+  cache.drawerDetails.delete(drawerId);
 
   return data;
 }
@@ -315,7 +328,7 @@ export async function removeAssetFromDrawer({
   const data = await fetchers.removeAssetFromDrawer({ drawerId, assetId });
 
   // clear the cache for this drawer
-  drawerDetails.delete(drawerId);
+  cache.drawerDetails.delete(drawerId);
 
   return data;
 }
@@ -327,7 +340,7 @@ export async function createDrawer(
   const data = await fetchers.createDrawer(drawerTitle, customConfig);
 
   // clear the list of drawers cache
-  listOfDrawers = null;
+  cache.listOfDrawers = null;
 
   return data;
 }
@@ -339,7 +352,7 @@ export async function deleteDrawer(
   const data = await fetchers.deleteDrawer(drawerId, customConfig);
 
   // clear the list of drawers cache
-  listOfDrawers = null;
+  cache.listOfDrawers = null;
 
   return data;
 }
@@ -351,7 +364,7 @@ export async function setDrawerSortBy(
   const data = await fetchers.setDrawerSortBy(drawerId, sortBy);
 
   // clear the drawer cache
-  drawerDetails.delete(drawerId);
+  cache.drawerDetails.delete(drawerId);
 
   return data;
 }
@@ -363,7 +376,7 @@ export async function setCustomDrawerOrder(
   const data = await fetchers.setCustomDrawerOrder(drawerId, assetIds);
 
   // clear the drawer cache
-  drawerDetails.delete(drawerId);
+  cache.drawerDetails.delete(drawerId);
 
   return data;
 }
@@ -399,6 +412,7 @@ const api = {
   setDrawerSortBy,
   setCustomDrawerOrder,
   startDrawerDownload: fetchers.startDrawerDownload,
+  clearCache,
 };
 
 export default api;

--- a/src/components/AuthDropDown/AuthDropDown.vue
+++ b/src/components/AuthDropDown/AuthDropDown.vue
@@ -17,15 +17,7 @@
       >
         Preferences
       </DropDownItem>
-      <DropDownItem
-        :href="`${
-          config.instance.base.url
-        }/loginManager/logout?redirect=${encodeURIComponent(
-          config.instance.base.url
-        )}`"
-      >
-        Logout
-      </DropDownItem>
+      <DropDownItem to="/logout">Logout</DropDownItem>
     </template>
     <template v-else>
       <DropDownItem

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import App from "./App.vue";
+import { resetStorePlugin } from "@/stores/resetStorePlugin";
 import { createPinia } from "pinia";
 import router from "@/router";
 import "@fontsource/work-sans/400.css";
@@ -13,5 +14,6 @@ import "./css/app.css";
 
 const app = createApp(App);
 const pinia = createPinia();
+pinia.use(resetStorePlugin);
 
 app.use(router).use(pinia).mount("#app");

--- a/src/pages/LocalLoginPage/LocalLoginPage.vue
+++ b/src/pages/LocalLoginPage/LocalLoginPage.vue
@@ -115,7 +115,7 @@ const props = withDefaults(
     redirectURL?: string;
   }>(),
   {
-    redirectURL: "/",
+    redirectURL: config.instance.base.path,
   }
 );
 
@@ -173,8 +173,10 @@ const login = async () => {
 
   if (status === "success") {
     errors.form = "";
-    instanceStore.refresh();
-    router.push(props.redirectURL);
+
+    // do a full reload to reinit stores and
+    // clear any cached api responses
+    window.location.href = props.redirectURL;
   }
 };
 

--- a/src/pages/LocalLoginPage/LocalLoginPage.vue
+++ b/src/pages/LocalLoginPage/LocalLoginPage.vue
@@ -103,12 +103,14 @@
 import Button from "@/components/Button/Button.vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
-import { ref, reactive, computed, onMounted } from "vue";
+import { ref, reactive, computed, onMounted, nextTick } from "vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import { useRouter } from "vue-router";
 import { EyeIcon, EyeOffIcon, SpinnerIcon } from "@/icons";
 import config from "@/config";
 import api from "@/api";
+import { resetAllStores } from "@/stores/resetAllStores";
+import { useDrawerStore } from "@/stores/drawerStore";
 
 const props = withDefaults(
   defineProps<{
@@ -135,6 +137,7 @@ const errors = reactive<{
 const shakeForm = ref(false);
 
 const instanceStore = useInstanceStore();
+const drawerStore = useDrawerStore();
 const router = useRouter();
 
 const login = async () => {
@@ -174,9 +177,13 @@ const login = async () => {
   if (status === "success") {
     errors.form = "";
 
-    // do a full reload to reinit stores and
-    // clear any cached api responses
-    window.location.href = props.redirectURL;
+    // once the user is successfully logged in,
+    // reset the cache and reinitialize stores
+    api.clearCache();
+    resetAllStores();
+    await instanceStore.init();
+    await drawerStore.init();
+    router.push(props.redirectURL);
   }
 };
 

--- a/src/pages/LogoutPage/LogoutPage.vue
+++ b/src/pages/LogoutPage/LogoutPage.vue
@@ -1,18 +1,24 @@
-<template>
-  <DefaultLayout>
-    <h1>Logged out</h1>
-  </DefaultLayout>
-</template>
 <script setup lang="ts">
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { onMounted } from "vue";
 import api from "@/api";
+import { useRouter } from "vue-router";
+import { resetAllStores } from "@/stores/resetAllStores";
+import { useInstanceStore } from "@/stores/instanceStore";
+import { useDrawerStore } from "@/stores/drawerStore";
 
-onMounted(() => {
-  api.logout();
+const instanceStore = useInstanceStore();
+const drawerStore = useDrawerStore();
+const router = useRouter();
+
+onMounted(async () => {
+  await api.logout();
 
   // do a full reload to clear any cached state
-  window.location.href = config.instance.base.path;
+  api.clearCache();
+  resetAllStores();
+  instanceStore.init();
+  drawerStore.init();
+  router.push("/");
 });
 </script>
 <style scoped></style>

--- a/src/pages/LogoutPage/LogoutPage.vue
+++ b/src/pages/LogoutPage/LogoutPage.vue
@@ -11,8 +11,8 @@ import api from "@/api";
 onMounted(() => {
   api.logout();
 
-  // do a full reload to clear any cache
-  window.location.href = "/";
+  // do a full reload to clear any cached state
+  window.location.href = config.instance.base.path;
 });
 </script>
 <style scoped></style>

--- a/src/pages/LogoutPage/LogoutPage.vue
+++ b/src/pages/LogoutPage/LogoutPage.vue
@@ -1,0 +1,18 @@
+<template>
+  <DefaultLayout>
+    <h1>Logged out</h1>
+  </DefaultLayout>
+</template>
+<script setup lang="ts">
+import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import { onMounted } from "vue";
+import api from "@/api";
+
+onMounted(() => {
+  api.logout();
+
+  // do a full reload to clear any cache
+  window.location.href = "/";
+});
+</script>
+<style scoped></style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,6 +13,7 @@ import DrawerViewPage from "./pages/DrawerViewPage/DrawerViewPage.vue";
 import CreateAssetPage from "./pages/CreateAssetPage/CreateAssetPage.vue";
 import DownloadDrawerPage from "./pages/DownloadDrawerPage/DownloadDrawerPage.vue";
 import { useErrorStore } from "./stores/errorStore";
+import LogoutPage from "./pages/LogoutPage/LogoutPage.vue";
 
 function parseIntFromParam(
   param: string | string[] | undefined
@@ -127,6 +128,11 @@ const router = createRouter({
       props: (route) => ({
         redirectURL: route.query.redirect ?? null,
       }),
+    },
+    {
+      name: "logout",
+      path: "/logout",
+      component: LogoutPage,
     },
     {
       name: "staticContentPage",

--- a/src/stores/resetAllStores.ts
+++ b/src/stores/resetAllStores.ts
@@ -1,0 +1,24 @@
+import { getActivePinia, type Store, type Pinia } from "pinia";
+
+interface ExtendedPinia extends Pinia {
+  _s: Map<string, Store>;
+}
+
+/**
+ * Resets all stores to their initial state.
+ *
+ * Only Option-style pinia stores have a $reset method
+ * built-in. Add a $reset method to your setup function-style
+ * stores to use this resetAllStores.
+ *
+ * @throws {Error} if no pinia instance is found
+ * @see: https://github.com/vuejs/pinia/discussions/911
+ */
+export function resetAllStores() {
+  const pinia = getActivePinia() as ExtendedPinia;
+  if (!pinia) {
+    throw new Error("Cannot reset all stores. Pinia not found.");
+  }
+
+  pinia._s.forEach((store) => store.$reset());
+}

--- a/src/stores/resetStorePlugin.ts
+++ b/src/stores/resetStorePlugin.ts
@@ -1,0 +1,10 @@
+import { clone as cloneDeep } from "ramda";
+
+/**
+ * adds a $reset method to the store that resets the store to its initial state
+ * This will work even for stores that are in setup function style
+ */
+export function resetStorePlugin({ store }) {
+  const initialState = cloneDeep(store.$state);
+  store.$reset = () => store.$patch(cloneDeep(initialState));
+}


### PR DESCRIPTION
Resolves:
- #195 

**Before:** After logging in, a guest user would see no drawers even if they had access to drawer. A refresh was required to see the drawers.
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/50752ba1-66dc-4da3-832a-206f536b4a30" width="500" />

**After:** After logging in, a guest user will see their drawers without needing to refresh.
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/9f1e4fac-a20b-420c-8d49-de10889436fc" width="500" />

### Details

This issue was caused by stale app state that wasn't refreshed after a user logged in. This PR now resets the Pinia stores and clears any cached api responses when a user logs in or logs out.

The PR complements a forthcoming change to [UMN-LATIS/elevator](https://github.com/UMN-LATIS/elevator) which will return a json response from the /logout endpoint rather than a redirect.
