### PR TITLE
support hiding tab buttons with custom css

### DIFF
--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -4,12 +4,14 @@
       <button
         v-for="tab in tabs"
         :key="tab.id"
-        class="tab-button px-4 py-2 text-sm border-b-2"
-        :class="{
-          'border-transparent text-neutral-400': tab.id !== activeTabId,
-          'tab-button--is-active border-neutral-900 text-neutral-900 font-bold':
-            tab.id === activeTabId,
-        }"
+        :class="[
+          `tab-button tab-button--${tab.id} px-4 py-2 text-sm border-b-2`,
+          {
+            'border-transparent text-neutral-400': tab.id !== activeTabId,
+            'tab-button--is-active border-neutral-900 text-neutral-900 font-bold':
+              tab.id === activeTabId,
+          },
+        ]"
         @click="setActiveTab(tab.id)"
       >
         {{ tab.label }}


### PR DESCRIPTION
This adding a stable custom CSS class on each tab button, so that an admin could include custom CSS to hide search tabs like:

```css
.tab-button--timeline { display: none; }
```

This complements https://github.com/UMN-LATIS/elevator/pull/150, which adds the custom CSS to the vue template.

Closes #144 