### PR TITLE
app footer fixes

### DIFF
--- a/src/components/AppFooter/AppFooter.vue
+++ b/src/components/AppFooter/AppFooter.vue
@@ -1,13 +1,8 @@
 <template>
   <footer
     v-if="instanceStore.customFooter"
-    class="app-footer bg-transparent-black-100"
-  >
-    <SanitizedHTML
-      class="flex flex-col max-w-screen-xl mx-auto p-4 lg:p-8"
-      :html="instanceStore.customFooter"
-      :addTags="['style']"
-    />
+    class="app-footer bg-transparent-black-100">
+    <SanitizedHTML :html="instanceStore.customFooter" :addTags="['style']" />
   </footer>
 </template>
 <script setup lang="ts">
@@ -19,10 +14,5 @@ const instanceStore = useInstanceStore();
 <style scoped>
 .app-footer {
   border-top: var(--app-borderWidth) solid var(--app-borderColor);
-  font-size: 0.825rem;
-  & :is(h1, h2, h3, h4, h5) {
-    font-size: 1rem;
-    font-weight: bold;
-  }
 }
 </style>

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -45,7 +45,9 @@
         Please contact your administrator if you believe this is an error.
       </p>
     </Notification>
-    <AppFooter />
+    <template #footer>
+      <AppFooter />
+    </template>
   </DefaultLayout>
 </template>
 <script setup lang="ts">

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -8,7 +8,7 @@
       class="my-8 mx-4" />
     <div
       v-if="isReady && canSearchAndBrowse"
-      class="home-page-content flex-1 md:grid max-w-screen-xl w-full mx-auto"
+      class="home-page-content flex-1 md:grid max-w-screen-xl w-full mx-auto md:grid-rows-1"
       :class="{
         'md:grid-cols-2': !featuredAssetId,
         'md:grid-cols-3': featuredAssetId,


### PR DESCRIPTION
- removes extra classes on `app-footer` as they may conflict with custom instance footers and will need to be overridden.
- moves `<AppFooter>` from `<main>` to `<footer>` in the `DefaultLayout`
- fixes #264. In Safari, sometimes grid items would overflow the grid container if `grid-template-rows` isn't explicitly set.