### PR TITLE
show message next to save button if user is missing required fields

### DIFF
--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -343,9 +343,16 @@ function getAssetAsSaveableFormData() {
       const fieldTitle = widgetDef.fieldTitle;
       const contents = state.localAsset[fieldTitle] as WidgetContent[];
 
+      // strip out our locally assigned ids
+      // we do this so ids aren't persisted on the
+      // mock backend, causi so that
+      // it's not persisted. but, it's probably a good idea
+      // to do this for the real backend too.
+      const contentsWithoutId = contents.map(({ id: _id, ...rest }) => rest);
+
       return {
         ...acc,
-        [fieldTitle]: contents ?? createDefaultWidgetContent(widgetDef),
+        [fieldTitle]: contentsWithoutId,
       };
     },
     {} as Record<string, WidgetContent[]>

--- a/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetForm.vue
+++ b/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetForm.vue
@@ -19,7 +19,7 @@
           :widgetDef="widgetDef"
           :widgetContents="widgetContents"
           :assetId="asset.assetId"
-          :collectionId="(asset.collectionId as number)"
+          :collectionId="typeof asset.collectionId === 'string' ? Number.parseInt(asset.collectionId) : asset.collectionId as number"
           :isOpen="openWidgets.has(widgetDef.widgetId)"
           @save="$emit('save')"
           @update:isOpen="

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -390,7 +390,7 @@ export type AssetPreview = SearchResultMatch;
 
 export interface SearchEntry {
   collection?: string[]; // collection ids as strings
-  searchDate?: DateTime;
+  searchDate?: PHPDateTime;
   searchText?: string;
   matchType?: string; // 'phrase_prefix' ?
   showHidden?: boolean | "0" | "1";
@@ -454,7 +454,7 @@ export interface SearchResultsResponse {
   sortableWidgets: SearchSortOptions;
 }
 
-export interface DateTime {
+export interface PHPDateTime {
   date: string;
   timezone_type: number;
   timezone: string;
@@ -497,7 +497,7 @@ export interface Asset {
   readyForDisplay: boolean;
   collectionId: number;
   availableAfter: PHPDateTime | null;
-  modified: DateTime;
+  modified: PHPDateTime;
   modifiedBy: number | string;
   createdBy: number | string;
   deletedBy: number | string | null;

--- a/tests/e2e/asset-creation.spec.ts
+++ b/tests/e2e/asset-creation.spec.ts
@@ -89,7 +89,76 @@ test.describe("Asset Creation", () => {
       const saveButton = page.getByRole("button", { name: "Save" });
       await expect(saveButton).toBeDisabled();
 
-      // TODO: maybe show a validation button by save?
+      // Should show validation message for missing required field
+      await expect(page.getByText("Missing required:")).toBeVisible();
+
+      // Check that the validation message contains "Title"
+      const validationText = page
+        .locator("text=Missing required:")
+        .locator("..");
+      await expect(validationText).toContainText("Title");
+    });
+
+    test("shows validation message for missing required fields", async ({
+      page,
+    }) => {
+      await page.goto("/assetManager/addAsset");
+
+      // Select template and collection
+      const templateSelect = page.getByLabel("Template");
+      await templateSelect.selectOption({ index: 1 });
+
+      const collectionSelect = page.getByLabel("Collection");
+      await collectionSelect.selectOption({ index: 1 });
+
+      // Click Continue to go to the asset form
+      const continueButton = page.getByRole("button", { name: "Continue" });
+      await continueButton.click();
+
+      // Verify validation message appears for missing required fields
+      await expect(page.getByText("Missing required:")).toBeVisible();
+
+      // Should show the specific missing field name (Title)
+      const validationText = page
+        .locator("text=Missing required:")
+        .locator("..");
+      await expect(validationText).toContainText("Title");
+
+      // Save button should be disabled
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await expect(saveButton).toBeDisabled();
+    });
+
+    test("validation message disappears when required fields are filled", async ({
+      page,
+    }) => {
+      await page.goto("/assetManager/addAsset");
+
+      // Select template and collection
+      const templateSelect = page.getByLabel("Template");
+      await templateSelect.selectOption({ index: 1 });
+
+      const collectionSelect = page.getByLabel("Collection");
+      await collectionSelect.selectOption({ index: 1 });
+
+      // Click Continue to go to the asset form
+      const continueButton = page.getByRole("button", { name: "Continue" });
+      await continueButton.click();
+
+      // Initially should show validation message
+      await expect(page.getByText("Missing required:")).toBeVisible();
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await expect(saveButton).toBeDisabled();
+
+      // Fill in the required title field
+      const titleField = page.getByLabel(/title/i).first();
+      await titleField.fill("Test Asset Title");
+
+      // Validation message should disappear
+      await expect(page.getByText("Missing required:")).not.toBeVisible();
+
+      // Save button should be enabled
+      await expect(saveButton).toBeEnabled();
     });
   });
 


### PR DESCRIPTION
It's not so easy to tell why the save button might be disabled - especially if there's another required field off screen.

Missing required:
<img width="500"  alt="ScreenShot 2025-07-25 at 15 39 53@2x" src="https://github.com/user-attachments/assets/25f3ae5a-ad50-4150-8181-c167d339a149" />

No unsaved changes:
<img width="500" alt="ScreenShot 2025-07-25 at 15 39 41@2x" src="https://github.com/user-attachments/assets/f1107616-190f-40a1-96c0-7c0fb3a7b75c" />

Saveable:

<img width="500"  alt="ScreenShot 2025-07-25 at 15 40 01@2x" src="https://github.com/user-attachments/assets/6987bcae-38e3-4ed6-b81c-69e6d89672d2" />
