### PR TITLE
add St Thomas theme

### DIFF
--- a/src/components/AppLogoMark/AppLogoMark.vue
+++ b/src/components/AppLogoMark/AppLogoMark.vue
@@ -18,4 +18,8 @@ import ElevatorIcon from "@/icons/ElevatorIcon.vue";
 
 const instanceStore = useInstanceStore();
 </script>
-<style scoped></style>
+<style scoped>
+.app-header__wordmark {
+  color: var(--app-appHeader-wordmark-textColor);
+}
+</style>

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -3,7 +3,7 @@
     <div
       ref="modal"
       :class="{
-        'modal flex bg-transparent-black-700 fixed inset-0 z-50 justify-center items-center p-4':
+        'modal flex bg-transparent-black-700 fixed inset-0 z-50 justify-center items-center p-4 min-h-dvh':
           isOpen,
         hidden: !isOpen,
       }"

--- a/src/components/ThemeSelector/ThemeSelector.vue
+++ b/src/components/ThemeSelector/ThemeSelector.vue
@@ -12,7 +12,7 @@
       :key="theme"
       :current="activeTheme === theme"
       @click="setTheme(theme)">
-      {{ capitalize(theme) }}
+      {{ prettyThemeName(theme) }}
     </DropDownItem>
   </DropDown>
 </template>
@@ -31,6 +31,13 @@ const {
 } = useTheming();
 
 function capitalize(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
+  return str
+    .split(" ")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ");
+}
+
+function prettyThemeName(theme: string) {
+  return capitalize(theme.replace(/-/g, " "));
 }
 </script>

--- a/src/css/themes/st-thomas.css
+++ b/src/css/themes/st-thomas.css
@@ -1,0 +1,154 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
+
+[data-theme="st-thomas"] {
+  --brand-purple-bright: #9E28B5;
+  --brand-purple: #510c76;
+  --brand-purple-light: #E9D9FF;
+
+  --app-fontFamily: Lato, sans-serif;
+  --app-textColor: var(--color-gray-600);
+  --app-backgroundColor: var(--color-purple-50);
+  --app-borderColor: var(--color-purple-300);
+  --app-borderWidth: 2px;
+
+  /**
+  * App Header
+  */
+  --app-appHeader-backgroundColor: var(--color-white);
+  --app-appHeader-secondaryNav-backgroundColor: var(--white);
+  --app-appHeader-textColor: var(--brand-purple-bright);
+  --app-appHeader-wordmark-textColor: var(--black);
+  --app-appHeader-logo-color: var(--brand-purple);
+  --app-appHeader-borderBottomColor: var(--app-borderColor);
+  --app-appMenu-backgroundColor: var(--color-purple-100);
+  --app-appMenu-headingColor: var(--brand-purple);
+  --app-appMenu-textColor: var(--color-purple-800);
+  --app-appMenuButton-backgroundColor: var(--brand-purple);
+  --app-appMenuButton-textColor: var(--app-backgroundColor);
+
+  & .app-header {
+    border-top: 0.5rem solid var(--brand-purple);
+  }
+
+  & .app-logo-mark {
+    display: flex;
+    align-items: flex-end !important;
+    & h1 {
+      line-height: 1;
+      font-weight: 400;
+    }
+  }
+
+  & .custom-app-header {
+    background-color: var(--color-purple-900);
+    color: var(--color-purple-100);
+  }
+
+  & .app-menu__items :where(button, a):where(:hover,:focus) {
+    background: var(--color-purple-50);
+    border-radius: 0.25rem;
+  }
+
+  /**
+  * Link
+  */
+  --app-link-textColor: var(--color-purple-600);
+  --app-link-textColor-inverse: var(--app-backgroundColor);
+  --app-link-hover-textColor: var(--color-purple-800);
+
+  /**
+  * Panel (Drawer)
+  */
+  --app-panel-borderColor: tranparent;
+  --app-panel-borderWidth: 2px;
+  --app-panel-header-textColor: var(--app-textColor);
+  --app-panel-header-backgroundColor: var(--color-purple-100);
+  --app-panel-body-top-borderColor: white;
+  --app-panel-body-textColor: var(--app-textColor);
+  --app-panel-body-backgroundColor: var(--color-purple-100);
+  --app-panel-body-items-gap: 1.5rem;
+
+  & .asset-view__details-panel {
+    background-color: var(--color-purple-100);
+    & button {
+      color: var(--color-purple-800);
+    }
+  }
+
+  /**
+  * Object Viewer
+  */
+  --app-objectViewer-backgroundColor: var(--color-neutral-300);
+
+  /**
+  * Widget List
+  */
+  --app-widgetList-gap: var(--app-panel-body-items-gap);
+
+  /**
+  * Accordion
+  */
+  --app-accordion-header-backgroundColor: var(--color-zinc-200);
+  --app-accordion-header-textColor: var(--app-textColor);
+  --app-accordion-body-backgroundColor: var(--white);
+  --app-accordion-body-textColor: var(--app-textColor);
+  --app-accordion-outer-borderWidth: 1px;
+  --app-accordion-outer-borderColor: var(--color-neutral-200);
+  --app-accordion-inner-borderWidth: 1px;
+  --app-accordion-inner-borderColor: transparent;
+
+  /* Tuple */
+  --app-tuple-label-textColor: var(--color-neutral-900);
+  --app-tuple-value-textColor: var(--color-neutral-700);
+
+  /* Scrollbar */
+  --app-scrollbar-width: 0.5rem;
+  --app-scrollbar-thumb-backgroundColor: #aaa;
+  --app-scrollbar-thumb-hover-backgroundColor: #555;
+  --app-scrollbar-track-backgroundColor: rgba(255, 255, 255, 33%);
+
+  /** Meta Data Only Page */
+  --app-metaDataOnlyView-backgroundColor: var(--color-neutral-300);
+  --app-metaDataOnlyView-contentViewer-backgroundColor: var(--color-neutral-50);
+  --app-metaDataOnlyView-contentViewer-textColor: var(--color-neutral-900);
+
+  /** Modal **/
+  --app-modalContents-backgroundColor: var(--color-neutral-50);
+  --app-modalContents-textColor: var(--color-nuetral-900);
+  --app-modalContents-header-backgroundColor: var(--color-neutral-200);
+  --app-modalContents-header-textColor: var(--color-neutral-900);
+
+  /* Thumbnail Image */
+  --app-thumbnailImage-backgroundColor: var(--color-white);
+  --app-thumbnailImage-textColor: var(--color-purple-400);
+  --app-thumbnailImage-active-ringColor: var(--app-link-textColor);
+
+  --app-mediaCard-backgroundColor: var(--color-white);
+  --app-mediaCard-borderColor: var(--color-purple-200);
+
+  /**
+  * Button Primary (default)
+  */
+  --app-button-primary-backgroundColor: var(--brand-purple);
+
+  /**
+  * Button Tertiary (default)
+  */
+  --app-button-tertiary-borderColor: transparent;
+  --app-button-tertiary-backgroundColor: transparent;
+  --app-button-tertiary-textColor: var(--color-purple-600);
+
+  /* Button Tertiary :hover */
+  --app-button-tertiary-hover-borderColor: transparent;
+  --app-button-tertiary-hover-backgroundColor: var(--color-purple-50);
+  --app-button-tertiary-hover-textColor: var(--color-purple-700);
+
+
+
+  & .prose {
+    & :where(h1,h2,h3,h4,h5):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      color: var(--brand-purple);
+    }
+  }
+}


### PR DESCRIPTION
Adds a theme with St. Thomas brand colors and type (Lato). I'm sure more things could be purple, but this seems like a good start.

On dev for testing.

`.env` will need `st-thomas` theme added the `AVAILABLE_THEMES` array (currently manually set on dev).

### Screenshots

![ScreenShot 2025-02-27 at 16 58 44@2x](https://github.com/user-attachments/assets/3209bb68-bf1b-408b-81ce-7676a5009cb9)
![ScreenShot 2025-02-27 at 16 59 09@2x](https://github.com/user-attachments/assets/d0e6aa9f-b8e9-4577-8c41-3c1c0436a369)
![ScreenShot 2025-02-27 at 16 59 34@2x](https://github.com/user-attachments/assets/aac70e56-b4eb-4306-809e-d3825736e4a2)
![ScreenShot 2025-02-27 at 16 59 51@2x](https://github.com/user-attachments/assets/13a3e9e7-8901-4196-ba35-544b90736e73)
