### PR TITLE
add `not-prose` to safe list as escape hatch for static page styles

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,7 @@ module.exports = {
     "md:grid-cols-1",
     "md:grid-cols-2",
     "md:grid-cols-3",
+    "not-prose",
   ],
   plugins: [
     require("@tailwindcss/typography"),


### PR DESCRIPTION
With this, users can avoid all the default prose styles if they wish to customize static content pages. 

for example:
```html
<div class="custom-homepage not-prose">
...
</div>
```


