### PR TITLE
Make the height of the collapsed TextArea widget configurable

### DIFF
--- a/src/components/MoreLikeThis/MoreLikeThis.vue
+++ b/src/components/MoreLikeThis/MoreLikeThis.vue
@@ -23,7 +23,9 @@
       @click="isShowingFullListOfResults = true"
     >
       {{
-        config.moreLikeThis.maxInlineResults ? "Show More" : "More Like This"
+        config.instance.moreLikeThis.maxInlineResults
+          ? "Show More"
+          : "More Like This"
       }}
     </ButtonWithCount>
 
@@ -62,7 +64,7 @@ const props = defineProps<{
 }>();
 
 const inlineResultsList = computed(() => {
-  return props.items.slice(0, config.moreLikeThis.maxInlineResults);
+  return props.items.slice(0, config.instance.moreLikeThis.maxInlineResults);
 });
 
 const numOfSeeMoreResults = computed(() => {

--- a/src/components/Widget/TextAreaWidget/TextAreaItem.vue
+++ b/src/components/Widget/TextAreaWidget/TextAreaItem.vue
@@ -19,15 +19,17 @@ import { useResizeObserver, useDebounceFn } from "@vueuse/core";
 import shave from "shave";
 import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
 import ChevronUpIcon from "@/icons/ChevronUpIcon.vue";
+import config from "@/config";
 
 const props = withDefaults(
   defineProps<{
     fieldContents: string;
     widget: WidgetProps;
-    textTruncationLength?: number;
+    textTruncationHeight?: number;
   }>(),
   {
-    textTruncationLength: 75,
+    textTruncationHeight:
+      config.instance.textAreaItem.defaultTextTruncationHeight,
   }
 );
 const show = ref(false);
@@ -45,7 +47,7 @@ function updateShave() {
 
   shave(
     [truncateText.value] as unknown as NodeList,
-    props.textTruncationLength
+    props.textTruncationHeight
   );
   isTruncated.value =
     truncateText.value.querySelector<HTMLElement>(".js-shave") !== null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,9 @@ const defaultConfig: AppConfig = {
         import.meta.env.VITE_THEMING_ENABLED?.toLowerCase() === "true" ?? true,
       defaultTheme: import.meta.env.VITE_THEMING_DEFAULT ?? "light",
     },
+    moreLikeThis: {
+      maxInlineResults: 3,
+    },
   },
   arcgis: {
     apiKey:
@@ -27,9 +30,6 @@ const defaultConfig: AppConfig = {
     test: import.meta.env.VITE_TEST_ROUTE ?? null,
   },
   mode: import.meta.env.MODE ?? null,
-  moreLikeThis: {
-    maxInlineResults: 3,
-  },
 };
 
 const overwriteMerge = (destArray, sourceArray) => sourceArray;

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,9 @@ const defaultConfig: AppConfig = {
       maxInlineResults: 3,
     },
     textAreaItem: {
-      defaultTextTruncationLength: 75,
+      // height in pixels
+      // ex. for 3 lines: 16px * 1.5 line-height * 3 lines = 72px
+      defaultTextTruncationHeight: 72,
     },
   },
   arcgis: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,9 @@ const defaultConfig: AppConfig = {
     moreLikeThis: {
       maxInlineResults: 3,
     },
+    textAreaItem: {
+      defaultTextTruncationLength: 75,
+    },
   },
   arcgis: {
     apiKey:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,7 @@ export interface AppConfig {
        * height of the the collapsed text area
        * in pixels
        */
-      defaultTextTruncationLength: number;
+      defaultTextTruncationHeight: number;
     };
   };
   arcgis: {
@@ -464,8 +464,8 @@ export interface Template {
   widgetArray: WidgetProps[];
   collections?: Record<string | number, string | undefined | unknown>;
   allowedCollections?:
-    | Record<string | number, string | undefined | unknown>
-    | unknown[];
+  | Record<string | number, string | undefined | unknown>
+  | unknown[];
 }
 
 export interface LngLat {
@@ -767,10 +767,10 @@ export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
 
 export type ApiStartDrawerDownloadResponse =
   | {
-      status: "accepted";
-      jobId: number;
-    }
+    status: "accepted";
+    jobId: number;
+  }
   | {
-      status: "completed";
-      url: string;
-    };
+    status: "completed";
+    url: string;
+  };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,15 @@ export interface AppConfig {
       enabled: boolean;
       defaultTheme: string;
     };
+    moreLikeThis: {
+      /**
+       * Number of results to show in More Like This
+       * section before showing the "Show More" button.
+       * If set to 0, users won't see any preview results
+       * and will have to click a "More Like This" button.
+       */
+      maxInlineResults: number;
+    };
   };
   arcgis: {
     apiKey: string;
@@ -24,15 +33,6 @@ export interface AppConfig {
     test: string | null;
   };
   mode: "development" | "production" | string | null;
-  moreLikeThis: {
-    /**
-     * Number of results to show in More Like This
-     * section before showing the "Show More" button.
-     * If set to 0, users won't see any preview results
-     * and will have to click a "More Like This" button.
-     */
-    maxInlineResults: number;
-  };
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,13 @@ export interface AppConfig {
        */
       maxInlineResults: number;
     };
+    textAreaItem: {
+      /**
+       * height of the the collapsed text area
+       * in pixels
+       */
+      defaultTextTruncationLength: number;
+    };
   };
   arcgis: {
     apiKey: string;


### PR DESCRIPTION
This complements UMN-LATIS/elevator#147, allowing an instance admin to configure the height of it's collapsed textarea widget.

The `AppConfig` is updated to use the value on `instance.textAreaItem.defaultTextTruncationHeight` to override the default height of ~3lines or 72px (16px base font size * 1.5 line-height * 3 lines).

Additionally, this PR moves `moreLikeThis.maxInlineResults  to be within the `instance` config object as well since it seems like a similar component-level instance setting.

Setting `defaultTextTruncationHeight` to `24`:
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/2e86c090-0424-424d-a3eb-caf18c2aca0d" width="400" />

Setting `defaultTextTruncationHeight` to `72`:
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/0f34cc09-24ab-4c24-8847-24cd6b986035" width="400" />
