### PR TITLE
Increase max-width of page content sections

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -92,7 +92,7 @@ a:hover {
 .prose {
   --tw-prose-headings: var(--app-headingColor);
   --tw-prose-links: var(--app-link-textColor);
-  max-width: 70ch;
+  max-width: 90ch;
   color: var(--app-textColor);
 }
 

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -18,7 +18,10 @@
           <SanitizedHTML
             v-if="page.content"
             :html="page.content"
-            class="prose prose-neutral" />
+            class="prose prose-neutral"
+            :class="{
+              'mx-auto': !featuredAssetId,
+            }" />
           <section v-else class="bg-white p-8 my-8 shadow-sm">
             <h1 class="text-4xl text-center font-bold">
               {{ instanceStore.instance?.name ?? "Elevator" }}


### PR DESCRIPTION
- increases `.prose` sections max-width to `90ch`
- centers homepage content when no featured asset is set

![ScreenShot 2024-04-19 at 10 58 27@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/68888100-b43a-4e17-83e2-25c6cb413034)
![ScreenShot 2024-04-19 at 10 57 50@2x](https://github.com/UMN-LATIS/elevator-ui/assets/980170/5658e429-faf5-468f-992a-3226d4765d47)

Closes #258 