### PR TITLE
show search button on mobile

### DIFF
--- a/src/components/SearchBar/SearchTextInputGroup.vue
+++ b/src/components/SearchBar/SearchTextInputGroup.vue
@@ -5,6 +5,7 @@
     v-model="searchStore.query"
     label="Search"
     type="search"
+    inputmode="search"
     :labelHidden="true"
     placeholder="Search"
     inputClass="!rounded-full"

--- a/src/components/SearchBar/SearchTextInputGroup.vue
+++ b/src/components/SearchBar/SearchTextInputGroup.vue
@@ -4,6 +4,7 @@
     ref="inputGroup"
     v-model="searchStore.query"
     label="Search"
+    type="search"
     :labelHidden="true"
     placeholder="Search"
     inputClass="!rounded-full"

--- a/src/components/SearchBar/SearchTextInputGroup.vue
+++ b/src/components/SearchBar/SearchTextInputGroup.vue
@@ -49,7 +49,7 @@
           </button>
         </div>
         <button
-          class="hidden md:inline-flex items-center justify-center bg-transparent-black-100 w-8 h-8 text-sm rounded-full text-neutral-900 gap-1 hover:bg-neutral-900 hover:text-neutral-200 transition:ease-in-out duration-150"
+          class="inline-flex items-center justify-center bg-transparent-black-100 w-8 h-8 text-sm rounded-full text-neutral-900 gap-1 hover:bg-neutral-900 hover:text-neutral-200 transition:ease-in-out duration-150"
           type="submit"
         >
           <SpinnerIcon


### PR DESCRIPTION
Remove hiding of search button on smaller screen. Changes `type` and `inputmode` on input element, so that the mobile device virtual keyboard shows a non-default button.

<img width="413" alt="CleanShot 2023-09-06 at 11 42 56@2x" src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/d6c94de4-f905-4d4a-9e38-8c77b8f77acf">
