### PR TITLE
fix: map marker not rendering if no primaryHandlerId

### DIFF
--- a/src/components/Map/Map.vue
+++ b/src/components/Map/Map.vue
@@ -65,7 +65,6 @@ import { LngLat, BoundingBox, MapContext, AddMarkerArgs } from "@/types";
 import { MapInjectionKey } from "@/constants/mapConstants";
 import Skeleton from "../Skeleton/Skeleton.vue";
 import { Point } from "geojson";
-import { useThrottleFn } from "@vueuse/core";
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/Map/Map.vue
+++ b/src/components/Map/Map.vue
@@ -377,7 +377,7 @@ onMounted(() => {
     .on("mouseleave", UNCLUSTERED_LAYER_ID, function () {
       map.getCanvas().style.cursor = "";
     })
-    .on("styledata", (event) => {
+    .on("styledata", () => {
       // add the source and layers for the markers and clusters
       // do this here instead of in the `load` event because the style
       // may change after the map is loaded

--- a/src/components/MapMarker/MapMarker.vue
+++ b/src/components/MapMarker/MapMarker.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { type Ref, onUnmounted, watch } from "vue";
+import { type Ref, onUnmounted, watch, onMounted } from "vue";
 import { inject, provide } from "vue";
 import { MapInjectionKey, MarkerInjectionKey } from "@/constants/mapConstants";
 import { MapContext, MarkerContext } from "@/types";
@@ -17,23 +17,19 @@ const props = defineProps<{
 
 const mapContext = inject<MapContext>(MapInjectionKey);
 
-watch(
-  [() => props.lng, () => props.lat],
-  () => {
-    if (!mapContext) {
-      throw new Error(
-        `Cannot add marker ${props.id} for [${props.lng}, ${props.lat}]. Map context is null.`
-      );
-    }
+onMounted(() => {
+  if (!mapContext) {
+    throw new Error(
+      `Cannot add marker ${props.id} for [${props.lng}, ${props.lat}]. Map context is null.`
+    );
+  }
 
-    mapContext.createOrUpdateMarker({
-      id: props.id,
-      lng: props.lng,
-      lat: props.lat,
-    });
-  },
-  { immediate: true }
-);
+  mapContext.createOrUpdateMarker({
+    id: props.id,
+    lng: props.lng,
+    lat: props.lat,
+  });
+});
 
 onUnmounted(() => {
   if (!mapContext) {

--- a/src/components/MapMarker/MapMarker.vue
+++ b/src/components/MapMarker/MapMarker.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { type Ref, onUnmounted, watch, onMounted } from "vue";
+import { type Ref, onUnmounted, onMounted } from "vue";
 import { inject, provide } from "vue";
 import { MapInjectionKey, MarkerInjectionKey } from "@/constants/mapConstants";
 import { MapContext, MarkerContext } from "@/types";
@@ -24,7 +24,7 @@ onMounted(() => {
     );
   }
 
-  mapContext.createOrUpdateMarker({
+  mapContext.addMarker({
     id: props.id,
     lng: props.lng,
     lat: props.lat,

--- a/src/components/SearchResultsMap/SearchResultsMap.vue
+++ b/src/components/SearchResultsMap/SearchResultsMap.vue
@@ -109,7 +109,7 @@ interface SearchResultMapMarker {
   id: string;
   assetUrl: string;
   title: string;
-  imgSrc: string;
+  imgSrc: string | null; // if there's no primaryHandlerId, this will be null
   entries: SearchResultMatchEntry[];
   lat: number;
   lng: number;
@@ -124,10 +124,10 @@ function getMatchTitle(match: SearchResultMatch): string {
 
 const markers = computed((): SearchResultMapMarker[] => {
   return props.matches.reduce((acc, match) => {
-    if (!match.primaryHandlerId) return acc;
-
     const assetUrl = getAssetUrl(match.objectId);
-    const imgSrc = getThumbURL(match.primaryHandlerId);
+    const imgSrc = match.primaryHandlerId
+      ? getThumbURL(match.primaryHandlerId)
+      : null;
     const title = getMatchTitle(match);
     const lngLats = convertSearchResultToLngLats(match);
 

--- a/src/components/SearchResultsMap/SearchResultsMap.vue
+++ b/src/components/SearchResultsMap/SearchResultsMap.vue
@@ -16,7 +16,7 @@
       </Button>
     </div>
     <Map
-      v-if="markers.length > 0"
+      v-show="markers.length > 0"
       :zoom="10"
       mapStyle="light"
       :apiKey="config.arcgis.apiKey"

--- a/src/components/SearchResultsMap/SearchResultsMap.vue
+++ b/src/components/SearchResultsMap/SearchResultsMap.vue
@@ -124,12 +124,14 @@ function getMatchTitle(match: SearchResultMatch): string {
 
 const markers = computed((): SearchResultMapMarker[] => {
   return props.matches.reduce((acc, match) => {
+    const lngLats = convertSearchResultToLngLats(match);
+    if (!lngLats.length) return acc;
+
     const assetUrl = getAssetUrl(match.objectId);
     const imgSrc = match.primaryHandlerId
       ? getThumbURL(match.primaryHandlerId)
       : null;
     const title = getMatchTitle(match);
-    const lngLats = convertSearchResultToLngLats(match);
 
     const markersForThisMatch = lngLats.map((lngLat) => ({
       id: `${match.objectId}-${lngLat.lng}-${lngLat.lat}`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -631,13 +631,14 @@ export interface AddMarkerArgs {
 }
 
 export interface MapContext {
-  createOrUpdateMarker: (args: AddMarkerArgs) => GeoJSON.Feature;
+  addMarker: (args: AddMarkerArgs) => GeoJSON.Feature;
   removeMarker: (markerId: string) => void;
   setMarkerPopupContainer: (
     markerId: string,
     popupContainerRef: Ref<HTMLElement | null>
   ) => void;
   removeMarkerPopup: (markerId: string) => void;
+  renderMarkers: () => void;
 }
 
 export interface LocalLoginResponse {


### PR DESCRIPTION
This resolves #243, an issue where only a subset of results with locations where showing on the map search results page.

![ScreenShot 2023-10-03 at 20 23 39@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/2c05083f-27e6-4481-ad37-e6aca247b52a)

The issue was the check for `primaryHandlerId`: when a search result had no `primaryHandlerId`, the loop skipped rendering the map marker.

A `primaryHandlerId` is needed for rendering a thumbURL, but not every match will have a thumbnail  (assets that are  "metadata only" won't have a `primaryHandlerId`, but they will still have a location). 

This PR allows `imgSrc` to be null, and instead skips any matches without locations.

An additional issue was uncovered once all map markers started loading: `Maximum recursive updates exceeded.`
<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/d0a7fc4e-9f04-4fbe-8938-7a07a4e05a03" width="600" />

This was caused by a conflict between the `watch`ers on `markers` (vue api) and the event listener for `styledata` changes (mapbox api).  I think the old `watch`ers on `markers` were before we started clustering map markers on zoom. Map clustering requires rending markers a different way. So, I've removed the old `watch` on the markers. (I didn't see a noticeable change in performance, but it stopped the vue warnings.)
