### PR TITLE
fix: lng lat label overflow

### DIFF
--- a/src/components/Widget/LocationWidget/LocationItem.vue
+++ b/src/components/Widget/LocationWidget/LocationItem.vue
@@ -1,13 +1,9 @@
 <template>
   <Accordion>
     <template #label>
-      <div v-if="!locationLabel" class="flex gap-6 p-4">
-        <Tuple label="Latitude" class="w-auto" variant="inline">{{
-          latStr
-        }}</Tuple>
-        <Tuple label="Longitude" class="w-auto" variant="inline">{{
-          lngStr
-        }}</Tuple>
+      <div v-if="!locationLabel" class="flex gap-4 p-4 pr-0 flex-wrap">
+        <Tuple label="Lat" class="w-auto" variant="inline">{{ latStr }}</Tuple>
+        <Tuple label="Lng" class="w-auto" variant="inline">{{ lngStr }}</Tuple>
       </div>
       <span v-else class="p-4">{{ locationLabel }}</span>
     </template>


### PR DESCRIPTION
Using the `inline` variant of Tuple causes will crop off some of the lng data and the accordion chevron because "Longitude" and "Latitude" are a bit long.

This:
- abbreviates with "Lng" and "Lat"
- removes unnecessary right padding that's causing a flexbox overflow with the chevron.
- adds flex-wrap, just in cause some screensizes or fonts or whatever still cause an overflow.

<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/e3124198-a8fd-4be2-86ee-6af571fbfae2" width="400" />
