### PR TITLE
fix: tags should wrap

### DIFF
--- a/src/components/Widget/TagWidget/TagWidget.vue
+++ b/src/components/Widget/TagWidget/TagWidget.vue
@@ -1,7 +1,7 @@
 <template>
   <ul>
     <li v-for="(content, key) in contents" :key="key">
-      <ul class="flex gap-2">
+      <ul class="flex gap-2 flex-wrap">
         <li v-for="(tag, index) in content.tags" :key="index">
           <ClickToSearchLink
             v-slot="{ isClickable }"


### PR DESCRIPTION
Fixes tag wrapping in the TagWidget.

Before:
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/a5757d83-8c5b-409f-91fc-bdd07a40688e" width="400" />

After:
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/c185e675-1e9b-47ad-9805-670c84ff7336" width="400" />
