### PR TITLE
fix: safari error when downloading file

### DIFF
--- a/src/components/DownloadFileButton/DownloadFileButton.vue
+++ b/src/components/DownloadFileButton/DownloadFileButton.vue
@@ -19,6 +19,7 @@
             v-if="download.isReady || download.filetype === 'original'"
             :href="download.url"
             class="py-2 hover:bg-transparent-black-50 border-t last:border-b block hover:no-underline group"
+            :download="`${download.originalFilename}-${download.filetype}.${download.extension}`"
             @click="
               analytics.trackDownloadEvent({
                 fileObjectId: props.fileObjectId,


### PR DESCRIPTION
Fixes #291

When the download link is clicked in safari, the browser cancels any in flight requests – maybe as it prepares to change to a new page? 

This causes some api requests to fail after the download link click. A 499 is observed on the server.

There are a few solutions to this:
- adding a `download` attr to the link
- changing to a button, and invoking the download url with JS
- open download in a new blank window

I went with the `download` attr as it seemed to be the simplest, but there could be edge cases I missed.