### PR TITLE
allow link tag in custom header

### DIFF
--- a/src/components/CustomAppHeader/CustomAppHeader.vue
+++ b/src/components/CustomAppHeader/CustomAppHeader.vue
@@ -2,8 +2,7 @@
   <div class="custom-app-header bg-transparent-black-100">
     <SanitizedHTML
       :html="instanceStore?.customHeader ?? ''"
-      :addTags="['style']"
-    />
+      :addTags="['style', 'link']" />
   </div>
 </template>
 <script setup lang="ts">


### PR DESCRIPTION
adds an exception to allow `<link>` in custom headers, so that external stylesheets can be linked.

Resolves UMN header rendering issue in https://github.com/UMN-LATIS/elevator/issues/152

Before

![ScreenShot 2023-11-15 at 13 41 40@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/cceea396-ebf6-421e-ad1f-4004b989c16b)

After
![ScreenShot 2023-11-15 at 13 38 54@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/3200c1b9-47b4-4def-a437-31d200009016)
