### PR TITLE
fix: download all skips the first file in Safari

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -146,9 +146,10 @@ async function getFileDownloadInfo(
   if (cachedResponse) {
     // this is a workaround for "Download All" issue in Safari.
     // Safari will not download the first file in the list if
-    // the download info is cached. This may be related to a user gesture
-    // requirement for downloads in Safari, but I'm unsure.
-    // The workaround is to delay the response until the next event loop.
+    // the cached download info is returned right away. The workaround
+    // is to wait until next tick before returning the response.
+    // I'm not entirely sure why safari behaves this way: bug?
+    // security feature? but this workaround seems to do the trick.
     return _waitThenResolve(cachedResponse);
   }
 


### PR DESCRIPTION
This is a workaround for an issue in safari where the first download is skipped when the user chooses "Download All."

The issue is related to the caching of `getFileDownloadInfo`. If a cached response is returned and immediately starts download, Safari will skip it. However, if we wait before returning the cached results, Safari will download as expected. So, this PR waits until next tick before resolving the cached file download info.

My suspicion is that this is some security feature to detect whether the download was triggered by a legit user gesture, but I couldn't find clear documentation about it.

We may need to tweak wait time if putting the results on the next loop isn't enough.

On dev for testing.