### PR TITLE
fix: search sort sometimes listed incorrectly

### DIFF
--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -223,32 +223,9 @@ async function handleSortOptionChange(sortOption: keyof SearchSortOptions) {
   });
 }
 
-function getInitialSortOption(searchQuery: string): keyof SearchSortOptions {
-  const sortOption = route.query.sort as keyof SearchSortOptions;
-
-  // if the query is blank and the sort option is best match
-  // then we should default to sorting by title, since best match
-  // doesn't make sense for a blank query
-  if (
-    searchQuery === "" &&
-    (!sortOption || sortOption === SORT_KEYS.BEST_MATCH)
-  ) {
-    return SORT_KEYS.TITLE;
-  }
-
-  // otherwise return the sort option from the query param
-  // or default to best match
-  return sortOption || SORT_KEYS.BEST_MATCH;
-}
-
 onMounted(() => {
   // set the initial tab based on the query param
   const initialTabId = props.resultsView || searchStore.resultsView || "grid";
-
-  // set initial sort option based on query param
-  searchStore.sort = getInitialSortOption(
-    searchStore.currentSearchTerm ?? searchStore.query
-  );
 
   // if the query param is set, use it to set the state
   // otherwise we'll fall back to the current resultsView

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -584,6 +584,7 @@ const actions = (state: SearchStoreState) => ({
     state.matches.value = res.matches;
     state.status.value = "success";
     state.sortOptions.value = res.sortableWidgets;
+    state.sort.value = res.searchEntry.sort ?? SORT_KEYS.BEST_MATCH;
 
     // update the boolean operator
     state.filterBy.searchableFieldsOperator =

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -562,6 +562,22 @@ const actions = (state: SearchStoreState) => ({
   },
 
   async getSearchId(): Promise<string> {
+    // normally, search sort is "sticky", but if we're transitioning
+    // from an empty search to a non-empty search, should reset sort to
+    // BEST_MATCH instead of by TITLE (which is the default for an
+    // empty search)
+    const previousSearchWasEmpty = state.searchEntry.value?.searchText === "";
+    const currentSearchIsNOTEmpty = state.query.value !== "";
+    const currentSortIsTitle = state.sort.value === SORT_KEYS.TITLE;
+
+    if (
+      previousSearchWasEmpty &&
+      currentSearchIsNOTEmpty &&
+      currentSortIsTitle
+    ) {
+      state.sort.value = SORT_KEYS.BEST_MATCH;
+    }
+
     return api
       .getSearchId(state.query.value, getters(state).searchRequestOptions.value)
       .catch((err) => {

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -586,15 +586,6 @@ const actions = (state: SearchStoreState) => ({
     state.sortOptions.value = res.sortableWidgets;
     state.sort.value = res.searchEntry.sort ?? SORT_KEYS.BEST_MATCH;
 
-    // if currentSearchTerm is empty, then "Best Match"
-    // doesn't make sense, so set it to "Default Title"
-    if (
-      res.searchEntry.searchText === "" &&
-      state.sort.value === SORT_KEYS.BEST_MATCH
-    ) {
-      state.sort.value = SORT_KEYS.TITLE;
-    }
-
     // update the boolean operator
     state.filterBy.searchableFieldsOperator =
       res.searchEntry.combineSpecificSearches;

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -586,6 +586,15 @@ const actions = (state: SearchStoreState) => ({
     state.sortOptions.value = res.sortableWidgets;
     state.sort.value = res.searchEntry.sort ?? SORT_KEYS.BEST_MATCH;
 
+    // if currentSearchTerm is empty, then "Best Match"
+    // doesn't make sense, so set it to "Default Title"
+    if (
+      res.searchEntry.searchText === "" &&
+      state.sort.value === SORT_KEYS.BEST_MATCH
+    ) {
+      state.sort.value = SORT_KEYS.TITLE;
+    }
+
     // update the boolean operator
     state.filterBy.searchableFieldsOperator =
       res.searchEntry.combineSpecificSearches;


### PR DESCRIPTION
Resolves #298 

Sometimes, the `sort` field in UI wouldn't match the search results. For example, if you typed "test" in the search input. The results returned would have `searchEntry.sort: 0` (best match), but the search selector would show `Default Title` 

The cause:
- On initial page load, the query is empty as the page waits for the search results to load.
- Previously, we had logic to set an initial sort state. It would use a query param (if one existed), or "Best Match", or – and this is where the problem is – it would use "Default Title" if the search was blank (i.e. we were asking for all results).
- Because the query was empty on page load (since data wasn't loaded), the initial sort was "Default Title"
- THEN – and this is error #2 – we were not properly updating the sort  in `searchStore` with the response from the server.

This:
- fixes searchStore to properly update sort once results are received.
- removes the logic in SearchResultsPage to set an initial sort while waiting for results
- removes logic to change "Best Match" to "Default Title" on empty search. The server response seems correct, so we shouldn't need this if we don't bother with setting initial sort before the results arrive.

