### PR TITLE
Fix scrollTo behavior

### DIFF
--- a/src/components/MediaCard/MediaCard.vue
+++ b/src/components/MediaCard/MediaCard.vue
@@ -1,33 +1,31 @@
 <template>
-  <article
-    class="media-card flex flex-col overflow-hidden border rounded-md shadow-sm"
+  <component
+    :is="to ? Link : 'div'"
+    :to="to"
+    class="media-card hover:no-underline group border rounded-md shadow-sm overflow-hidden opacity-75 focus:opacity-100 hover:opacity-100 hover:shadow-lg focus:shadow-lg"
   >
-    <div class="placeholder-image aspect-video overflow-hidden">
-      <component
-        :is="to ? Link : 'div'"
-        :to="to"
-        class="flex items-center justify-center w-full h-full media-card__image"
-      >
-        <LazyLoadImage
-          v-if="imgSrc"
-          :src="imgSrc"
-          :alt="imgAlt || 'Untitled'"
-          loading="lazy"
-          class="object-cover w-full h-full"
-        />
-        <DocumentIcon v-else />
-      </component>
-    </div>
+    <article class="flex flex-col">
+      <div class="placeholder-image aspect-video overflow-hidden">
+        <div
+          class="flex items-center justify-center w-full h-full media-card__image"
+        >
+          <LazyLoadImage
+            v-if="imgSrc"
+            :src="imgSrc"
+            :alt="imgAlt || 'Untitled'"
+            loading="lazy"
+            class="object-cover w-full h-full"
+          />
+          <DocumentIcon v-else />
+        </div>
+      </div>
 
-    <component
-      :is="to ? Link : 'div'"
-      :to="to"
-      class="flex-1 p-4 media-card__body hover:no-underline"
-    >
-      <slot />
-    </component>
-    <slot name="footer"></slot>
-  </article>
+      <div :to="to" class="flex-1 p-4 media-card__body hover:no-underline">
+        <slot />
+      </div>
+      <slot name="footer"></slot>
+    </article>
+  </component>
 </template>
 <script setup lang="ts">
 import { DocumentIcon } from "@/icons";
@@ -58,7 +56,8 @@ defineProps<{
 }
 
 .media-card:has(.media-card__image:hover),
-.media-card:has(.media-card__body:hover) {
+.media-card:has(.media-card__body:hover),
+.media-card:focus {
   --hover-text-color: var(--color-blue-600);
   --hover-bg-color: var(--color-blue-50);
   background: var(--hover-bg-color);

--- a/src/components/MediaCard/MediaCard.vue
+++ b/src/components/MediaCard/MediaCard.vue
@@ -1,8 +1,7 @@
 <template>
-  <component
-    :is="to ? Link : 'div'"
+  <Link
     :to="to"
-    class="media-card hover:no-underline group border rounded-md shadow-sm overflow-hidden opacity-75 focus:opacity-100 hover:opacity-100 hover:shadow-lg focus:shadow-lg"
+    class="media-card hover:no-underline group border rounded-md shadow-sm overflow-hidden hover:shadow-lg focus:shadow-lg"
   >
     <article class="flex flex-col w-full">
       <div class="placeholder-image aspect-video overflow-hidden">
@@ -25,7 +24,7 @@
       </div>
       <slot name="footer"></slot>
     </article>
-  </component>
+  </Link>
 </template>
 <script setup lang="ts">
 import { DocumentIcon } from "@/icons";
@@ -35,7 +34,7 @@ import Link from "@/components/Link/Link.vue";
 defineProps<{
   imgSrc?: string | null;
   imgAlt?: string | null;
-  to?: string;
+  to: string;
 }>();
 </script>
 <style scoped>

--- a/src/components/MediaCard/MediaCard.vue
+++ b/src/components/MediaCard/MediaCard.vue
@@ -4,7 +4,7 @@
     :to="to"
     class="media-card hover:no-underline group border rounded-md shadow-sm overflow-hidden opacity-75 focus:opacity-100 hover:opacity-100 hover:shadow-lg focus:shadow-lg"
   >
-    <article class="flex flex-col">
+    <article class="flex flex-col w-full">
       <div class="placeholder-image aspect-video overflow-hidden">
         <div
           class="flex items-center justify-center w-full h-full media-card__image"

--- a/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
@@ -2,7 +2,7 @@
   <RouterLink
     :title="title"
     class="thumbnail-related-asset-widget-image inline-flex"
-    :to="`#${assetId}`"
+    :to="{ query: { activeObjectId: assetId } }"
   >
     <ThumbnailImage
       v-if="assetCache.primaryHandler"

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -259,15 +259,20 @@ onMounted(() => {
 
 // scroll to objectId if it's in the search results
 watch(
-  () => props.objectId,
-  (objectId) => {
-    if (!objectId) return;
+  [() => props.objectId, () => searchStore.status],
+  ([objectId, status]) => {
+    if (!objectId || status === "fetching") return;
     nextTick(() => {
+      if (!objectId) {
+        throw new Error("objectId should be set when scrolling to it");
+      }
       const el = document.getElementById(`object-${objectId}`);
-      if (!el) return;
+
+      if (!el) {
+        throw new Error(`Could not find element with id: object-${objectId}`);
+      }
 
       el.scrollIntoView({
-        behavior: "smooth",
         block: "center",
       });
     });

--- a/src/router.ts
+++ b/src/router.ts
@@ -57,10 +57,9 @@ const router = createRouter({
       name: "asset",
       path: "/asset/viewAsset/:assetId",
       component: AssetViewPage,
-      // component: () => import("@/pages/AssetViewPage/AssetViewPage.vue"),
       props: (route) => ({
         assetId: route.params.assetId,
-        objectId: route.hash?.substring(1),
+        objectId: route.query.activeObjectId ?? null,
       }),
     },
     {


### PR DESCRIPTION
This resolves an issue when trying to access an element with an object id beginning with a numeral triggered by scrollTo:
<img width="600" alt="ScreenShot 2023-08-07 at 22 12 37@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/5e9b20bf-bd8e-4745-b1f6-67d25ce14b49">

To support objectId's beginning with numbers, this PR changes the `activeObjectId` from a hash to a query param: `?activeObjectId=12345`. We looked at prefixing the hash with some string, but the query param seemed cleaner since it lets us skip parsing the hash string, and we're using query params elsewhere.

This PR also resolves a regression where the search results page doesn't scroll to the last active result when a user clicks on the result count ("11 of 120") by watching the status of the searchStore, and triggering the scrollTo once fetching completes. 

Finally, as part of this PR, I fixed a CSS issue with broken focus styles on the search results page. When option-tabbing through the search results links, the focussed result now correctly shows an outline.

Resolves:
- #208 
- #209 
