### PR TITLE
Make search results map, gallery, and timeline view embeddable

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -246,11 +246,23 @@ export async function fetchSearchId(
 
 export async function fetchSearchResultsById(
   searchId: string,
-  page: number,
-  loadAll: boolean
+  opts: {
+    page?: number;
+    loadAll?: boolean;
+  } = {}
 ) {
+  const defaultOpts = {
+    page: 0,
+    loadAll: false,
+  };
+
+  const finalOpts = {
+    ...defaultOpts,
+    ...opts,
+  };
+
   const res = await axios.get<SearchResultsResponse>(
-    `${BASE_URL}/search/searchResults/${searchId}/${page}/${loadAll}`
+    `${BASE_URL}/search/searchResults/${searchId}/${finalOpts.page}/${finalOpts.loadAll}`
   );
 
   const searchResults = res.data;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -164,25 +164,33 @@ async function getSearchIdForCollection(collectionId: number): Promise<string> {
 
 async function getSearchResultsById(
   searchId: string,
-  page = 0,
-  loadAll = false
+  opts: { page?: number; loadAll?: boolean } = {}
 ): Promise<SearchResultsResponse> {
+  const defaultOpts = {
+    page: 0,
+    loadAll: false,
+  };
+
+  const finalOpts = {
+    ...defaultOpts,
+    ...opts,
+  };
+
   // check the cache first
   const searchMap = cache.paginatedSearchResults.get(searchId);
-  if (searchMap && searchMap[page]) {
-    return searchMap[page];
+  if (searchMap && searchMap[finalOpts.page]) {
+    return searchMap[finalOpts.page];
   }
 
   const searchResults = await fetchers.fetchSearchResultsById(
     searchId,
-    page,
-    loadAll
+    finalOpts
   );
 
   // cache the results
   cache.paginatedSearchResults.set(searchId, {
     ...(searchMap || {}), // add to existing cache if it exists
-    [page]: searchResults,
+    [finalOpts.page]: searchResults,
   });
   return searchResults;
 }

--- a/src/components/ShareButton/ShareButton.vue
+++ b/src/components/ShareButton/ShareButton.vue
@@ -1,0 +1,45 @@
+<template>
+  <IconButton title="Share" @click="isOpen = !isOpen">
+    <ShareIcon />
+    <span class="sr-only">Share</span>
+  </IconButton>
+  <Modal
+    label="Share"
+    :isOpen="isOpen"
+    class="max-w-xl mx-auto"
+    @close="isOpen = false">
+    <div class="flex flex-col gap-4">
+      <CopyableTextArea label="Embed" :value="embedValue" />
+      <CopyableTextArea label="Link" :value="props.url" />
+      <Button
+        icon="open_in_new"
+        label="Open in New Window"
+        :href="props.url"
+        target="_blank">
+        Open Viewer in New Window
+      </Button>
+    </div>
+  </Modal>
+</template>
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import IconButton from "@/components/IconButton/IconButton.vue";
+import Modal from "@/components/Modal/Modal.vue";
+import CopyableTextArea from "@/components/CopyableTextArea/CopyableTextArea.vue";
+import Button from "@/components/Button/Button.vue";
+import ShareIcon from "@/icons/ShareIcon.vue";
+
+const props = defineProps<{
+  url: string;
+}>();
+
+const removeExtraWhitespace = (str: string) => str.replace(/\s+/g, " ").trim();
+
+const isOpen = ref(false);
+
+const embedValue = computed(() => {
+  return removeExtraWhitespace(`
+  <iframe width="560" height="480" src="${props.url}" frameborder="0" allowfullscreen></iframe>`);
+});
+</script>
+<style scoped></style>

--- a/src/components/ShareButton/ShareButton.vue
+++ b/src/components/ShareButton/ShareButton.vue
@@ -2,24 +2,24 @@
   <IconButton title="Share" @click="isOpen = !isOpen">
     <ShareIcon />
     <span class="sr-only">Share</span>
+    <Modal
+      label="Share"
+      :isOpen="isOpen"
+      class="max-w-xl mx-auto"
+      @close="isOpen = false">
+      <div class="flex flex-col gap-4">
+        <CopyableTextArea label="Embed" :value="embedValue" />
+        <CopyableTextArea label="Link" :value="props.url" />
+        <Button
+          icon="open_in_new"
+          label="Open in New Window"
+          :href="props.url"
+          target="_blank">
+          Open Viewer in New Window
+        </Button>
+      </div>
+    </Modal>
   </IconButton>
-  <Modal
-    label="Share"
-    :isOpen="isOpen"
-    class="max-w-xl mx-auto"
-    @close="isOpen = false">
-    <div class="flex flex-col gap-4">
-      <CopyableTextArea label="Embed" :value="embedValue" />
-      <CopyableTextArea label="Link" :value="props.url" />
-      <Button
-        icon="open_in_new"
-        label="Open in New Window"
-        :href="props.url"
-        target="_blank">
-        Open Viewer in New Window
-      </Button>
-    </div>
-  </Modal>
 </template>
 <script setup lang="ts">
 import { computed, ref } from "vue";

--- a/src/components/ShareFileButton/ShareFileButton.vue
+++ b/src/components/ShareFileButton/ShareFileButton.vue
@@ -1,51 +1,18 @@
 <template>
-  <IconButton title="Share" @click="isOpen = !isOpen">
-    <ShareIcon />
-    <span class="sr-only">Share</span>
-  </IconButton>
-  <Modal
-    label="Share"
-    :isOpen="isOpen"
-    class="max-w-xl mx-auto"
-    @close="isOpen = false"
-  >
-    <div class="flex flex-col gap-4">
-      <CopyableTextArea label="Embed" :value="embedValue" />
-      <CopyableTextArea label="Link" :value="linkValue" />
-      <Button
-        icon="open_in_new"
-        label="Open in New Window"
-        :href="linkValue"
-        target="_blank"
-        >Open Viewer in New Window</Button
-      >
-    </div>
-  </Modal>
+  <ShareButton :url="url" />
 </template>
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import IconButton from "@/components/IconButton/IconButton.vue";
+import ShareButton from "@/components/ShareButton/ShareButton.vue";
+import { computed } from "vue";
 import config from "@/config";
-import Modal from "@/components/Modal/Modal.vue";
-import CopyableTextArea from "@/components/CopyableTextArea/CopyableTextArea.vue";
-import Button from "@/components/Button/Button.vue";
-import ShareIcon from "@/icons/ShareIcon.vue";
 
 const props = defineProps<{
   fileObjectId: string;
 }>();
 
-const removeExtraWhitespace = (str: string) => str.replace(/\s+/g, " ").trim();
-
-const isOpen = ref(false);
-const linkValue = computed(
+const url = computed(
   () =>
     `${config.instance.base.url}/asset/getEmbed/${props.fileObjectId}/null/true`
 );
-
-const embedValue = computed(() => {
-  return removeExtraWhitespace(`
-  <iframe width="560" height="480" src="${linkValue.value}" frameborder="0" allowfullscreen></iframe>`);
-});
 </script>
 <style scoped></style>

--- a/src/components/SkeletonCard/SkeletonCard.vue
+++ b/src/components/SkeletonCard/SkeletonCard.vue
@@ -1,10 +1,8 @@
 <template>
   <article
-    class="card-skeleton flex flex-col overflow-hidden border rounded-md shadow-sm"
-  >
+    class="card-skeleton flex flex-col overflow-hidden border rounded-md shadow-sm">
     <div
-      class="placeholder-image aspect-video flex items-center justify-center w-full overflow-hidden"
-    >
+      class="placeholder-image aspect-video flex items-center justify-center w-full overflow-hidden">
       <Skeleton width="100%" height="100%" class="rounded-none">
         <ImageIcon class="opacity-25 w-8 h-8" />
       </Skeleton>

--- a/src/pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue
+++ b/src/pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue
@@ -41,7 +41,6 @@ import { watch } from "vue";
 import SearchResultsMap from "@/components/SearchResultsMap/SearchResultsMap.vue";
 import SearchResultsTimeline from "@/components/SearchResultsTimeline/SearchResultsTimeline.vue";
 import SearchResultsGallery from "@/components/SearchResultsGallery/SearchResultsGallery.vue";
-import { SpinnerIcon } from "@/icons";
 import Skeleton from "@/components/Skeleton/Skeleton.vue";
 
 const props = defineProps<{
@@ -54,7 +53,7 @@ const searchStore = useSearchStore();
 watch(
   () => props.searchId,
   () => {
-    searchStore.search(props.searchId);
+    searchStore.search(props.searchId, { loadAll: true });
   },
   { immediate: true }
 );

--- a/src/pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue
+++ b/src/pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="p-4">
+    <Transition name="fade" mode="out-in">
+      <div
+        v-if="!searchStore.isReady"
+        class="flex items-center justify-center bg-neutral-200 p-4 gap-4 min-h-[480px]">
+        <Skeleton width="100%" height="100%" class="rounded-none">
+          Loading...
+        </Skeleton>
+      </div>
+
+      <div v-else>
+        <SearchResultsMap
+          v-if="embedType === 'map'"
+          class=""
+          :totalResults="searchStore.totalResults"
+          :matches="searchStore.matches"
+          :status="searchStore.status"
+          @loadMore="() => searchStore.loadMore()" />
+
+        <SearchResultsTimeline
+          v-else-if="embedType === 'timeline'"
+          :totalResults="searchStore.totalResults ?? Infinity"
+          :matches="searchStore.matches"
+          :status="searchStore.status"
+          @loadMore="() => searchStore.loadMore()" />
+
+        <SearchResultsGallery
+          v-else-if="embedType === 'gallery'"
+          :totalResults="searchStore.totalResults ?? Infinity"
+          :matches="searchStore.matches"
+          :status="searchStore.status"
+          @loadMore="() => searchStore.loadMore()" />
+      </div>
+    </Transition>
+  </div>
+</template>
+<script setup lang="ts">
+import { useSearchStore } from "@/stores/searchStore";
+import { watch } from "vue";
+import SearchResultsMap from "@/components/SearchResultsMap/SearchResultsMap.vue";
+import SearchResultsTimeline from "@/components/SearchResultsTimeline/SearchResultsTimeline.vue";
+import SearchResultsGallery from "@/components/SearchResultsGallery/SearchResultsGallery.vue";
+import { SpinnerIcon } from "@/icons";
+import Skeleton from "@/components/Skeleton/Skeleton.vue";
+
+const props = defineProps<{
+  searchId: string;
+  embedType: "map" | "timeline" | "gallery";
+}>();
+
+const searchStore = useSearchStore();
+
+watch(
+  () => props.searchId,
+  () => {
+    searchStore.search(props.searchId);
+  },
+  { immediate: true }
+);
+</script>
+<style scoped></style>

--- a/src/pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue
+++ b/src/pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue
@@ -2,7 +2,7 @@
   <div class="p-4">
     <Transition name="fade" mode="out-in">
       <div
-        v-if="!searchStore.isReady"
+        v-if="!isReady"
         class="flex items-center justify-center bg-neutral-200 p-4 gap-4 min-h-[480px]">
         <Skeleton width="100%" height="100%" class="rounded-none">
           Loading...
@@ -37,7 +37,7 @@
 </template>
 <script setup lang="ts">
 import { useSearchStore } from "@/stores/searchStore";
-import { watch } from "vue";
+import { watch, ref } from "vue";
 import SearchResultsMap from "@/components/SearchResultsMap/SearchResultsMap.vue";
 import SearchResultsTimeline from "@/components/SearchResultsTimeline/SearchResultsTimeline.vue";
 import SearchResultsGallery from "@/components/SearchResultsGallery/SearchResultsGallery.vue";
@@ -50,10 +50,19 @@ const props = defineProps<{
 
 const searchStore = useSearchStore();
 
+const isReady = ref(false);
+searchStore.onBeforeNewSearch(() => {
+  isReady.value = false;
+});
+searchStore.onAfterNewSearch(() => {
+  isReady.value = true;
+});
+
 watch(
   () => props.searchId,
   () => {
-    searchStore.search(props.searchId, { loadAll: true });
+    const loadAll = ["map", "timeline"].includes(props.embedType);
+    searchStore.search(props.searchId, { loadAll });
   },
   { immediate: true }
 );

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -6,8 +6,7 @@
         <div class="flex justify-between items-center my-8">
           <BrowseCollectionHeader
             v-if="searchStore.browsingCollectionId"
-            :collectionId="searchStore.browsingCollectionId"
-          />
+            :collectionId="searchStore.browsingCollectionId" />
           <h2 v-else-if="searchStore.isReady" class="text-4xl font-bold">
             <q v-if="nonBrowsingPageTitle">{{ nonBrowsingPageTitle }}</q>
             <span v-else>Search Results</span>
@@ -17,25 +16,21 @@
 
         <DidYouMeanSuggestions
           v-if="searchStore.isReady"
-          :searchTerm="searchStore.currentSearchTerm"
-        />
+          :searchTerm="searchStore.currentSearchTerm" />
 
         <Tabs
           labelsClass="sticky top-14 z-20 search-results-page__tabs -mx-4 px-4 border-b border-neutral-200 pt-4"
           :activeTabId="searchStore.resultsView"
-          @tabChange="handleTabChange"
-        >
+          @tabChange="handleTabChange">
           <div
-            class="sm:flex justify-between items-center bg-transparent-black-50 rounded-md mb-4 p-2 flex-wrap"
-          >
+            class="sm:flex justify-between items-center bg-transparent-black-50 rounded-md mb-4 p-2 flex-wrap">
             <ResultsCount
               class="mb-2 sm:mb-0"
               :fetchStatus="searchStore.status"
               :showingCount="searchStore.matches.length"
               :total="searchStore.totalResults ?? 0"
               @loadMore="searchStore.loadMore"
-              @loadAll="searchStore.loadMore({ loadAll: true })"
-            />
+              @loadAll="searchStore.loadMore({ loadAll: true })" />
             <div class="flex items-center gap-2">
               <SearchResultsSortSelect
                 v-if="!['map', 'timeline'].includes(searchStore.resultsView)"
@@ -44,17 +39,19 @@
                 :searchQuery="
                   searchStore.searchEntry?.searchText ?? searchStore.query
                 "
-                @sortOptionChange="handleSortOptionChange"
-              />
+                @sortOptionChange="handleSortOptionChange" />
               <div
                 v-if="
                   searchStore.isReady &&
                   instanceStore.currentUser?.canManageDrawers
                 "
-                class="flex items-center w-10 h-10 bg-white rounded-md border border-neutral-300 justify-center"
-              >
+                class="flex items-center w-10 h-10 bg-white rounded-md border border-neutral-300 justify-center">
                 <AddSearchResultsToDrawerButton />
               </div>
+              <ShareButton
+                v-if="searchStore.isReady"
+                url="http://localhost"
+                class="!bg-white rounded-md border border-neutral-300 justify-center" />
             </div>
           </div>
           <Tab id="grid" label="Grid">
@@ -65,16 +62,14 @@
               :showAddToDrawerButton="
                 instanceStore.currentUser?.canManageDrawers
               "
-              @loadMore="() => searchStore.loadMore()"
-            />
+              @loadMore="() => searchStore.loadMore()" />
           </Tab>
           <Tab id="list" label="List">
             <SearchResultsList
               :totalResults="searchStore.totalResults"
               :matches="searchStore.matches"
               :status="searchStore.status"
-              @loadMore="() => searchStore.loadMore()"
-            />
+              @loadMore="() => searchStore.loadMore()" />
           </Tab>
           <Tab id="timeline" label="Timeline">
             <SearchResultsTimeline
@@ -84,8 +79,7 @@
               :totalResults="searchStore.totalResults"
               :matches="searchStore.matches"
               :status="searchStore.status"
-              @loadMore="() => searchStore.loadMore()"
-            />
+              @loadMore="() => searchStore.loadMore()" />
           </Tab>
           <Tab id="map" label="Map">
             <SearchResultsMap
@@ -93,8 +87,7 @@
               :totalResults="searchStore.totalResults"
               :matches="searchStore.matches"
               :status="searchStore.status"
-              @loadMore="() => searchStore.loadMore()"
-            />
+              @loadMore="() => searchStore.loadMore()" />
           </Tab>
           <Tab id="gallery" label="Gallery">
             <SearchResultsGallery
@@ -102,8 +95,7 @@
               :totalResults="searchStore.totalResults ?? Infinity"
               :matches="searchStore.matches"
               :status="searchStore.status"
-              @loadMore="() => searchStore.loadMore()"
-            />
+              @loadMore="() => searchStore.loadMore()" />
           </Tab>
 
           <ResultsCount
@@ -116,8 +108,7 @@
             :showingCount="searchStore.matches.length"
             :total="searchStore.totalResults ?? 0"
             @loadMore="searchStore.loadMore"
-            @loadAll="searchStore.loadMore({ loadAll: true })"
-          />
+            @loadAll="searchStore.loadMore({ loadAll: true })" />
         </Tabs>
       </template>
     </div>
@@ -149,6 +140,7 @@ import Skeleton from "@/components/Skeleton/Skeleton.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import AddSearchResultsToDrawerButton from "./AddSearchResultsToDrawerButton.vue";
 import DidYouMeanSuggestions from "./DidYouMeanSuggestions.vue";
+import ShareButton from "@/components/ShareButton/ShareButton.vue";
 
 const props = withDefaults(
   defineProps<{

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -50,8 +50,7 @@
                     searchStore.resultsView
                   )
                 "
-                :url="embedUrl"
-                class="!bg-white rounded-md border border-neutral-300 justify-center" />
+                :url="embedUrl" />
             </div>
           </div>
           <Tab id="grid" label="Grid">

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -49,8 +49,11 @@
                 <AddSearchResultsToDrawerButton />
               </div>
               <ShareButton
-                v-if="searchStore.isReady"
-                url="http://localhost"
+                v-if="
+                  searchStore.isReady &&
+                  ['map', 'timeline'].includes(searchStore.resultsView)
+                "
+                :url="embedUrl"
                 class="!bg-white rounded-md border border-neutral-300 justify-center" />
             </div>
           </div>
@@ -119,6 +122,7 @@ import { watch, computed, onMounted, nextTick, ref } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useSearchStore } from "@/stores/searchStore";
+import config from "@/config";
 import BrowseCollectionHeader from "./BrowseCollectionHeader.vue";
 import Tab from "@/components/Tabs/Tab.vue";
 import Tabs from "@/components/Tabs/Tabs.vue";
@@ -160,6 +164,10 @@ const route = useRoute();
 const router = useRouter();
 const nonBrowsingPageTitle = computed(() => {
   return searchStore.searchEntry?.searchText ?? searchStore.query;
+});
+const BASE_URL = config.instance.base.url;
+const embedUrl = computed(() => {
+  return `${BASE_URL}/search/${props.resultsView}/${searchStore.searchId}`;
 });
 
 // will be true once a new search with a new searchId has been loaded for the

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -45,7 +45,11 @@
                 v-if="instanceStore.currentUser?.canManageDrawers" />
 
               <ShareButton
-                v-if="['map', 'timeline'].includes(searchStore.resultsView)"
+                v-if="
+                  ['map', 'timeline', 'gallery'].includes(
+                    searchStore.resultsView
+                  )
+                "
                 :url="embedUrl"
                 class="!bg-white rounded-md border border-neutral-300 justify-center" />
             </div>

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -31,7 +31,7 @@
               :total="searchStore.totalResults ?? 0"
               @loadMore="searchStore.loadMore"
               @loadAll="searchStore.loadMore({ loadAll: true })" />
-            <div class="flex items-center gap-2">
+            <div v-if="searchStore.isReady" class="flex items-center">
               <SearchResultsSortSelect
                 v-if="!['map', 'timeline'].includes(searchStore.resultsView)"
                 :sortOptions="searchStore.sortOptions"
@@ -39,20 +39,13 @@
                 :searchQuery="
                   searchStore.searchEntry?.searchText ?? searchStore.query
                 "
+                class="mr-1"
                 @sortOptionChange="handleSortOptionChange" />
-              <div
-                v-if="
-                  searchStore.isReady &&
-                  instanceStore.currentUser?.canManageDrawers
-                "
-                class="flex items-center w-10 h-10 bg-white rounded-md border border-neutral-300 justify-center">
-                <AddSearchResultsToDrawerButton />
-              </div>
+              <AddSearchResultsToDrawerButton
+                v-if="instanceStore.currentUser?.canManageDrawers" />
+
               <ShareButton
-                v-if="
-                  searchStore.isReady &&
-                  ['map', 'timeline'].includes(searchStore.resultsView)
-                "
+                v-if="['map', 'timeline'].includes(searchStore.resultsView)"
                 :url="embedUrl"
                 class="!bg-white rounded-md border border-neutral-300 justify-center" />
             </div>

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,6 +15,7 @@ import DownloadDrawerPage from "./pages/DownloadDrawerPage/DownloadDrawerPage.vu
 import { useErrorStore } from "./stores/errorStore";
 import LogoutPage from "./pages/LogoutPage/LogoutPage.vue";
 import ExcerptViewPage from "./pages/ExcerptViewPage/ExcerptViewPage.vue";
+import SearchResultsEmbedPage from "./pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue";
 
 function parseIntFromParam(
   param: string | string[] | undefined
@@ -137,6 +138,12 @@ const router = createRouter({
         objectId: route.query.objectId ?? null,
         resultsView: route.query.resultsView ?? null,
       }),
+    },
+    {
+      name: "searchResultsMapEmbed",
+      path: "/search/:embedType/:searchId",
+      component: SearchResultsEmbedPage,
+      props: true,
     },
     {
       name: "localLogin",


### PR DESCRIPTION
![ScreenShot 2023-11-13 at 16 14 46@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/849d9436-9fef-4d6f-91e0-15c050ea6d3b)

- adds an share button to map, gallery, and timeline tabs of search results page
- adds route for embed views

Closes #240 

Question: How do we handle the number of results loaded? Should there be a load more button on the embed views? Or some way to ensure the same results are loaded for embed?

