### PR TITLE
Convert any html in accordion label to text

### DIFF
--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -12,7 +12,7 @@
             'font-bold ': isOpen,
             'font-normal': !isOpen,
           }"
-          >{{ label }}</span
+          >{{ convertHtmlToText(label) }}</span
         >
       </slot>
       <div class="place-items-center flex p-4">
@@ -34,6 +34,7 @@
 import { ref } from "vue";
 import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
 import ChevronUpIcon from "@/icons/ChevronUpIcon.vue";
+import { convertHtmlToText } from "@/helpers/displayUtils";
 
 withDefaults(
   defineProps<{

--- a/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
+++ b/src/components/RemoveFromDrawerButton/RemoveFromDrawerButton.vue
@@ -28,7 +28,7 @@
 import { ref, computed } from "vue";
 import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import { useDrawerStore } from "@/stores/drawerStore";
-import { stripTags } from "@/helpers/displayUtils";
+import { convertHtmlToText } from "@/helpers/displayUtils";
 
 const props = defineProps<{
   drawerId: number;
@@ -54,7 +54,9 @@ const isConfirmModalOpen = ref(false);
 const objectTitle = computed(() => {
   const rawTitle = object.value?.title;
   if (!rawTitle) return null;
-  return Array.isArray(rawTitle) ? stripTags(rawTitle[0]) : stripTags(rawTitle);
+  return Array.isArray(rawTitle)
+    ? convertHtmlToText(rawTitle[0])
+    : convertHtmlToText(rawTitle);
 });
 
 const excerptTitle = computed(() => excerpt.value?.excerptLabel ?? null);

--- a/src/components/SearchResultCard/SearchResultCard.vue
+++ b/src/components/SearchResultCard/SearchResultCard.vue
@@ -60,7 +60,11 @@
 
 <script lang="ts" setup>
 import { SearchResultMatch } from "@/types";
-import { getAssetUrl, getThumbURL, stripTags } from "@/helpers/displayUtils";
+import {
+  getAssetUrl,
+  getThumbURL,
+  convertHtmlToText,
+} from "@/helpers/displayUtils";
 import { computed } from "vue";
 import MediaCard from "@/components/MediaCard/MediaCard.vue";
 import Link from "@/components/Link/Link.vue";
@@ -96,11 +100,13 @@ const assetUrl = computed(() => getAssetUrl(props.searchMatch.objectId));
 
 const title = computed(() => {
   if (Array.isArray(props.searchMatch.title)) {
-    return props.searchMatch.title.map((str) => stripTags(str)).join(",");
+    return props.searchMatch.title
+      .map((str) => convertHtmlToText(str))
+      .join(",");
   }
 
   if (props.searchMatch.title && props.searchMatch.title.length > 0) {
-    return stripTags(props.searchMatch.title);
+    return convertHtmlToText(props.searchMatch.title);
   }
 
   return "(no title)";

--- a/src/components/SearchResultRow/SearchResultRow.vue
+++ b/src/components/SearchResultRow/SearchResultRow.vue
@@ -46,7 +46,7 @@
 </template>
 <script setup lang="ts">
 import { SearchResultMatch } from "@/types";
-import { getThumbURL, stripTags } from "@/helpers/displayUtils";
+import { getThumbURL, convertHtmlToText } from "@/helpers/displayUtils";
 import { computed } from "vue";
 import LazyLoadImage from "../LazyLoadImage/LazyLoadImage.vue";
 import Link from "../Link/Link.vue";
@@ -59,11 +59,11 @@ const props = defineProps<{
 
 const title = computed(() => {
   if (Array.isArray(props.searchMatch.title)) {
-    return props.searchMatch.title.map(stripTags).join(",");
+    return props.searchMatch.title.map(convertHtmlToText).join(",");
   }
 
   if (props.searchMatch.title && props.searchMatch.title.length > 0) {
-    return stripTags(props.searchMatch.title);
+    return convertHtmlToText(props.searchMatch.title);
   }
 
   return "(no title)";

--- a/src/components/SearchResultsGallery/useSlidesForMatches.ts
+++ b/src/components/SearchResultsGallery/useSlidesForMatches.ts
@@ -1,6 +1,10 @@
 import { SearchResultMatch, RelatedAssetCacheItemWithId, Asset } from "@/types";
 import { reactive } from "vue";
-import { getThumbURL, getAssetTitle, stripTags } from "@/helpers/displayUtils";
+import {
+  getThumbURL,
+  getAssetTitle,
+  convertHtmlToText,
+} from "@/helpers/displayUtils";
 import api from "@/api";
 
 export interface Slide {
@@ -22,9 +26,9 @@ export interface Slide {
 
 const selectTitleFromMatch = (match: SearchResultMatch) => {
   if (Array.isArray(match.title)) {
-    return match.title.map(stripTags).join(", ");
+    return match.title.map(convertHtmlToText).join(", ");
   }
-  return match.title?.length ? stripTags(match.title) : "(No Title)";
+  return match.title?.length ? convertHtmlToText(match.title) : "(No Title)";
 };
 
 const selectThumbSrc = (match: SearchResultMatch) => {

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -114,10 +114,10 @@ export function getWidgetsForDisplay({
 
 export function getAssetTitle(asset: Asset): string {
   const title = asset?.title?.[0] ?? "(No Title)";
-  return stripTags(title);
+  return convertHtmlToText(title);
 }
 
-export function stripTags(html: string): string {
+export function convertHtmlToText(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
   return doc.body.textContent || "";
 }
@@ -132,7 +132,7 @@ export function toClickToSearchUrl(
     return (
       config.instance.base.url +
       "/search/querySearch/" +
-      encodeURIComponent(stripTags(cleanedLinkText))
+      encodeURIComponent(convertHtmlToText(cleanedLinkText))
     );
   }
 


### PR DESCRIPTION
Fixes #217 

![ScreenShot 2023-08-23 at 14 28 53@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/0aea3ca9-86ae-4fce-962f-eef1a4235c28)

Renamed`stripTags` to `convertHtmlToText` since the function does more than just stripping tags. Some files touched by the name change.