### PR TITLE
fix extra clear input button on search

### DIFF
--- a/src/components/SearchBar/SearchTextInputGroup.vue
+++ b/src/components/SearchBar/SearchTextInputGroup.vue
@@ -5,7 +5,6 @@
     ref="inputGroup"
     v-model="searchStore.query"
     label="Search"
-    type="search"
     inputmode="search"
     :labelHidden="true"
     placeholder="Search"


### PR DESCRIPTION
fixes #246

There's probably better ways to work with the search input type, but the easiest fix seems to just use the default text input type.

I'll push to dev once #269 is merged.