### PR TITLE
Add support for custom footer content

### DIFF
--- a/src/components/AppFooter/AppFooter.vue
+++ b/src/components/AppFooter/AppFooter.vue
@@ -1,0 +1,25 @@
+<template>
+  <footer class="app-footer px-4 py-8 bg-transparent-black-100">
+    <SanitizedHTML
+      v-if="instanceStore.customFooter"
+      class="flex flex-col max-w-screen-xl mx-auto"
+      :html="instanceStore.customFooter"
+    />
+  </footer>
+</template>
+<script setup lang="ts">
+import { useInstanceStore } from "@/stores/instanceStore";
+import SanitizedHTML from "../SanitizedHTML/SanitizedHTML.vue";
+
+const instanceStore = useInstanceStore();
+</script>
+<style scoped>
+.app-footer {
+  border-top: var(--app-borderWidth) solid var(--app-borderColor);
+  font-size: 0.825rem;
+  & :is(h1, h2, h3, h4, h5) {
+    font-size: 1rem;
+    font-weight: bold;
+  }
+}
+</style>

--- a/src/components/AppFooter/AppFooter.vue
+++ b/src/components/AppFooter/AppFooter.vue
@@ -1,8 +1,8 @@
 <template>
-  <footer class="app-footer px-4 py-8 bg-transparent-black-100">
+  <footer class="app-footer bg-transparent-black-100">
     <SanitizedHTML
       v-if="instanceStore.customFooter"
-      class="flex flex-col max-w-screen-xl mx-auto"
+      class="flex flex-col max-w-screen-xl mx-auto p-4 lg:p-8"
       :html="instanceStore.customFooter"
     />
   </footer>

--- a/src/components/AppFooter/exampleFooterContent.html
+++ b/src/components/AppFooter/exampleFooterContent.html
@@ -1,0 +1,87 @@
+<section class="grid sm:grid-cols-3 gap-4">
+  <div>
+    <h2>Advisory</h2>
+    <p> The content contained herein may trigger secondary trauma or PTSD; we encourage
+      individuals to seek counseling or healing if you experience any stress related to boarding school history.
+      Indigenous peoples are warned that this digital archive contains images, names, and references to deceased
+      persons.</p>
+    <p>National Indian Boarding School Digital Archive is an initiative of the National Native American Boarding
+      School
+      Healing Coalition.</p>
+  </div>
+
+  <div>
+    <h2>Education</h2>
+    <ul>
+      <li>
+        <a href="https://boardingschoolhealing.org/education/us-indian-boarding-school-history/">
+          U.S. Boarding School History
+        </a>
+      </li>
+      <li><a href="https://boardingschoolhealing.org/education/resources/">Resources</a></li>
+      <li><a href="https://boardingschoolhealing.org/get-involved/for-teachers/">For Teachers</a></li>
+      <li><a href="https://boardingschoolhealing.org/resource-database-center/">Resource Database</a></li>
+    </ul>
+  </div>
+  <div>
+    <h2>Quick Links</h2>
+    <ul>
+      <li><a href=" https://nibsda.elevator.umn.edu/page/view/143">Content Warning</a></li>
+
+      <li><a href=" https://boardingschoolhealing.org/self-care-resources/">Self-Care and Trauma Resources</a></li>
+
+      <li><a href="https://nctr.ca/records/view-your-records/archival-map/">National Centre for Truth and
+          Reconciliation - International Map</a></li>
+      <li><a href=" https://nibsda.elevator.umn.edu/page/view/157">Citation Styles & Best Practices</a></li>
+
+      <li><a href="mailto:to:info@nabshc.org">Contact Us</a></li>
+    </ul>
+  </div>
+</section>
+<section class="border-t border-neutral-400 flex justify-between items-center gap-4 my-4 py-4 flex-wrap">
+  <p>Copyright © 2023 All Rights Reserved by
+    <a href="https://boardingschoolhealing.org/">National Native American Boarding School Healing Coalition</a>.
+  </p>
+
+  <ul class="flex justify-end items-center gap-2">
+    <li><a href="https://www.facebook.com/NNABSHC" target="_blank" rel="noopener">
+        <span class="sr-only">Facebook</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path fill="currentColor"
+            d="M12 2.04c-5.5 0-10 4.49-10 10.02c0 5 3.66 9.15 8.44 9.9v-7H7.9v-2.9h2.54V9.85c0-2.51 1.49-3.89 3.78-3.89c1.09 0 2.23.19 2.23.19v2.47h-1.26c-1.24 0-1.63.77-1.63 1.56v1.88h2.78l-.45 2.9h-2.33v7a10 10 0 0 0 8.44-9.9c0-5.53-4.5-10.02-10-10.02Z" />
+        </svg>
+      </a></li>
+    <li><a class="social-icon twitter" href="https://twitter.com/NABSHC?lang=en" target="_blank" rel="noopener">
+        <span class="sr-only">Twitter</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path fill="currentColor"
+            d="M22.46 6c-.77.35-1.6.58-2.46.69c.88-.53 1.56-1.37 1.88-2.38c-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.29c0 .34.04.67.11.98C8.28 9.09 5.11 7.38 3 4.79c-.37.63-.58 1.37-.58 2.15c0 1.49.75 2.81 1.91 3.56c-.71 0-1.37-.2-1.95-.5v.03c0 2.08 1.48 3.82 3.44 4.21a4.22 4.22 0 0 1-1.93.07a4.28 4.28 0 0 0 4 2.98a8.521 8.521 0 0 1-5.33 1.84c-.34 0-.68-.02-1.02-.06C3.44 20.29 5.7 21 8.12 21C16 21 20.33 14.46 20.33 8.79c0-.19 0-.37-.01-.56c.84-.6 1.56-1.36 2.14-2.23Z" />
+        </svg>
+      </a></li>
+    <li><a class="social-icon youtube" href="https://www.youtube.com/channel/UCLca5mONkWmxjdnhEE_EIXg" target="_blank"
+        rel="noopener">
+        <span class="sr-only">YouTube</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path fill="currentColor"
+            d="m10 15l5.19-3L10 9v6m11.56-7.83c.13.47.22 1.1.28 1.9c.07.8.1 1.49.1 2.09L22 12c0 2.19-.16 3.8-.44 4.83c-.25.9-.83 1.48-1.73 1.73c-.47.13-1.33.22-2.65.28c-1.3.07-2.49.1-3.59.1L12 19c-4.19 0-6.8-.16-7.83-.44c-.9-.25-1.48-.83-1.73-1.73c-.13-.47-.22-1.1-.28-1.9c-.07-.8-.1-1.49-.1-2.09L2 12c0-2.19.16-3.8.44-4.83c.25-.9.83-1.48 1.73-1.73c.47-.13 1.33-.22 2.65-.28c1.3-.07 2.49-.1 3.59-.1L12 5c4.19 0 6.8.16 7.83.44c.9.25 1.48.83 1.73 1.73Z" />
+        </svg>
+      </a></li>
+    <li><a class="social-icon linkedin" href="https://www.linkedin.com/company/nabshc?trk=ppro_cprof" target="_blank"
+        rel="noopener">
+        <span class="sr-only">LinkedIn</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path fill="currentColor"
+            d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77Z" />
+        </svg>
+      </a></li>
+
+    <li><a class="social-icon instagram" href="https://www.instagram.com/nabshc/" target="_blank" rel="noopener">
+        <span class="sr-only">Instagram</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path fill="currentColor"
+            d="M7.8 2h8.4C19.4 2 22 4.6 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8C4.6 22 2 19.4 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2m-.2 2A3.6 3.6 0 0 0 4 7.6v8.8C4 18.39 5.61 20 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6C20 5.61 18.39 4 16.4 4H7.6m9.65 1.5a1.25 1.25 0 0 1 1.25 1.25A1.25 1.25 0 0 1 17.25 8A1.25 1.25 0 0 1 16 6.75a1.25 1.25 0 0 1 1.25-1.25M12 7a5 5 0 0 1 5 5a5 5 0 0 1-5 5a5 5 0 0 1-5-5a5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3a3 3 0 0 0 3 3a3 3 0 0 0 3-3a3 3 0 0 0-3-3Z" />
+        </svg>
+      </a>
+    </li>
+  </ul>
+</section>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -6,6 +6,7 @@
     <main id="main" class="flex-1 flex flex-col" tabindex="-1">
       <slot />
     </main>
+    <AppFooter />
     <Transition name="fade">
       <a
         v-show="showScrollToTop"
@@ -21,6 +22,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import AppHeader from "@/components/AppHeader/AppHeader.vue";
+import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import { ChevronUpIcon } from "@/icons";
 import { useWindowScroll } from "@vueuse/core";
 import SkipNavLink from "@/components/SkipNavLink/SkipNavLink.vue";

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -6,7 +6,6 @@
     <main id="main" class="flex-1 flex flex-col" tabindex="-1">
       <slot />
     </main>
-    <AppFooter />
     <Transition name="fade">
       <a
         v-show="showScrollToTop"
@@ -22,7 +21,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import AppHeader from "@/components/AppHeader/AppHeader.vue";
-import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import { ChevronUpIcon } from "@/icons";
 import { useWindowScroll } from "@vueuse/core";
 import SkipNavLink from "@/components/SkipNavLink/SkipNavLink.vue";

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -6,7 +6,7 @@
     />
     <div
       v-if="isReady && canSearchAndBrowse"
-      class="home-page-content flex-1 md:grid"
+      class="home-page-content flex-1 md:grid max-w-screen-xl w-full mx-auto"
       :class="{
         'md:grid-cols-2': !featuredAssetId,
         'md:grid-cols-3': featuredAssetId,
@@ -17,7 +17,7 @@
           <SanitizedHTML
             v-if="page"
             :html="page.content ?? ''"
-            class="prose prose-neutral mx-auto"
+            class="prose prose-neutral"
           />
         </Transition>
       </article>

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -42,6 +42,7 @@
         Please contact your administrator if you believe this is an error.
       </p>
     </Notification>
+    <AppFooter />
   </DefaultLayout>
 </template>
 <script setup lang="ts">
@@ -54,6 +55,7 @@ import api from "@/api";
 import FeaturedAssetCard from "@/components/FeaturedAssetCard/FeaturedAssetCard.vue";
 import SignInRequiredNotice from "./SignInRequiredNotice.vue";
 import Notification from "@/components/Notification/Notification.vue";
+import AppFooter from "@/components/AppFooter/AppFooter.vue";
 
 const page = ref<StaticContentPage | null>(null);
 const instanceStore = useInstanceStore();

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -11,11 +11,13 @@
         <SanitizedHTML :html="page.content ?? ''" class="w-full" />
       </div>
     </div>
+    <AppFooter />
   </DefaultLayout>
 </template>
 <script setup lang="ts">
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
+import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import { ref, watch } from "vue";
 import { ApiStaticPageResponse } from "@/types";
 import api from "@/api";

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -2,12 +2,14 @@
   <DefaultLayout>
     <div
       v-if="page"
-      class="static-page__content prose prose-neutral p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl"
+      class="static-page__content p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl"
     >
-      <h1 class="text-4xl font-bold">
-        {{ page.title || "No Title" }}
-      </h1>
-      <SanitizedHTML :html="page.content ?? ''" />
+      <div class="prose prose-neutral">
+        <h1 class="text-4xl font-bold">
+          {{ page.title || "No Title" }}
+        </h1>
+        <SanitizedHTML :html="page.content ?? ''" class="w-full" />
+      </div>
     </div>
   </DefaultLayout>
 </template>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -2,7 +2,7 @@
   <DefaultLayout>
     <div
       v-if="page"
-      class="static-page__content prose prose-neutral p-4 lg:p-8 mx-auto flex-1"
+      class="static-page__content prose prose-neutral p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl"
     >
       <h1 class="text-4xl font-bold">
         {{ page.title || "No Title" }}

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -35,6 +35,7 @@ const createState = () => ({
     userCanSearchAndBrowse: false,
     templates: [],
   }),
+  customFooter: ref<string | null>(null),
 });
 
 const getters = (state: ReturnType<typeof createState>) => ({
@@ -88,6 +89,7 @@ const actions = (state: ReturnType<typeof createState>) => ({
       state.collections.value = normalizeAssetCollections(
         apiResponse.collections
       );
+      state.customFooter.value = apiResponse.customFooter;
 
       // add id to searchable field object from api response
       state.searchableFields.value = Object.entries(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -510,6 +510,7 @@ export interface ApiInstanceNavResponse {
   templates: Record<number, string>; // { templateId: templateName }
   featuredAssetId: string; // featured asset for homepage
   featuredAssetText: string; // text appearing above the featured asset
+  customFooter: string | null; // html
 }
 
 export interface StaticContentPage {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -58,6 +58,14 @@ module.exports = {
       },
     },
   },
+  safelist: [
+    "sm:grid-cols-1",
+    "sm:grid-cols-2",
+    "sm:grid-cols-3",
+    "md:grid-cols-1",
+    "md:grid-cols-2",
+    "md:grid-cols-3",
+  ],
   plugins: [
     require("@tailwindcss/typography"),
     require("@tailwindcss/forms"),


### PR DESCRIPTION
This adds support for the custom footer content in elevator. The footer will only show on the home page and static content pages.

<img width="800" alt="ScreenShot 2023-07-21 at 16 49 10@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/994cc793-62f8-4a2a-85f1-38bd7fa8c0ee">

It's likely that existing custom footer content will need a little scrubbing to remove old CSS classes and formatting to better fit with the updated ui. (I'd be happy to to help current instances do this). I've added the cleaned example footer content in `exampleFooterContent.html`, which could be used as a base for updates.
