### PR TITLE
make local dev env more akin to prod

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,15 @@
       async
       src="https://www.googletagmanager.com/gtag/js?id=%VITE_GOOGLE_ANALYTICS_ID%"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
+      if (!!"%VITE_GOOGLE_ANALYTICS_ID%") {
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+        gtag("js", new Date());
 
-      gtag("config", "%VITE_GOOGLE_ANALYTICS_ID%");
+        gtag("config", "%VITE_GOOGLE_ANALYTICS_ID%");
+      }
     </script>
   </head>
   <body>

--- a/src/helpers/useAnalytics.ts
+++ b/src/helpers/useAnalytics.ts
@@ -33,8 +33,12 @@ async function getAssetDetails(assetId: string): Promise<{
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 export function useAnalytics() {
-  const { gtag } = window;
+  const gtag = window.gtag || noop;
+
   invariant(
     gtag,
     "Google Analytics is not loaded. Make sure to load the script in the head of your document."


### PR DESCRIPTION
in prod, gtag script won't be loaded so window.gtag will be undefined. 

This: 
- uses a `noop` function in analytics is gtag is not defined on window.
- updates local dev `index.html` to replicate how undefined analytics key works (no script snippet if GA key is undefined)

on dev