### PR TITLE
fix: related asset titles not being used in some cases.

### DIFF
--- a/src/components/Widget/RelatedAssetWidget/AccordionRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/AccordionRelatedAssetWidgetItem.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="accordion-related-asset-widget-item w-full max-w-lg">
     <Accordion :label="title">
-      <template v-if="assetCache?.primaryHandler" #label>
+      <template v-if="assetCacheItem?.primaryHandler" #label>
         <div
-          v-if="assetCache?.primaryHandler"
+          v-if="assetCacheItem?.primaryHandler"
           class="flex items-center flex-1 w-full gap-4 py-2 pl-2 pr-4"
         >
           <img
-            v-if="assetCache.primaryHandler"
-            :src="getTinyURL(assetCache.primaryHandler)"
+            v-if="assetCacheItem.primaryHandler"
+            :src="getTinyURL(assetCacheItem.primaryHandler)"
             :alt="title"
             class="aspect-square h-10 overflow-hidden rounded"
             loading="lazy"
@@ -31,9 +31,9 @@ import { getTinyURL } from "@/helpers/displayUtils";
 
 const props = defineProps<{
   assetId: string;
-  assetCache: RelatedAssetCacheItem | null;
+  assetCacheItem: RelatedAssetCacheItem | null;
 }>();
 
-const title = computed(() => getTitleFromCacheItem(props.assetCache));
+const title = computed(() => getTitleFromCacheItem(props.assetCacheItem));
 </script>
 <style scoped></style>

--- a/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
@@ -16,10 +16,10 @@ import { useAsset } from "@/helpers/useAsset";
 
 const props = defineProps<{
   assetId: string;
-  assetCache: RelatedAssetCacheItem | null;
+  assetCacheItem: RelatedAssetCacheItem | null;
 }>();
 
-const title = computed(() => getTitleFromCacheItem(props.assetCache));
+const title = computed(() => getTitleFromCacheItem(props.assetCacheItem));
 const assetIdRef = computed(() => props.assetId);
 const { asset } = useAsset(assetIdRef);
 </script>

--- a/src/components/Widget/RelatedAssetWidget/LinkedRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/LinkedRelatedAssetWidgetItem.vue
@@ -12,10 +12,12 @@ import Link from "@/components/Link/Link.vue";
 
 const props = defineProps<{
   assetId: string;
-  assetCache: RelatedAssetCacheItem | null;
+  assetCacheItem: RelatedAssetCacheItem | null;
 }>();
 
-const title = computed((): string => getTitleFromCacheItem(props.assetCache));
+const title = computed((): string =>
+  getTitleFromCacheItem(props.assetCacheItem)
+);
 const assetUrl = computed((): string => getAssetUrl(props.assetId));
 </script>
 <style scoped></style>


### PR DESCRIPTION
This fixes #234 : Related Asset Cache Titles aren't being used in some cases 

The suggestion issue was correct: The <RelatedAssetWidget> passes `assetCacheItem`, not `assetCache` to child components, but some of those children were expecting an `assetCache` prop. This updates to use `assetCacheItem`.

(Aside: it'd be nice if one could declare an interface for dynamic `<component>`s, so the linter would check if there's a prop mismatch like this... maybe there is?)