### PR TITLE
Support pages with iframes

### DIFF
--- a/src/components/SanitizedHTML/SanitizedHTML.vue
+++ b/src/components/SanitizedHTML/SanitizedHTML.vue
@@ -17,6 +17,7 @@ const props = withDefaults(
 
 const sanitizeConfig = {
   FORBID_ATTR: props.removeInlineStyles ? ["style"] : [],
+  ADD_TAGS: ["iframe"],
 };
 
 const sanitizedHtml = computed(() =>


### PR DESCRIPTION
This permits embedded `<iframe>` tags within sanitized html content. Fixes #225.

See: https://dev.elevator.umn.edu/defaultinstance/page/view/21
<img width="500" alt="ScreenShot 2023-08-28 at 14 40 42@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/32ba654e-3589-4b57-94b4-be16ed18186f">



