### PR TITLE
always show adv search add field dropdown

### DIFF
--- a/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
+++ b/src/components/AdvancedSearchForm/FilterByFieldsSection.vue
@@ -35,10 +35,7 @@
     </div>
 
     <div class="flex justify-between items-baseline">
-      <AdvSearchDropDown
-        v-if="supportedSearchableFields.length"
-        label="Add Field"
-      >
+      <AdvSearchDropDown label="Add Field">
         <div class="divide-y divide-neutral-200">
           <div>
             <AdvSearchDropDownItem


### PR DESCRIPTION
Fixes Advanced search not offering any fields #216. 

Even if there are no supported searchable fields, there will always be global searches like Data, Location, and File Type.

![ScreenShot 2023-08-23 at 14 49 33@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/4bab3a05-3488-4365-b6ea-66ba3fe2479f)
