### PR TITLE
add config option for custom home route

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,9 @@ const defaultConfig: AppConfig = {
       import.meta.env.VITE_ARCGIS_API_KEY ?? "PLEASE_SET_MAPBOX_ACCESS_TOKEN",
   },
   routes: {
-    test: import.meta.env.VITE_TEST_ROUTE ?? null,
+    home: {
+      redirect: import.meta.env.VITE_ROUTES_HOME_REDIRECT ?? null,
+    },
   },
   mode: import.meta.env.MODE ?? null,
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { RouteRecordRaw, createRouter, createWebHistory } from "vue-router";
 import config from "@/config";
 import HomePage from "@/pages/HomePage/HomePage.vue";
 import AssetViewPage from "@/pages/AssetViewPage/AssetViewPage.vue";
@@ -25,6 +25,24 @@ function parseIntFromParam(
   }
   return null;
 }
+
+// creates a home route based on the config
+// if a redirect is set, it will create a redirect route
+// instead of the normal homepage route
+const createHomeRoute = (): RouteRecordRaw => {
+  if (config.routes.home.redirect) {
+    return {
+      name: "home",
+      path: "/",
+      redirect: config.routes.home.redirect,
+    };
+  }
+  return {
+    name: "home",
+    path: "/",
+    component: HomePage,
+  };
+};
 
 const router = createRouter({
   history: createWebHistory(config.instance.base.path),
@@ -55,12 +73,7 @@ const router = createRouter({
     };
   },
   routes: [
-    {
-      name: "home",
-      path: "/",
-      component: HomePage,
-      // component: () => import("@/pages/HomePage/HomePage.vue"),
-    },
+    createHomeRoute(),
     {
       // this route is really `/asset/viewAsset/:assetId#:objectId?`
       // but we can't use `#` in the path

--- a/src/router.ts
+++ b/src/router.ts
@@ -26,21 +26,37 @@ function parseIntFromParam(
   return null;
 }
 
-// creates a home route based on the config
-// if a redirect is set, it will create a redirect route
-// instead of the normal homepage route
+/**
+ * creates a home route based on the config
+ * use a custom redirect if one is set
+ */
 const createHomeRoute = (): RouteRecordRaw => {
-  if (config.routes.home.redirect) {
-    return {
-      name: "home",
-      path: "/",
-      redirect: config.routes.home.redirect,
-    };
-  }
-  return {
+  const defaultHomeRoute = {
     name: "home",
     path: "/",
     component: HomePage,
+  };
+
+  if (!config.routes.home.redirect) {
+    return defaultHomeRoute;
+  }
+
+  // if the redirect is a full URL, remove the base url
+  const redirect = config.routes.home.redirect.replace(
+    config.instance.base.url,
+    ""
+  );
+
+  // if the redirect is the root url, don't create a redirect route
+  // instead just use the default home route to avoid loops
+  if (redirect === "/") {
+    return defaultHomeRoute;
+  }
+
+  return {
+    name: "home",
+    path: "/",
+    redirect,
   };
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,7 +37,9 @@ export interface AppConfig {
     apiKey: string;
   };
   routes: {
-    test: string | null;
+    home: {
+      redirect?: string;
+    };
   };
   mode: "development" | "production" | string | null;
 }


### PR DESCRIPTION
This allows an admin to set a custom home page route, for example `/search/listCollections`.  Users will be redirected to this route when set.

Either absolute paths or full urls can be used. If a full url is used, the base url will be stripped so that the redirect becomes an absolute path.( e.g. `https://dev.elevator.umn.edu/defaultinstance/search/listCollections` -> `/search/listCollections`)

If the redirect is set to null or `/` or the base path, the default home page will be used.

This complements a forthcoming PR to elevator, which adds the custom home page config option to the instance settings.

On dev for testing: <https://dev.elevator.umn.edu/defaultinstance>. Currently the custom home route is set to  `/search/listCollections`.
