### PR TITLE
Add a Download All button for downloading all asset files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^18.2.0",
     "shave": "^5.0.2",
     "storybook-vue3-router": "^2.3.1",
+    "streamsaver": "^2.0.6",
     "striptags": "^4.0.0-alpha.4",
     "swiper": "^9.3.2",
     "tiny-invariant": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@vueuse/integrations": "^10.1.2",
     "autolink-js": "^1.0.2",
     "axios": "^1.4.0",
+    "client-zip": "^2.4.6",
     "deepmerge": "^4.3.1",
     "dompurify": "^3.0.3",
     "focus-trap": "^7.4.3",

--- a/src/components/DownloadFileButton/DownloadFileButton.vue
+++ b/src/components/DownloadFileButton/DownloadFileButton.vue
@@ -19,6 +19,7 @@
             v-if="download.isReady || download.filetype === 'original'"
             :href="download.url"
             class="py-2 hover:bg-transparent-black-50 border-t last:border-b block hover:no-underline group"
+            :download="`${download.originalFilename}-${download.filetype}.${download.extension}`"
             @click="
               analytics.trackDownloadEvent({
                 fileObjectId: props.fileObjectId,

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -1,9 +1,15 @@
 <template>
   <div>
-    <Button variant="tertiary" class="-ml-2" @click="handleDownloadAllFiles">
+    <Button
+      v-if="props.contents.length > 1"
+      variant="tertiary"
+      class="-ml-2"
+      :disabled="isDownloading"
+      @click="handleDownloadAllFiles">
       Download All Files
       <SpinnerIcon v-if="isDownloading" class="ml-2" />
     </Button>
+
     <div class="upload-widget flex gap-2 flex-wrap mt-2">
       <button
         v-for="(content, key) in contents"

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -46,7 +46,7 @@ import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { computed, onMounted, onBeforeUnmount } from "vue";
 import Button from "@/components/Button/Button.vue";
-import { useFileDownloader } from "@/helpers/downloadFileObjects";
+import { useFileDownloader } from "@/helpers/useFileDownloader";
 import { SpinnerIcon } from "@/icons";
 
 const props = defineProps<{

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -40,8 +40,7 @@ import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { computed, onMounted, onBeforeUnmount } from "vue";
 import Button from "@/components/Button/Button.vue";
-import api from "@/api";
-import { DownloadTask, useFileDownloader } from "@/helpers/downloadFileObjects";
+import { useFileDownloader } from "@/helpers/downloadFileObjects";
 import { SpinnerIcon } from "@/icons";
 
 const props = defineProps<{
@@ -85,46 +84,19 @@ function handleNextPrevArrowPresses(event: KeyboardEvent) {
   }
 }
 
-// async function downloadFile(fileObjectId, assetId) {
-//   console.log("Download file", fileObjectId);
-//   const downloadInfo = await api.getFileDownloadInfo(fileObjectId, assetId);
-
-//   // the first one in downloadInfo is the preferred download.
-//   const preferredDownload = downloadInfo?.[0] ?? null;
-
-//   if (!preferredDownload) {
-//     console.error("No download info found for file", fileObjectId);
-//     return;
-//   }
-
-//   try {
-//     const link = document.createElement("a");
-//     link.href = preferredDownload.url;
-//     link.download = `${preferredDownload.originalFilename}-${assetId}-${fileObjectId}-${preferredDownload.filetype}.${preferredDownload.extension}`;
-//     document.body.appendChild(link);
-//     link.click();
-//     link.remove();
-//   } catch (error) {
-//     console.error("Error downloading file", error);
-//     throw error;
-//   }
-// }
-
-const { isDownloading, downloadFiles } = useFileDownloader();
+const { isDownloading, downloadAssetFiles } = useFileDownloader();
 
 async function handleDownloadAllFiles() {
-  // snapshot the assetId in case it changes during the download process
   const assetId = assetStore.activeAssetId;
 
   if (!assetId) {
     throw new Error("Cannot download all: No assetId found");
   }
 
-  const fileAndAssetIds = props.contents.map((c) => ({
-    fileId: c.fileId,
+  downloadAssetFiles(
     assetId,
-  }));
-  downloadFiles(fileAndAssetIds);
+    props.contents.map((c) => c.fileId)
+  );
 }
 
 onMounted(() => {

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -1,31 +1,33 @@
 <template>
-  <div class="upload-widget flex gap-2 flex-wrap mt-2">
-    <button
-      v-for="(content, key) in contents"
-      :key="key"
-      :title="content.fileDescription"
-      class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline hover:bg-blue-50 hover:text-blue-600 w-24 text-neutral-600"
-      :class="{
-        'opacity-80 hover:opacity-100 hover:border-blue-600': !isFileActive(
-          content.fileId
-        ),
-        'ring ring-offset-1 ring-blue-600 hover:border-transparent opacity-100 bg-blue-50':
-          isFileActive(content.fileId),
-      }"
-      @click="assetStore.activeFileObjectId = content.fileId"
-    >
-      <ThumbnailImage
-        :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
-        :alt="content.fileDescription"
-        :fileType="content.fileType"
-        class="thumbnail-related-asset-widget__image max-w-full"
-      />
-      <SanitizedHTML
-        v-if="content.fileDescription"
-        class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
-        :html="content.fileDescription"
-      />
-    </button>
+  <div>
+    <Button variant="tertiary" class="-ml-2" @click="handleDownloadAllFiles">
+      Download All Files
+    </Button>
+    <div class="upload-widget flex gap-2 flex-wrap mt-2">
+      <button
+        v-for="(content, key) in contents"
+        :key="key"
+        :title="content.fileDescription"
+        class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline hover:bg-blue-50 hover:text-blue-600 w-24 text-neutral-600"
+        :class="{
+          'opacity-80 hover:opacity-100 hover:border-blue-600': !isFileActive(
+            content.fileId
+          ),
+          'ring ring-offset-1 ring-blue-600 hover:border-transparent opacity-100 bg-blue-50':
+            isFileActive(content.fileId),
+        }"
+        @click="assetStore.activeFileObjectId = content.fileId">
+        <ThumbnailImage
+          :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
+          :alt="content.fileDescription"
+          :fileType="content.fileType"
+          class="thumbnail-related-asset-widget__image max-w-full" />
+        <SanitizedHTML
+          v-if="content.fileDescription"
+          class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
+          :html="content.fileDescription" />
+      </button>
+    </div>
   </div>
 </template>
 
@@ -36,6 +38,8 @@ import { useAssetStore } from "@/stores/assetStore";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { computed, onMounted, onBeforeUnmount } from "vue";
+import Button from "@/components/Button/Button.vue";
+import api from "@/api";
 
 const props = defineProps<{
   widget: UploadWidgetProps;
@@ -76,6 +80,42 @@ function handleNextPrevArrowPresses(event: KeyboardEvent) {
   if (event.key === "ArrowRight") {
     return setNextFileAsActive();
   }
+}
+
+async function downloadFile(fileObjectId, assetId) {
+  console.log("Download file", fileObjectId);
+  const downloadInfo = await api.getFileDownloadInfo(fileObjectId, assetId);
+
+  // the first one in downloadInfo is the preferred download.
+  const preferredDownload = downloadInfo?.[0] ?? null;
+
+  if (!preferredDownload) {
+    console.error("No download info found for file", fileObjectId);
+    return;
+  }
+
+  try {
+    const link = document.createElement("a");
+    link.href = preferredDownload.url;
+    link.download = `${preferredDownload.originalFilename}-${assetId}-${fileObjectId}-${preferredDownload.filetype}.${preferredDownload.extension}`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } catch (error) {
+    console.error("Error downloading file", error);
+    throw error;
+  }
+}
+
+async function handleDownloadAllFiles() {
+  // snapshot the assetId in case it changes during the download process
+  const assetId = assetStore.activeAssetId;
+
+  const promisedDownloads = props.contents.map((content) =>
+    downloadFile(content.fileId, assetId)
+  );
+
+  return Promise.allSettled(promisedDownloads);
 }
 
 onMounted(() => {

--- a/src/helpers/downloadFileObjects.ts
+++ b/src/helpers/downloadFileObjects.ts
@@ -25,7 +25,7 @@ async function getDownloadTask(
     const downloadInfo = await api.getFileDownloadInfo(fileId, assetId);
 
     if (!downloadInfo?.length) {
-      // we can mark this task as errored
+      console.warn(`No download info for fileId ${fileId}`);
       return null;
     }
 

--- a/src/helpers/downloadFileObjects.ts
+++ b/src/helpers/downloadFileObjects.ts
@@ -1,0 +1,146 @@
+import { FileDownloadNormalized } from "@/types";
+import api from "@/api";
+import { computed, ref } from "vue";
+import { downloadZip } from "client-zip";
+
+export type DownloadStatus = "pending" | "downloading" | "completed" | "error";
+
+export interface DownloadTask {
+  id: string;
+  filename: string;
+  url: string;
+  status: DownloadStatus;
+  error?: Error;
+}
+
+export type DownloadableStream = {
+  name: string; // filename
+  lastModified: Date;
+  input: Response;
+};
+
+// function getPendingTasks(tasks: DownloadTask[]) {
+//   return tasks.filter((task) => task.status === "pending");
+// }
+
+// function getDownloadingTasks(tasks: DownloadTask[]) {
+//   return tasks.filter((task) => task.status === "downloading");
+// }
+
+// function getCompletedTasks(tasks: DownloadTask[]) {
+//   return tasks.filter((task) => task.status === "completed");
+// }
+
+// function getErroredTasks(tasks: DownloadTask[]) {
+//   return tasks.filter((task) => task.status === "errored");
+// }
+
+// function areAllSettled(tasks: DownloadTask[]) {
+//   return tasks.every(
+//     (task) => task.status === "completed" || task.status === "errored"
+//   );
+// }
+
+export interface FileDownloadInfo {
+  filename: string;
+  url: string;
+}
+
+async function getDownloadTask(object: { fileId: string; assetId: string }) {
+  const downloadInfo = await api.getFileDownloadInfo(
+    object.fileId,
+    object.assetId
+  );
+
+  if (!downloadInfo?.length) {
+    // we can mark this task as errored
+    return {
+      id: object.fileId,
+      filename: "",
+      url: "",
+      status: "error",
+      error: new Error("No download info retrieved from api"),
+    } as DownloadTask;
+  }
+
+  const preferredDownload = downloadInfo[0];
+
+  return {
+    id: object.fileId,
+    status: "pending",
+    filename: `${object.fileId}-${preferredDownload.filetype}.${preferredDownload.extension}`,
+    url: preferredDownload.url,
+  } as DownloadTask;
+}
+
+async function getDownloadTasks(
+  objects: Array<{ fileId: string; assetId: string }>
+) {
+  const tasks: DownloadTask[] = [];
+
+  for (const object of objects) {
+    const task = await getDownloadTask(object);
+    tasks.push(task);
+  }
+
+  return tasks;
+}
+
+export function useFileDownloader() {
+  const tasks = ref<DownloadTask[]>([]);
+  const isDownloading = ref(false);
+  const pending = computed(() =>
+    tasks.value.filter((task) => task.status === "pending")
+  );
+
+  async function downloadFiles(
+    objects: Array<{ fileId: string; assetId: string }>
+  ) {
+    isDownloading.value = true;
+
+    const assetId = objects[0].assetId;
+    console.log("Getting download info for each file");
+    const downloadTasks = await getDownloadTasks(objects);
+    tasks.value = downloadTasks;
+
+    // collect fetch responses downloadZip
+    // will use these as input streams
+    const streams = [] as DownloadableStream[];
+    console.log("Getting download streams for each file");
+    for (const task of tasks.value) {
+      console.log(`Fetching ${task.url}`);
+      const response = await fetch(task.url);
+      streams.push({
+        name: task.filename,
+        lastModified: new Date(),
+        input: response,
+      });
+    }
+
+    // get the ZIP stream in a Blob
+    console.log("Getting the blob");
+    const blob = await downloadZip(streams).blob();
+
+    // make and click a temporary link to download the Blob
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(blob);
+    const isoDate = new Date().toISOString().replace(/T.*/g, "");
+    link.download = `asset-${assetId}-${isoDate}.zip`;
+    link.click();
+    link.remove();
+
+    console.log("Revoking the Blob URL");
+
+    // revoke the Blob URL
+    URL.revokeObjectURL(link.href);
+
+    isDownloading.value = false;
+  }
+
+  return {
+    tasks,
+    isDownloading,
+    pending,
+    downloadFiles,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12006,6 +12006,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
   integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
 
+streamsaver@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/streamsaver/-/streamsaver-2.0.6.tgz#869d2347dd70191e0ac888d52296956a8cba2ed9"
+  integrity sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw==
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,6 +5299,11 @@ cli-table3@^0.6.1:
   optionalDependencies:
     "@colors/colors" "1.5.0"
 
+client-zip@^2.4.6:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/client-zip/-/client-zip-2.4.6.tgz#c797c29d9463b17eca4b623339ccf06e620b2794"
+  integrity sha512-e7t1u14h/yT0A12qBwFsaus8UZZ8+MCaNAEn/z53mrukLq/LFcKX7TkbntAppGu8he2p8pz9vc5NEGE/h4ohlw==
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"


### PR DESCRIPTION
Closes #282 

- Adds a download all button the Uploads Widget.
- when clicked, we'll get download information for every file and then start a download stream for each. The streams are piped to `downloadZip()`.
- adds `client-zip`, a very nice library for combining multiple streams into a single zip file.

Tried a few other approaches, but ran into issues with each. (e.g. max number of concurrent downloads, popup blockers, trying do download 200 files and getting 200 prompts for where to save and what to name files. I had to quit my browser with that one...)

Let me know if you want me to move the button. I can avoid a component refactor if I put it where it is... but it probably looks better moved up on the same line.

On dev for testing.

![ScreenShot 2025-03-03 at 20 57 13@2x](https://github.com/user-attachments/assets/0a1f3194-3f2a-42b2-89c8-c014a887ca96)
