### PR TITLE
show related asset label in parens if configured

### DIFF
--- a/src/components/Widget/RelatedAssetWidget/AccordionRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/AccordionRelatedAssetWidgetItem.vue
@@ -20,18 +20,14 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
 import Accordion from "@/components/Accordion/Accordion.vue";
 import WidgetList from "@/components/WidgetList/WidgetList.vue";
-import { RelatedAssetCacheItem } from "@/types";
-import { getTitleFromCacheItem } from "./getTitleFromCacheItem";
 import { getTinyURL } from "@/helpers/displayUtils";
-
-const props = defineProps<{
+import { RelatedAssetCacheItem } from "@/types";
+defineProps<{
   assetId: string;
-  assetCacheItem: RelatedAssetCacheItem | null;
+  title: string;
+  assetCacheItem: RelatedAssetCacheItem;
 }>();
-
-const title = computed(() => getTitleFromCacheItem(props.assetCacheItem));
 </script>
 <style scoped></style>

--- a/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
@@ -9,16 +9,13 @@
 <script setup lang="ts">
 import WidgetList from "@/components/WidgetList/WidgetList.vue";
 import { computed } from "vue";
-import type { RelatedAssetCacheItem } from "@/types";
-import { getTitleFromCacheItem } from "./getTitleFromCacheItem";
 import { useAsset } from "@/helpers/useAsset";
 
 const props = defineProps<{
   assetId: string;
-  assetCacheItem: RelatedAssetCacheItem | null;
+  title: string;
 }>();
 
-const title = computed(() => getTitleFromCacheItem(props.assetCacheItem));
 const assetIdRef = computed(() => props.assetId);
 const { asset } = useAsset(assetIdRef);
 </script>

--- a/src/components/Widget/RelatedAssetWidget/LinkedRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/LinkedRelatedAssetWidgetItem.vue
@@ -5,19 +5,14 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import type { RelatedAssetCacheItem } from "@/types";
-import { getTitleFromCacheItem } from "./getTitleFromCacheItem";
 import { getAssetUrl } from "@/helpers/displayUtils";
 import Link from "@/components/Link/Link.vue";
 
 const props = defineProps<{
   assetId: string;
-  assetCacheItem: RelatedAssetCacheItem | null;
+  title: string;
 }>();
 
-const title = computed((): string =>
-  getTitleFromCacheItem(props.assetCacheItem)
-);
 const assetUrl = computed((): string => getAssetUrl(props.assetId));
 </script>
 <style scoped></style>

--- a/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
+++ b/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
@@ -108,8 +108,9 @@ function getRelatedAssetTitle({
   widgetDef: RelatedAssetWidgetDef;
   label: string;
 }): string {
-  const trimmedTitle = cacheItem?.relatedAssetTitle?.[0].trim() ?? "";
-  const trimmedLabel = label?.trim() ?? "";
+  const relatedAssetTitleArr: string[] = cacheItem?.relatedAssetTitle ?? [];
+  const trimmedTitle: string = relatedAssetTitleArr?.[0]?.trim() ?? "";
+  const trimmedLabel: string = label.trim();
   const shouldShowLabel =
     widgetDef.fieldData.showLabel &&
     trimmedLabel.length > 0 &&

--- a/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
+++ b/src/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue
@@ -11,8 +11,8 @@
       :key="relatedAsset.targetAssetId"
       :isActiveObject="assetStore.activeObjectId === relatedAsset.targetAssetId"
       :assetId="relatedAsset.targetAssetId"
-      :assetCacheItem="asset.relatedAssetCache?.[relatedAsset.targetAssetId]"
-      :label="relatedAsset.label ?? ''">
+      :assetCacheItem="relatedAsset.cacheItem"
+      :title="relatedAsset.title">
       <div class="flex items-center justify-end gap-2">
         <ArrowButton :to="`/asset/viewAsset/${relatedAsset.targetAssetId}`" />
       </div>
@@ -25,6 +25,8 @@ import {
   Asset,
   RelatedAssetWidgetDef,
   RelatedAssetWidgetContent,
+  RelatedAssetCacheItem,
+  RelatedAssetCache,
 } from "@/types";
 import AccordionRelatedAssetWidgetItem from "./AccordionRelatedAssetWidgetItem.vue";
 import CollapsedInlineRelatedAssetWidgetItem from "./CollapsedInlineRelatedAssetWidgetItem.vue";
@@ -60,10 +62,26 @@ const widgetType = computed((): Component => {
 });
 
 const contentsWithAssetId = computed(() =>
-  props.contents.filter(
-    (item): item is WithTargetAssetId<RelatedAssetWidgetContent> =>
-      !!item.targetAssetId
-  )
+  props.contents
+    .filter(
+      (item): item is WithTargetAssetId<RelatedAssetWidgetContent> =>
+        !!item.targetAssetId
+    )
+    .map((relatedAsset) => {
+      const cacheItem = getRelatedAssetCacheItem(
+        relatedAsset.targetAssetId,
+        props.asset.relatedAssetCache
+      );
+      return {
+        ...relatedAsset,
+        cacheItem,
+        title: getRelatedAssetTitle({
+          cacheItem,
+          label: relatedAsset.label ?? "",
+          widgetDef: props.widget,
+        }),
+      };
+    })
 );
 
 const activeIndex = computed(() =>
@@ -73,6 +91,35 @@ const activeIndex = computed(() =>
 );
 
 const hasActiveObjectWithin = computed(() => activeIndex.value !== -1);
+
+function getRelatedAssetCacheItem(
+  targetAssetId: string,
+  relatedAssetCache: RelatedAssetCache | never[] | null
+): RelatedAssetCacheItem | null {
+  return relatedAssetCache?.[targetAssetId] ?? null;
+}
+
+function getRelatedAssetTitle({
+  cacheItem,
+  widgetDef,
+  label,
+}: {
+  cacheItem: RelatedAssetCacheItem | null;
+  widgetDef: RelatedAssetWidgetDef;
+  label: string;
+}): string {
+  const trimmedTitle = cacheItem?.relatedAssetTitle?.[0].trim() ?? "";
+  const trimmedLabel = label?.trim() ?? "";
+  const shouldShowLabel =
+    widgetDef.fieldData.showLabel &&
+    trimmedLabel.length > 0 &&
+    trimmedLabel !== trimmedTitle;
+
+  if (!shouldShowLabel) {
+    return trimmedTitle || "(No Title)";
+  }
+  return `${trimmedTitle} (${trimmedLabel})`;
+}
 
 function setPrevObjectAsActive() {
   const prevIndex =

--- a/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
@@ -21,22 +21,17 @@
   </RouterLink>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
 import { getTinyURL } from "@/helpers/displayUtils";
-import type { RelatedAssetCacheItem } from "@/types";
-import { getTitleFromCacheItem } from "./getTitleFromCacheItem";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import ThumbnailGeneric from "@/components/ThumbnailGeneric/ThumbnailGeneric.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
+import { RelatedAssetCacheItem } from "@/types";
 
-const props = defineProps<{
+defineProps<{
   assetId: string;
-  assetCacheItem: RelatedAssetCacheItem;
+  title: string;
   isActiveObject: boolean;
+  assetCacheItem: RelatedAssetCacheItem;
 }>();
-
-const title = computed((): string =>
-  getTitleFromCacheItem(props.assetCacheItem)
-);
 </script>
 <style scoped></style>

--- a/src/components/Widget/RelatedAssetWidget/getTitleFromCacheItem.ts
+++ b/src/components/Widget/RelatedAssetWidget/getTitleFromCacheItem.ts
@@ -1,7 +1,0 @@
-import { RelatedAssetCacheItem } from "@/types";
-
-export function getTitleFromCacheItem(
-  relatedAssetCacheItem: RelatedAssetCacheItem | null
-): string {
-  return relatedAssetCacheItem?.relatedAssetTitle?.[0] ?? "(No Title)";
-}


### PR DESCRIPTION
<img width="500" alt="ScreenShot 2025-07-31 at 10 36 20@2x" src="https://github.com/user-attachments/assets/d9599765-77a3-4dc1-ac3c-0494aa078fcf" />

Show related asset label if `showLabel` is true. 

Details:
- Label will NOT show if it matches the title. (assumed this is the desired behavior, but let me know).
- moves title calculation to the parent RelatedAssetWidget component and then passes it down to child components.
- In parent, `cacheItem` and `title` are now part of each `contentsWithAssetId` object.

On dev for testing.

Resolves #317 
