### PR TITLE
fix: white screen when analytics key undefined (early return)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,15 @@
       async
       src="https://www.googletagmanager.com/gtag/js?id=%VITE_GOOGLE_ANALYTICS_ID%"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
+      if (!!"%VITE_GOOGLE_ANALYTICS_ID%") {
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+        gtag("js", new Date());
 
-      gtag("config", "%VITE_GOOGLE_ANALYTICS_ID%");
+        gtag("config", "%VITE_GOOGLE_ANALYTICS_ID%");
+      }
     </script>
   </head>
   <body>

--- a/src/helpers/useAnalytics.ts
+++ b/src/helpers/useAnalytics.ts
@@ -33,8 +33,12 @@ async function getAssetDetails(assetId: string): Promise<{
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 export function useAnalytics() {
-  const { gtag } = window;
+  const gtag = window.gtag || noop;
+
   invariant(
     gtag,
     "Google Analytics is not loaded. Make sure to load the script in the head of your document."

--- a/src/helpers/useAnalytics.ts
+++ b/src/helpers/useAnalytics.ts
@@ -33,18 +33,12 @@ async function getAssetDetails(assetId: string): Promise<{
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 export function useAnalytics() {
-  const gtag = window.gtag || noop;
-
-  invariant(
-    gtag,
-    "Google Analytics is not loaded. Make sure to load the script in the head of your document."
-  );
+  const { gtag } = window;
 
   async function trackViewAssetEvent(assetId: string) {
+    if (!gtag) return;
+
     const assetDetails = await getAssetDetails(assetId);
     gtag("event", VIEW_ASSET_EVENT, assetDetails);
   }
@@ -58,6 +52,8 @@ export function useAnalytics() {
     assetId: string;
     fileType: string;
   }) {
+    if (!gtag) return;
+
     const assetDetails = await getAssetDetails(assetId);
     gtag("event", DOWNLOAD_EVENT, {
       ...assetDetails,


### PR DESCRIPTION
An alternative approach if `noop` is too "clever" (in a bad way).