### PR TITLE
fix: showing custom header and footer

### DIFF
--- a/src/pages/AllCollectionsPage/AllCollectionsPage.vue
+++ b/src/pages/AllCollectionsPage/AllCollectionsPage.vue
@@ -1,7 +1,8 @@
 <template>
   <DefaultLayout class="all-collections-page">
     <template #custom-header>
-      <CustomAppHeader v-if="instanceStore.customHeaderMode == 1" />
+      <CustomAppHeader
+        v-if="instanceStore.customHeaderMode === ShowCustomHeaderMode.ALWAYS" />
     </template>
     <div class="p-8 px-4">
       <h1 class="text-4xl font-bold my-8">Collections</h1>

--- a/src/pages/AllCollectionsPage/AllCollectionsPage.vue
+++ b/src/pages/AllCollectionsPage/AllCollectionsPage.vue
@@ -18,14 +18,19 @@
         />
       </div>
     </div>
+    <template #footer>
+      <AppFooter
+        v-if="instanceStore.customHeaderMode === ShowCustomHeaderMode.ALWAYS" />
+    </template>
   </DefaultLayout>
 </template>
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
 import CollectionItem from "./CollectionItem.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
+import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
-import { useInstanceStore } from "@/stores/instanceStore";
+import { useInstanceStore, ShowCustomHeaderMode } from "@/stores/instanceStore";
 import { useResizeObserver } from "@vueuse/core";
 import { ApiStaticPageResponse } from "@/types";
 import api from "@/api";

--- a/src/pages/AllDrawersPage/AllDrawersPage.vue
+++ b/src/pages/AllDrawersPage/AllDrawersPage.vue
@@ -32,18 +32,23 @@
         </TransitionGroup>
       </div>
     </div>
+    <template #footer>
+      <AppFooter
+        v-if="instanceStore.customHeaderMode === ShowCustomHeaderMode.ALWAYS" />
+    </template>
   </DefaultLayout>
 </template>
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
+import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import Link from "@/components/Link/Link.vue";
 import { useResizeObserver } from "@vueuse/core";
 import DeleteDrawerButton from "./DeleteDrawerButton.vue";
 import CreateDrawerButton from "./CreateDrawerButton.vue";
 import { useDrawerStore } from "@/stores/drawerStore";
-import { useInstanceStore } from "@/stores/instanceStore";
+import { useInstanceStore, ShowCustomHeaderMode } from "@/stores/instanceStore";
 
 const gridContainer = ref<HTMLElement | null>(null);
 const numCols = ref(1);

--- a/src/pages/AllDrawersPage/AllDrawersPage.vue
+++ b/src/pages/AllDrawersPage/AllDrawersPage.vue
@@ -1,7 +1,8 @@
 <template>
   <DefaultLayout class="all-drawers-page">
     <template #custom-header>
-      <CustomAppHeader v-if="instanceStore.customHeaderMode == 1" />
+      <CustomAppHeader
+        v-if="instanceStore.customHeaderMode === ShowCustomHeaderMode.ALWAYS" />
     </template>
     <div class="p-8 px-4">
       <h1 class="text-4xl font-bold my-8">Drawers</h1>

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -49,7 +49,8 @@
       </p>
     </Notification>
     <template #footer>
-      <AppFooter />
+      <AppFooter
+        v-if="instanceStore.customHeaderMode !== ShowCustomHeaderMode.NEVER" />
     </template>
   </DefaultLayout>
 </template>
@@ -58,7 +59,7 @@ import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import { ref, watch, computed } from "vue";
 import { StaticContentPage, Asset } from "@/types";
-import { useInstanceStore } from "@/stores/instanceStore";
+import { useInstanceStore, ShowCustomHeaderMode } from "@/stores/instanceStore";
 import api from "@/api";
 import FeaturedAssetCard from "@/components/FeaturedAssetCard/FeaturedAssetCard.vue";
 import SignInRequiredNotice from "./SignInRequiredNotice.vue";

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -1,7 +1,8 @@
 <template>
   <DefaultLayout class="home-page">
     <template #custom-header>
-      <CustomAppHeader v-if="instanceStore.customHeaderMode > 0" />
+      <CustomAppHeader
+        v-if="instanceStore.customHeaderMode !== ShowCustomHeaderMode.NEVER" />
     </template>
     <SignInRequiredNotice
       v-if="isReady && !canSearchAndBrowse && !instanceStore.isLoggedIn"

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -21,7 +21,8 @@
       </div>
     </div>
     <template #footer>
-      <AppFooter v-if="instanceStore.customFooter" />
+      <AppFooter
+        v-if="instanceStore.customHeaderMode === ShowCustomHeaderMode.ALWAYS" />
     </template>
   </DefaultLayout>
 </template>
@@ -32,7 +33,7 @@ import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import { computed, ref, watch } from "vue";
 import { ApiStaticPageResponse } from "@/types";
-import { useInstanceStore } from "@/stores/instanceStore";
+import { useInstanceStore, ShowCustomHeaderMode } from "@/stores/instanceStore";
 import api from "@/api";
 import config from "@/config";
 

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -1,7 +1,8 @@
 <template>
   <DefaultLayout class="static-content-page">
     <template #custom-header>
-      <CustomAppHeader v-if="instanceStore.customHeaderMode > 0" />
+      <CustomAppHeader
+        v-if="instanceStore.customHeaderMode === ShowCustomHeaderMode.ALWAYS" />
     </template>
     <div
       v-if="page"

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -17,6 +17,12 @@ import {
   flattenCollections,
 } from "@/helpers/collectionHelpers";
 
+export enum ShowCustomHeaderMode {
+  NEVER = 0,
+  ALWAYS = 1,
+  HOME_PAGE_ONLY = 2,
+}
+
 const createState = () => ({
   fetchStatus: ref<FetchStatus>("idle"),
   currentUser: ref<User | null>(null),
@@ -37,7 +43,7 @@ const createState = () => ({
     showCollectionInSearchResults: true,
     showTemplateInSearchResults: true,
   }),
-  customHeaderMode: ref<number>(0),
+  customHeaderMode: ref<ShowCustomHeaderMode>(ShowCustomHeaderMode.NEVER),
   customHeader: ref<string | null>(null),
   customFooter: ref<string | null>(null),
 });


### PR DESCRIPTION
- adds enum for different custom header modes
- render footer on collection and drawers page if mode allows
- fix static page: only render on "always" mode
- fix home page: do not render if "never" mode

On dev for testing