### PR TITLE
use new `downloadable` prop with Download All

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -144,6 +144,7 @@ export async function fetchFileDownloadInfo(
         : `${BASE_URL}/fileManager/getDerivativeById/${fileId}/${filetype}`,
     originalFilename: downloadDetails.originalFilename,
     extension: getExtensionFromFilename(downloadDetails.originalFilename),
+    isDownloadable: downloadDetails.downloadable,
   }));
 }
 
@@ -197,7 +198,7 @@ export async function fetchInstanceNav(): Promise<ApiInstanceNavResponse> {
 export async function postLtiPayload({
   fileObjectId,
   excerptId,
-  launchId
+  launchId,
 }: {
   fileObjectId: string;
   returnUrl: string;
@@ -216,7 +217,7 @@ export async function postLtiPayload13({
   fileObjectId,
   excerptId,
   launchId,
-  userId
+  userId,
 }: {
   fileObjectId: string;
   returnUrl: string;
@@ -234,7 +235,6 @@ export async function postLtiPayload13({
 
   return res.data;
 }
-
 
 export async function fetchSearchId(
   query: string,

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -198,7 +198,7 @@ export async function fetchInstanceNav(): Promise<ApiInstanceNavResponse> {
 export async function postLtiPayload({
   fileObjectId,
   excerptId,
-  launchId,
+  launchId
 }: {
   fileObjectId: string;
   returnUrl: string;
@@ -217,7 +217,7 @@ export async function postLtiPayload13({
   fileObjectId,
   excerptId,
   launchId,
-  userId,
+  userId
 }: {
   fileObjectId: string;
   returnUrl: string;

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -236,6 +236,7 @@ export async function postLtiPayload13({
   return res.data;
 }
 
+
 export async function fetchSearchId(
   query: string,
   opts: Omit<SearchRequestOptions, "searchText"> = {}

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -191,8 +191,6 @@ async function handleDownloadAll({ preferOriginals = false } = {}) {
         assetId
       );
 
-      console.log({ downloadInfo });
-
       if (!downloadInfo) {
         console.warn(
           `No download info found for file ${content.fileId}. Skipping.`

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -157,21 +157,12 @@ async function downloadFile(url: string, filename: string): Promise<void> {
 }
 
 function getPreferredDownloadInfo(
-  downloadInfo: FileDownloadNormalized[],
+  downloadables: FileDownloadNormalized[],
   { preferOriginals = false } = {}
 ): FileDownloadNormalized {
-  if (!downloadInfo?.length) {
-    throw new Error(`No download info found: ${downloadInfo}`);
+  if (!downloadables?.length) {
+    throw new Error(`No download info found: ${downloadables}`);
   }
-
-  // ignore any derivatives that aren't downloadable as files
-  // mostly doing this for testing. In prod, this case should
-  // rarely happen
-  const nonDownloadableTypes = ["dicom", "tiled"];
-
-  const downloadables = downloadInfo.filter(
-    (derivative) => !nonDownloadableTypes.includes(derivative.filetype)
-  );
 
   if (downloadables.length < 1) {
     throw new Error(`No downloadable derivatives found: ${downloadables}`);
@@ -204,11 +195,26 @@ async function handleDownloadAll({ preferOriginals = false } = {}) {
         assetId
       );
 
-      if (!downloadInfo || downloadInfo.length < 1) {
+      if (!downloadInfo) {
+        console.warn(
+          `No download info found for file ${content.fileId}. Skipping.`
+        );
         continue;
       }
+
+      const downloadables = downloadInfo.filter(
+        (derivative) => derivative.isDownloadable && derivative.isReady
+      );
+
+      if (!downloadables.length) {
+        console.warn(
+          `No downloadable derivatives found for file ${content.fileId}. Skipping.`
+        );
+        continue;
+      }
+
       const { url, filetype, extension } = getPreferredDownloadInfo(
-        downloadInfo,
+        downloadables,
         { preferOriginals }
       );
 

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -160,10 +160,6 @@ function getPreferredDownloadInfo(
   downloadables: FileDownloadNormalized[],
   { preferOriginals = false } = {}
 ): FileDownloadNormalized {
-  if (!downloadables?.length) {
-    throw new Error(`No download info found: ${downloadables}`);
-  }
-
   if (downloadables.length < 1) {
     throw new Error(`No downloadable derivatives found: ${downloadables}`);
   }
@@ -194,6 +190,8 @@ async function handleDownloadAll({ preferOriginals = false } = {}) {
         content.fileId,
         assetId
       );
+
+      console.log({ downloadInfo });
 
       if (!downloadInfo) {
         console.warn(

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -602,15 +602,6 @@ const actions = (state: SearchStoreState) => ({
     state.sortOptions.value = res.sortableWidgets;
     state.sort.value = res.searchEntry.sort ?? SORT_KEYS.BEST_MATCH;
 
-    // if currentSearchTerm is empty, then "Best Match"
-    // doesn't make sense, so set it to "Default Title"
-    if (
-      res.searchEntry.searchText === "" &&
-      state.sort.value === SORT_KEYS.BEST_MATCH
-    ) {
-      state.sort.value = SORT_KEYS.TITLE;
-    }
-
     // update the boolean operator
     state.filterBy.searchableFieldsOperator =
       res.searchEntry.combineSpecificSearches;

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -602,6 +602,15 @@ const actions = (state: SearchStoreState) => ({
     state.sortOptions.value = res.sortableWidgets;
     state.sort.value = res.searchEntry.sort ?? SORT_KEYS.BEST_MATCH;
 
+    // if currentSearchTerm is empty, then "Best Match"
+    // doesn't make sense, so set it to "Default Title"
+    if (
+      res.searchEntry.searchText === "" &&
+      state.sort.value === SORT_KEYS.BEST_MATCH
+    ) {
+      state.sort.value = SORT_KEYS.TITLE;
+    }
+
     // update the boolean operator
     state.filterBy.searchableFieldsOperator =
       res.searchEntry.combineSpecificSearches;

--- a/src/types/FileDownloadTypes.ts
+++ b/src/types/FileDownloadTypes.ts
@@ -12,4 +12,5 @@ export interface FileDownloadDetails {
   forcedMimeType: null;
   localAsset: null;
   storageKey: string;
+  downloadable: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -642,6 +642,7 @@ export interface FileDownloadNormalized {
   url: string;
   originalFilename: string;
   extension: string;
+  isDownloadable: boolean;
 }
 
 export interface Tab {


### PR DESCRIPTION
Previously, Download All would skip some trying to download some assets based on the file type (e.g. "dicom", "tiled"). This updates to use a `downloadable` prop passed back with download info. Files must have at least one `downloadable` version for a download to be attempted.

on dev for testing.