### PR TITLE
fix: move add results to drawer button to results/sort bar

### DIFF
--- a/src/components/SearchResultsSortSelect/SearchResultsSortSelect.vue
+++ b/src/components/SearchResultsSortSelect/SearchResultsSortSelect.vue
@@ -4,7 +4,7 @@
     <select
       id="sort"
       name="sort"
-      class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-neutral-900 ring-1 ring-inset ring-neutral-300 focus:ring-2 focus:ring-indigo-600 text-sm sm:leading-6 max-w-full bg-transparent-white-800"
+      class="block w-full rounded-md border-0 py-2 pl-3 pr-10 text-neutral-900 ring-1 ring-inset ring-neutral-300 focus:ring-2 focus:ring-indigo-600 text-sm sm:leading-6 max-w-full bg-transparent-white-800"
       :value="selectedSortOption"
       @change="handleOptionChange"
     >

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -13,15 +13,6 @@
             <span v-else>Search Results</span>
           </h2>
           <Skeleton v-else class="!w-1/2 !h-12" />
-
-          <div
-            v-if="
-              searchStore.isReady && instanceStore.currentUser?.canManageDrawers
-            "
-            class="flex items-center p-1 bg-white rounded-md"
-          >
-            <AddSearchResultsToDrawerButton />
-          </div>
         </div>
 
         <DidYouMeanSuggestions
@@ -35,26 +26,36 @@
           @tabChange="handleTabChange"
         >
           <div
-            class="sm:flex justify-between items-baseline bg-transparent-black-50 rounded-md mb-4"
+            class="sm:flex justify-between items-center bg-transparent-black-50 rounded-md mb-4 p-2 flex-wrap"
           >
             <ResultsCount
-              class="mb-2 sm:mb-0 p-2"
+              class="mb-2 sm:mb-0"
               :fetchStatus="searchStore.status"
               :showingCount="searchStore.matches.length"
               :total="searchStore.totalResults ?? 0"
               @loadMore="searchStore.loadMore"
               @loadAll="searchStore.loadMore({ loadAll: true })"
             />
-            <SearchResultsSortSelect
-              v-if="!['map', 'timeline'].includes(searchStore.resultsView)"
-              class="p-2"
-              :sortOptions="searchStore.sortOptions"
-              :selectedSortOption="searchStore.sort"
-              :searchQuery="
-                searchStore.searchEntry?.searchText ?? searchStore.query
-              "
-              @sortOptionChange="handleSortOptionChange"
-            />
+            <div class="flex items-center gap-2">
+              <SearchResultsSortSelect
+                v-if="!['map', 'timeline'].includes(searchStore.resultsView)"
+                :sortOptions="searchStore.sortOptions"
+                :selectedSortOption="searchStore.sort"
+                :searchQuery="
+                  searchStore.searchEntry?.searchText ?? searchStore.query
+                "
+                @sortOptionChange="handleSortOptionChange"
+              />
+              <div
+                v-if="
+                  searchStore.isReady &&
+                  instanceStore.currentUser?.canManageDrawers
+                "
+                class="flex items-center w-10 h-10 bg-white rounded-md border border-neutral-300 justify-center"
+              >
+                <AddSearchResultsToDrawerButton />
+              </div>
+            </div>
           </div>
           <Tab id="grid" label="Grid">
             <SearchResultsGrid


### PR DESCRIPTION
![ScreenShot 2023-10-04 at 15 11 05@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/3c957830-1651-44a0-ac20-065d266756e7)

Fixes #244.

Previously, the add results to drawer button was aligned vertically center with the search results page header.  This would be difficult to find and jump around when a page had a large custom header.  This moves the button to the results count/sort bar, so that it's in a consistent position regardless of header size.