### PR TITLE
make related asset links flow as col

### DIFF
--- a/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
+++ b/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="related-asset-widget gap-2 flex flex-wrap w-full">
+  <div
+    class="related-asset-widget flex flex-wrap w-full"
+    :class="{
+      'flex-col gap-0': widgetType === LinkedRelatedAssetWidgetItem,
+      'gap-2': widgetType !== AccordionRelatedAssetWidgetItem,
+    }"
+  >
     <component
       :is="widgetType"
       v-for="relatedAsset in contentsWithAssetId"

--- a/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
+++ b/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
@@ -2,8 +2,8 @@
   <div
     class="related-asset-widget flex flex-wrap w-full"
     :class="{
-      'flex-col gap-0': widgetType === LinkedRelatedAssetWidgetItem,
-      'gap-2': widgetType !== AccordionRelatedAssetWidgetItem,
+      'flex-col gap-1 leading-5': widgetType === LinkedRelatedAssetWidgetItem,
+      'gap-2': widgetType !== LinkedRelatedAssetWidgetItem,
     }"
   >
     <component


### PR DESCRIPTION
Makes related asset links flow as a column to improve readability:

<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/288fef56-ff6c-41ba-99a0-04f11b637e77" width="500" />

Resolves #215