### PR TITLE
Add dropdown menu options for downloading all assets in upload widget

### DIFF
--- a/src/components/DropDown/DropDown.vue
+++ b/src/components/DropDown/DropDown.vue
@@ -15,7 +15,8 @@
       tailwindcssOriginClass>
       <MenuButton
         class="inline-flex w-full justify-center rounded-md items-center focus:outline-none focus:ring-2 p-2 placeholder:focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100"
-        :class="labelClass">
+        :class="labelClass"
+        @click="(event) => emit('trigger:click', event)">
         <slot name="label">
           {{ label }}
         </slot>
@@ -55,4 +56,8 @@ withDefaults(
     labelClass: "",
   }
 );
+
+const emit = defineEmits<{
+  (eventName: "trigger:click", event: MouseEvent): void;
+}>();
 </script>

--- a/src/components/DropDown/DropDownItem.vue
+++ b/src/components/DropDown/DropDownItem.vue
@@ -1,7 +1,7 @@
 <template>
   <MenuItem v-slot="{ active }" class="dropdown__dropdown-item">
     <component
-      :is="$attrs.disabled ? 'span' : Link"
+      :is="$attrs.disabled ? 'div' : Link"
       class="block px-4 py-2 text-sm !no-underline"
       :class="{
         'bg-blue-50 !text-blue-900': active,

--- a/src/components/Tuple/Tuple.vue
+++ b/src/components/Tuple/Tuple.vue
@@ -4,22 +4,22 @@
     :class="{
       'w-full': variant === 'stacked',
       'inline-flex items-baseline gap-2': variant === 'inline',
-    }"
-  >
-    <div class="tuple__label">
+    }">
+    <div class="tuple__label flex justify-between items-center">
       <slot name="label">
         <span
           class="text-xs block uppercase leading-none mb-1 tracking-wide"
           :class="{
             'font-bold': variant === 'stacked',
             'sr-only': variant === 'value-only',
-          }"
-          >{{ label }}</span
-        >
+          }">
+          {{ label }}
+        </span>
+        <slot name="label-extra"></slot>
       </slot>
     </div>
     <span class="tuple__value block" v-bind="$attrs">
-      <slot> - </slot>
+      <slot>-</slot>
     </span>
   </div>
 </template>

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -120,10 +120,11 @@ async function downloadFile(url: string, filename: string): Promise<void> {
       // and start the download. Note: This doesn't need to be long
       // enough to COMPLETE the whole download, just long enough to start.
       // ~2s seems to be a good balance.
+      const WAIT_TIME_FOR_DOWNLOAD_RESPONSE = 2000;
       setTimeout(() => {
         link.remove();
         resolve();
-      }, 2000);
+      }, WAIT_TIME_FOR_DOWNLOAD_RESPONSE);
     } catch (error) {
       console.error(`Error downloading file: ${url}`, error);
       reject(error);

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -1,41 +1,68 @@
 <template>
-  <div class="upload-widget flex gap-2 flex-wrap mt-2">
-    <button
-      v-for="(content, key) in contents"
-      :key="key"
-      :title="content.fileDescription"
-      class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline hover:bg-blue-50 hover:text-blue-600 w-24 text-neutral-600"
-      :class="{
-        'opacity-80 hover:opacity-100 hover:border-blue-600': !isFileActive(
-          content.fileId
-        ),
-        'ring ring-offset-1 ring-blue-600 hover:border-transparent opacity-100 bg-blue-50':
-          isFileActive(content.fileId),
-      }"
-      @click="assetStore.activeFileObjectId = content.fileId"
-    >
-      <ThumbnailImage
-        :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
-        :alt="content.fileDescription"
-        :fileType="content.fileType"
-        class="thumbnail-related-asset-widget__image max-w-full"
-      />
-      <SanitizedHTML
-        v-if="content.fileDescription"
-        class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
-        :html="content.fileDescription"
-      />
-    </button>
-  </div>
+  <Tuple :label="widget.label" class="widget">
+    <template #label-extra>
+      <DropDown
+        label="More actions"
+        labelClass="inline-flex items-center !p-1 bg-black/5 rounded-md"
+        :showChevron="false">
+        <template #label>
+          <VerticalDotsIcon />
+          <span class="sr-only">More actions</span>
+        </template>
+        <DropDownItem>
+          <button class="block w-full" @click="handleDownloadAllDerivatives">
+            Download All Derivatives
+          </button>
+        </DropDownItem>
+        <!-- <DropDownItem>
+          <button>Download All Originals</button>
+        </DropDownItem> -->
+      </DropDown>
+    </template>
+    <div class="upload-widget flex gap-2 flex-wrap mt-2">
+      <button
+        v-for="(content, key) in contents"
+        :key="key"
+        :title="content.fileDescription"
+        class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline hover:bg-blue-50 hover:text-blue-600 w-24 text-neutral-600"
+        :class="{
+          'opacity-80 hover:opacity-100 hover:border-blue-600': !isFileActive(
+            content.fileId
+          ),
+          'ring ring-offset-1 ring-blue-600 hover:border-transparent opacity-100 bg-blue-50':
+            isFileActive(content.fileId),
+        }"
+        @click="assetStore.activeFileObjectId = content.fileId">
+        <ThumbnailImage
+          :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
+          :alt="content.fileDescription"
+          :fileType="content.fileType"
+          class="thumbnail-related-asset-widget__image max-w-full" />
+        <SanitizedHTML
+          v-if="content.fileDescription"
+          class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
+          :html="content.fileDescription" />
+      </button>
+    </div>
+  </Tuple>
 </template>
 
 <script setup lang="ts">
-import { UploadWidgetProps, UploadWidgetContent } from "@/types";
+import {
+  UploadWidgetProps,
+  UploadWidgetContent,
+  FileDownloadNormalized,
+} from "@/types";
 import config from "@/config";
 import { useAssetStore } from "@/stores/assetStore";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { computed, onMounted, onBeforeUnmount } from "vue";
+import Tuple from "@/components/Tuple/Tuple.vue";
+import { VerticalDotsIcon } from "@/icons";
+import DropDown from "@/components/DropDown/DropDown.vue";
+import DropDownItem from "@/components/DropDown/DropDownItem.vue";
+import api from "@/api";
 
 const props = defineProps<{
   widget: UploadWidgetProps;
@@ -75,6 +102,75 @@ function handleNextPrevArrowPresses(event: KeyboardEvent) {
 
   if (event.key === "ArrowRight") {
     return setNextFileAsActive();
+  }
+}
+
+async function downloadFile(url: string, filename: string) {
+  try {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.style.display = "none";
+    link.target = "_blank";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } catch (error) {
+    console.error("Error downloading file", error);
+    throw error;
+  }
+}
+
+function getPreferredDownloadInfo(
+  downloadInfo: FileDownloadNormalized[]
+): FileDownloadNormalized {
+  if (!downloadInfo?.length) {
+    throw new Error(`No download info found: ${downloadInfo}`);
+  }
+
+  // ignore any derivatives that aren't downloadable as files
+  // mostly doing this for testing. In prod, this case should
+  // rarely happen
+  const nonDownloadableTypes = ["dicom", "tiled"];
+
+  const downloadables = downloadInfo.filter(
+    (derivative) => !nonDownloadableTypes.includes(derivative.filetype)
+  );
+
+  if (downloadables.length < 1) {
+    throw new Error(`No downloadable derivatives found: ${downloadables}`);
+  }
+
+  // return the first deriv
+  return downloadables[0];
+}
+
+async function handleDownloadAllDerivatives() {
+  console.log("Downloading all derivatives");
+  // snapshot the assetId in case it changes during the download process
+  const assetId = assetStore.activeAssetId;
+
+  for (const content of props.contents) {
+    try {
+      const fileId = content.fileId;
+      const downloadInfo = await api.getFileDownloadInfo(
+        content.fileId,
+        assetId
+      );
+
+      if (!downloadInfo || downloadInfo.length < 1) {
+        console.warn(`No download info found for ${fileId}`);
+        continue;
+      }
+      const { url, filetype, extension } =
+        getPreferredDownloadInfo(downloadInfo);
+
+      const filename = `${fileId}-${filetype}.${extension}`;
+      await downloadFile(url, filename);
+    } catch (error) {
+      console.error("Error downloading file. Skipping.", error);
+      continue;
+    }
   }
 }
 

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -115,9 +115,11 @@ async function downloadFile(url: string, filename: string): Promise<void> {
       document.body.appendChild(link);
       link.click();
 
-      // timeout needs to be long enough for server to response to download
-      // request otherwise there will be a network error
-      // ~2s seems to be a good balance
+      // To address an Network Error issue with Safari, we need to make
+      // the timeout long enough to receive the 200 response from the server
+      // and start the download. Note: This doesn't need to be long
+      // enough to COMPLETE the whole download, just long enough to start.
+      // ~2s seems to be a good balance.
       setTimeout(() => {
         link.remove();
         resolve();

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -193,22 +193,18 @@ async function handleDownloadAll({ preferOriginals = false } = {}) {
   if (isDownloadingAll.value) return;
 
   isDownloadingAll.value = true;
-  console.log("Downloading all derivatives");
   // snapshot the assetId in case it changes during the download process
   const assetId = assetStore.activeAssetId;
 
   for (const content of props.contents) {
     try {
       const fileId = content.fileId;
-      console.log(`${fileId} - api.getFileDownloadInfo start`);
       const downloadInfo = await api.getFileDownloadInfo(
         content.fileId,
         assetId
       );
-      console.log(`${fileId} - api.getFileDownloadInfo end`);
 
       if (!downloadInfo || downloadInfo.length < 1) {
-        console.warn(`No download info found for ${fileId}`);
         continue;
       }
       const { url, filetype, extension } = getPreferredDownloadInfo(
@@ -217,12 +213,12 @@ async function handleDownloadAll({ preferOriginals = false } = {}) {
       );
 
       const filename = `${fileId}-${filetype}.${extension}`;
-      console.log(`${fileId} - Downloading ${filename} start`);
       await downloadFile(url, filename);
-      console.log(`${fileId} - Downloading ${filename} end`);
     } catch (error) {
-      console.error(`Error downloading file ${content.fileId}. Skipping.`);
-      console.error(error);
+      console.error(
+        `Error downloading file ${content.fileId}. Skipping.`,
+        error
+      );
       continue;
     }
   }

--- a/src/components/Widget/Widget.vue
+++ b/src/components/Widget/Widget.vue
@@ -1,5 +1,11 @@
 <template>
-  <Tuple :label="widget.label" class="widget">
+  <component
+    :is="getWidgetComponentByType(widget.type)"
+    v-if="['upload'].includes(widget.type)"
+    :widget="widget"
+    :contents="widgetContents"
+    :asset="asset"></component>
+  <Tuple v-else :label="widget.label" class="widget">
     <component
       :is="getWidgetComponentByType(widget.type)"
       v-if="getWidgetComponentByType(widget.type)"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,7 @@ declare global {
       config?: Partial<AppConfig>;
     };
     location: Location;
-    gtag: (command: string, ...args: unknown[]) => void;
+    gtag?: (command: string, ...args: unknown[]) => void;
     dataLayer?: unknown[];
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,7 @@ declare global {
       config?: Partial<AppConfig>;
     };
     location: Location;
-    gtag?: (command: string, ...args: unknown[]) => void;
+    gtag: (command: string, ...args: unknown[]) => void;
     dataLayer?: unknown[];
   }
 }


### PR DESCRIPTION
Closes https://github.com/UMN-LATIS/elevator-ui/issues/282

This supersedes #293 

- Adds a "more actions" menu to the Upload Widget component to allow users to download all derivatives (or originals, if permitted).
- Some browsers (safari) it seems will abort any in-flight download requests if a response hasn't been returned from the server, so an artificial timeout is added ~2s to wait for the server to respond. (The download doesn't need to finish within 2s, it just needs to start within that time or an error will be thrown).
- To determine whether or not a user can download originals, we need to get file info for the first download. Since using the download all feature is rare, we avoid doing with every upload widget rendering. Instead, the permission check will happen once the user attempts to open the "More actions" menu. It's a little hacky.

On dev for testing.

https://github.com/user-attachments/assets/91eb2510-a6d1-4246-b86e-7c220ded20c6

