### PR TITLE
fix: object doesn't scroll into view

### DIFF
--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -259,15 +259,14 @@ onMounted(() => {
 
 // scroll to objectId if it's in the search results
 watch(
-  () => props.objectId,
-  (objectId) => {
-    if (!objectId) return;
+  [() => props.objectId, () => searchStore.status],
+  ([objectId, status]) => {
+    if (!objectId || status === "fetching") return;
     nextTick(() => {
       const el = document.getElementById(`object-${objectId}`);
       if (!el) return;
 
       el.scrollIntoView({
-        behavior: "smooth",
         block: "center",
       });
     });


### PR DESCRIPTION
watch the search store status and only attempt to scroll into view if we're no longer fetching

Resolves #209 