### PR TITLE
navigate to next file or related asset with left/right keypresses

### DIFF
--- a/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
+++ b/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
@@ -102,10 +102,16 @@ function handleNextPrevArrowPresses(event: KeyboardEvent) {
   }
 }
 
+const isThumbnailRelatedAsset = computed(
+  () => widgetType.value === ThumbnailRelatedAssetWidgetItem
+);
+
 onMounted(() => {
-  // if there aren't multiple files, don't bother
-  // listening for arrow key presses
-  if (contentsWithAssetId.value.length < 2) return;
+  // only listen for key presses if there are multiple assets
+  // and this is a thumbnail related asset widget
+  if (!isThumbnailRelatedAsset.value || contentsWithAssetId.value.length < 2) {
+    return;
+  }
   window.addEventListener("keydown", handleNextPrevArrowPresses);
 });
 

--- a/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
+++ b/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
@@ -10,8 +10,9 @@
       :is="widgetType"
       v-for="relatedAsset in contentsWithAssetId"
       :key="relatedAsset.targetAssetId"
+      :isActiveObject="assetStore.activeObjectId === relatedAsset.targetAssetId"
       :assetId="relatedAsset.targetAssetId"
-      :assetCache="asset.relatedAssetCache?.[relatedAsset.targetAssetId]"
+      :assetCacheItem="asset.relatedAssetCache?.[relatedAsset.targetAssetId]"
       :label="relatedAsset.label ?? ''"
     >
       <div class="flex items-center justify-end gap-2">
@@ -21,7 +22,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { type Component, computed } from "vue";
+import { type Component, computed, onMounted, onBeforeUnmount } from "vue";
 import {
   Asset,
   RelatedAssetWidgetProps,
@@ -32,6 +33,7 @@ import CollapsedInlineRelatedAssetWidgetItem from "./CollapsedInlineRelatedAsset
 import ThumbnailRelatedAssetWidgetItem from "./ThumbnailRelatedAssetWidgetItem.vue";
 import LinkedRelatedAssetWidgetItem from "./LinkedRelatedAssetWidgetItem.vue";
 import ArrowButton from "@/components/ArrowButton/ArrowButton.vue";
+import { useAssetStore } from "@/stores/assetStore";
 
 const props = defineProps<{
   widget: RelatedAssetWidgetProps;
@@ -40,6 +42,8 @@ const props = defineProps<{
 }>();
 
 type WithTargetAssetId<T> = T & { targetAssetId: string };
+
+const assetStore = useAssetStore();
 
 const widgetType = computed((): Component => {
   if (props.widget.fieldData.collapseNestedChildren) {
@@ -63,5 +67,50 @@ const contentsWithAssetId = computed(() =>
       !!item.targetAssetId
   )
 );
+
+const activeIndex = computed(() =>
+  contentsWithAssetId.value.findIndex(
+    (item) => item.targetAssetId === assetStore.activeObjectId
+  )
+);
+
+const hasActiveObjectWithin = computed(() => activeIndex.value !== -1);
+
+function setPrevObjectAsActive() {
+  const prevIndex =
+    (activeIndex.value - 1 + props.contents.length) % props.contents.length;
+  const prevObjectId = contentsWithAssetId.value[prevIndex].targetAssetId;
+  assetStore.setActiveObject(prevObjectId);
+}
+
+function setNextObjectAsActive() {
+  const nextIndex = (activeIndex.value + 1) % props.contents.length;
+  const nextObjectId = contentsWithAssetId.value[nextIndex].targetAssetId;
+  assetStore.setActiveObject(nextObjectId);
+}
+
+// within a widget, pressing the left or right arrow keys will
+// navigate to the previous or next file
+function handleNextPrevArrowPresses(event: KeyboardEvent) {
+  if (!hasActiveObjectWithin.value) return;
+
+  if (event.key === "ArrowLeft") {
+    return setPrevObjectAsActive();
+  }
+  if (event.key === "ArrowRight") {
+    return setNextObjectAsActive();
+  }
+}
+
+onMounted(() => {
+  // if there aren't multiple files, don't bother
+  // listening for arrow key presses
+  if (contentsWithAssetId.value.length < 2) return;
+  window.addEventListener("keydown", handleNextPrevArrowPresses);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", handleNextPrevArrowPresses);
+});
 </script>
 <style scoped></style>

--- a/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
@@ -10,8 +10,8 @@
     :to="`#${assetId}`"
   >
     <ThumbnailImage
-      v-if="assetCache.primaryHandler"
-      :src="getTinyURL(assetCache.primaryHandler)"
+      v-if="assetCacheItem.primaryHandler"
+      :src="getTinyURL(assetCacheItem.primaryHandler)"
       :alt="title"
       class="thumbnail-related-asset-widget__image max-w-full"
     />
@@ -27,7 +27,6 @@
 import { computed } from "vue";
 import { getTinyURL } from "@/helpers/displayUtils";
 import type { RelatedAssetCacheItem } from "@/types";
-import { useAssetStore } from "@/stores/assetStore";
 import { getTitleFromCacheItem } from "./getTitleFromCacheItem";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import ThumbnailGeneric from "@/components/ThumbnailGeneric/ThumbnailGeneric.vue";
@@ -35,15 +34,12 @@ import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 
 const props = defineProps<{
   assetId: string;
-  assetCache: RelatedAssetCacheItem;
+  assetCacheItem: RelatedAssetCacheItem;
+  isActiveObject: boolean;
 }>();
 
-const assetStore = useAssetStore();
-
-const title = computed((): string => getTitleFromCacheItem(props.assetCache));
-
-const isActiveObject = computed(
-  (): boolean => assetStore.activeObjectId === props.assetId
+const title = computed((): string =>
+  getTitleFromCacheItem(props.assetCacheItem)
 );
 </script>
 <style scoped></style>

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -53,22 +53,28 @@ const activeIndex = computed(() =>
 
 const hasActiveFileWithin = computed(() => activeIndex.value !== -1);
 
+function setPrevFileAsActive() {
+  const prevFileIndex =
+    (activeIndex.value - 1 + props.contents.length) % props.contents.length;
+  assetStore.activeFileObjectId = props.contents[prevFileIndex].fileId;
+}
+
+function setNextFileAsActive() {
+  const nextFileIndex = (activeIndex.value + 1) % props.contents.length;
+  assetStore.activeFileObjectId = props.contents[nextFileIndex].fileId;
+}
+
 // within a widget, pressing the left or right arrow keys will
 // navigate to the previous or next file
 function handleNextPrevArrowPresses(event: KeyboardEvent) {
   if (!hasActiveFileWithin.value) return;
 
-  const nextFileIndex = (activeIndex.value + 1) % props.contents.length;
-  const prevFileIndex =
-    (activeIndex.value - 1 + props.contents.length) % props.contents.length;
-
   if (event.key === "ArrowLeft") {
-    assetStore.activeFileObjectId = props.contents[prevFileIndex].fileId;
-    return;
+    return setPrevFileAsActive();
   }
+
   if (event.key === "ArrowRight") {
-    console.log("nextFileIndex", nextFileIndex);
-    assetStore.activeFileObjectId = props.contents[nextFileIndex].fileId;
+    return setNextFileAsActive();
   }
 }
 


### PR DESCRIPTION
This adds keyboard shortcuts for navigating between related assets or uploads on an asset view page. When viewing a file or object that's active, pressing left or right will move to the next/prev item within the group.

![ScreenShot 2023-08-28 at 16 25 33](https://github.com/UMN-LATIS/elevator-ui/assets/980170/4c43ddf0-27e3-4963-9d54-b1d34c888f2d)
