### PR TITLE
Add some helpers for editing static content pages

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,4 @@
-{}
+{
+  "htmlWhitespaceSensitivity": "ignore",
+  "bracketSameLine": true
+}

--- a/public/img/warning-icon.svg
+++ b/public/img/warning-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+</svg>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -228,27 +228,24 @@ h6 {
 
 .el-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   grid-gap: 1rem;
-}
-
-.el-grid--2-cols,
-.el-grid--1\/2-1\/2 {
-  grid-template-columns: repeat(2, minmax(300px, 1fr));
-}
-
-.el-grid--2\/3-1\/3 {
   grid-template-columns: 1fr;
 }
 
 @media (min-width: 480px) {
-  .el-grid--2\/3-1\/3 {
-    grid-template-columns: 2fr 1fr;
+  .el-grid--2-cols,
+  .el-grid--1\/2-1\/2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-}
-
-.el-grid--3-cols {
-  grid-template-columns: repeat(3, minmax(300px, 1fr));
+  .el-grid--3-cols {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .el-grid--2\/3-1\/3 {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  }
+  .el-grid--1\/3-2\/3 {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+  }
 }
 
 /** END CLASSES THAT CAN BE USED ON STATIC PAGES **/

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -96,6 +96,18 @@ a:hover {
   color: var(--app-textColor);
 }
 
+.prose img,
+.prose iframe {
+  border: 1px solid #ccc;
+  background: #eee;
+  border-radius: 0.5rem;
+}
+
+.prose iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
 h1,
 h2,
 h3,

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -246,6 +246,12 @@ h6 {
   .el-grid--1\/3-2\/3 {
     grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   }
+  .el-grid--1\/4-1\/4-1\/2 {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
+  }
+  .el-grid--1\/2-1\/4-1\/4 {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+  }
 }
 
 /** END CLASSES THAT CAN BE USED ON STATIC PAGES **/

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -108,6 +108,10 @@ a:hover {
   aspect-ratio: 16 / 9;
 }
 
+.prose a {
+  font-weight: inherit;
+}
+
 h1,
 h2,
 h3,
@@ -228,8 +232,19 @@ h6 {
   grid-gap: 1rem;
 }
 
-.el-grid--2-cols {
+.el-grid--2-cols,
+.el-grid--1\/2-1\/2 {
   grid-template-columns: repeat(2, minmax(300px, 1fr));
+}
+
+.el-grid--2\/3-1\/3 {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 480px) {
+  .el-grid--2\/3-1\/3 {
+    grid-template-columns: 2fr 1fr;
+  }
 }
 
 .el-grid--3-cols {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -210,4 +210,18 @@ h6 {
   background-image: url("/img/warning-icon.svg");
 }
 
+.el-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-gap: 1rem;
+}
+
+.el-grid--2-cols {
+  grid-template-columns: repeat(2, minmax(300px, 1fr));
+}
+
+.el-grid--3-cols {
+  grid-template-columns: repeat(3, minmax(300px, 1fr));
+}
+
 /** END CLASSES THAT CAN BE USED ON STATIC PAGES **/

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -155,14 +155,6 @@ h6 {
 * (all prefixed with `el-` to avoid conflicts)
 **/
 
-.el-static-page-img {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  background: #ddd;
-  width: 100%;
-}
-
 .el-btn {
   display: inline-block;
   border: var(--app-button-borderWidth) solid var(--app-button-borderColor);

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -149,3 +149,73 @@ h6 {
     transform: translate3d(4px, 0, 0);
   }
 }
+
+/**
+* CLASSES THAT CAN BE USED ON STATIC PAGES
+* (all prefixed with `el-` to avoid conflicts)
+**/
+
+.el-static-page-img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  background: #ddd;
+  width: 100%;
+}
+
+.el-btn {
+  display: inline-block;
+  border: var(--app-button-borderWidth) solid var(--app-button-borderColor);
+  background: var(--app-button-primary-backgroundColor);
+  color: var(--app-button-primary-textColor);
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    border-color: var(--app-button-primary-hover-borderColor);
+    background: var(--app-button-primary-hover-backgroundColor);
+    color: var(--app-button-primary-hover-textColor);
+    text-decoration: none;
+  }
+
+  &:active {
+    border-color: var(--app-button-primary-active-borderColor);
+    background: var(--app-button-primary-active-backgroundColor);
+    color: var(--app-button-primary-active-textColor);
+    text-decoration: none;
+  }
+
+  &:disabled {
+    border-color: var(--app-button-primary-disabled-borderColor);
+    background: var(--app-button-primary-disabled-backgroundColor);
+    color: var(--app-button-primary-disabled-textColor);
+    cursor: not-allowed;
+  }
+}
+
+.el-text-center {
+  @apply text-center;
+}
+
+.el-alert {
+  @apply p-4 text-neutral-900 rounded-2xl border border-solid border-neutral-100 bg-neutral-100 text-sm;
+  background-image: url("/img/warning-icon.svg");
+  background-position: 1rem 1.25rem;
+  background-repeat: no-repeat;
+  background-size: 1.5rem;
+  padding-left: 3.5rem;
+
+  & p {
+    margin-bottom: 0;
+    margin-top: 0.5em;
+  }
+}
+
+.el-alert-warning {
+  @apply bg-amber-300;
+  background-image: url("/img/warning-icon.svg");
+}
+
+/** END CLASSES THAT CAN BE USED ON STATIC PAGES **/

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -133,4 +133,11 @@ watch(
 .featured-asset-block {
   border-left: var(--border-width) solid var(--border-color);
 }
+
+.prose img,
+.prose iframe {
+  border: 1px solid #ccc;
+  background: #eee;
+  border-radius: 0.5rem;
+}
 </style>

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -5,23 +5,20 @@
     </template>
     <SignInRequiredNotice
       v-if="isReady && !canSearchAndBrowse && !instanceStore.isLoggedIn"
-      class="my-8 mx-4"
-    />
+      class="my-8 mx-4" />
     <div
       v-if="isReady && canSearchAndBrowse"
       class="home-page-content flex-1 md:grid max-w-screen-xl w-full mx-auto"
       :class="{
         'md:grid-cols-2': !featuredAssetId,
         'md:grid-cols-3': featuredAssetId,
-      }"
-    >
+      }">
       <article class="page-content-block col-span-2 p-4 lg:p-8">
         <Transition v-if="page" name="fade">
           <SanitizedHTML
             v-if="page.content"
             :html="page.content"
-            class="prose prose-neutral"
-          />
+            class="prose prose-neutral" />
           <section v-else class="bg-white p-8 my-8 shadow-sm">
             <h1 class="text-4xl text-center font-bold">
               {{ instanceStore.instance?.name ?? "Elevator" }}
@@ -31,8 +28,7 @@
       </article>
       <aside
         v-if="featuredAssetId"
-        class="featured-asset-block col-span-1 p-4 lg:p-8"
-      >
+        class="featured-asset-block col-span-1 p-4 lg:p-8">
         <h2 class="text-sm font-bold uppercase mb-2">Featured</h2>
         <div class="mb-4">
           <SanitizedHTML :html="featuredAssetText" />
@@ -43,8 +39,7 @@
     <Notification
       v-else-if="isReady && !canSearchAndBrowse && instanceStore.isLoggedIn"
       title="Nothing to See Here"
-      class="my-8 mx-4"
-    >
+      class="my-8 mx-4">
       <p>
         Your account does not have permission to search and browse assets.
         Please contact your administrator if you believe this is an error.
@@ -139,5 +134,10 @@ watch(
   border: 1px solid #ccc;
   background: #eee;
   border-radius: 0.5rem;
+}
+
+.prose iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
 }
 </style>

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -128,16 +128,4 @@ watch(
 .featured-asset-block {
   border-left: var(--border-width) solid var(--border-color);
 }
-
-.prose img,
-.prose iframe {
-  border: 1px solid #ccc;
-  background: #eee;
-  border-radius: 0.5rem;
-}
-
-.prose iframe {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-}
 </style>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -5,13 +5,12 @@
     </template>
     <div
       v-if="page"
-      class="static-page__content p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl"
-    >
+      class="static-page__content p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl">
       <a
         v-if="canCurrentUserEdit"
         :href="`${BASE_URL}/instances/editPage/${pageId}`"
-        class="float-right uppercase text-xs font-medium bg-blue-100 px-2 py-1 rounded-md no-underline hover:bg-blue-600 hover:text-blue-100 hover:no-underline"
-        >Edit Page
+        class="float-right uppercase text-xs font-medium bg-blue-100 px-2 py-1 rounded-md no-underline hover:bg-blue-600 hover:text-blue-100 hover:no-underline">
+        Edit Page
       </a>
       <div class="prose prose-neutral mx-auto">
         <h1 class="text-4xl font-bold">
@@ -75,5 +74,10 @@ watch(
   border: 1px solid #ccc;
   background: #eee;
   border-radius: 0.5rem;
+}
+
+.prose iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
 }
 </style>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -13,7 +13,7 @@
         class="float-right uppercase text-xs font-medium bg-blue-100 px-2 py-1 rounded-md no-underline hover:bg-blue-600 hover:text-blue-100 hover:no-underline"
         >Edit Page
       </a>
-      <div class="prose prose-neutral">
+      <div class="prose prose-neutral mx-auto">
         <h1 class="text-4xl font-bold">
           {{ page.title || "No Title" }}
         </h1>
@@ -69,5 +69,11 @@ watch(
 
 .prose :first-child {
   margin-top: 0;
+}
+.prose img,
+.prose iframe {
+  border: 1px solid #ccc;
+  background: #eee;
+  border-radius: 0.5rem;
 }
 </style>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -7,10 +7,17 @@
       v-if="page"
       class="static-page__content p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl"
     >
+      <a
+        v-if="canCurrentUserEdit"
+        :href="`${BASE_URL}/instances/editPage/${pageId}`"
+        class="float-right uppercase text-xs font-medium bg-blue-100 px-2 py-1 rounded-md no-underline hover:bg-blue-600 hover:text-blue-100 hover:no-underline"
+        >Edit Page
+      </a>
       <div class="prose prose-neutral">
         <h1 class="text-4xl font-bold">
           {{ page.title || "No Title" }}
         </h1>
+
         <SanitizedHTML :html="page.content ?? ''" class="w-full" />
       </div>
     </div>
@@ -24,10 +31,11 @@ import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import AppFooter from "@/components/AppFooter/AppFooter.vue";
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { ApiStaticPageResponse } from "@/types";
 import { useInstanceStore } from "@/stores/instanceStore";
 import api from "@/api";
+import config from "@/config";
 
 const instanceStore = useInstanceStore();
 
@@ -35,7 +43,15 @@ const props = defineProps<{
   pageId: number;
 }>();
 
+const BASE_URL = config.instance.base.path;
 const page = ref<ApiStaticPageResponse | null>(null);
+
+const canCurrentUserEdit = computed(() => {
+  return (
+    instanceStore.currentUser?.isAdmin ||
+    instanceStore.currentUser?.isSuperAdmin
+  );
+});
 
 watch(
   () => props.pageId,

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -69,15 +69,4 @@ watch(
 .prose :first-child {
   margin-top: 0;
 }
-.prose img,
-.prose iframe {
-  border: 1px solid #ccc;
-  background: #eee;
-  border-radius: 0.5rem;
-}
-
-.prose iframe {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-}
 </style>

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -13,8 +13,8 @@
         Edit Page
       </a>
       <div class="prose prose-neutral mx-auto">
-        <h1 class="text-4xl font-bold">
-          {{ page.title || "No Title" }}
+        <h1 class="text-4xl font-bold text-center">
+          {{ page.title || "Untitled" }}
         </h1>
 
         <SanitizedHTML :html="page.content ?? ''" class="w-full" />


### PR DESCRIPTION
- Adds layout classes that content editors can use on static pages if they want to add some layout. These are namespaced under `el-` to keep these abstracted away from a specific framework (tailwind, bootstrap). I chose a BEM approach where multiple classes can be applied like `el-grid el-grid--2/3-1/3` for a 2 column layout with first col 2/3 width and second 1/3 width.
- NIBSDA static page content has been prepped for migration to new ui. They're available for review on https://dev.elevator.umn.edu/defaultinstance/. Content is also saved in [its own private repo](https://github.com/UMN-LATIS/nibsda-static-page-content) with a few notes. Principally, the content just needs to use semantic markup (`p` instead of `h5`), remove inline styles, and change to `el-` classes where advanced layout is needed.
- Add an "Edit" button to static content page for Admins:

<img src="https://github.com/UMN-LATIS/elevator-ui/assets/980170/3216595d-b9a5-4106-b7d8-5c78f7700ef0" width="480" alt="Edit button added to page" />

- fixed some alignment on the static pages. Content container and page title now centered.

