### PR TITLE
fix blank `collectionId` in select when loading edit page

### DIFF
--- a/mock-server/routes/assets.ts
+++ b/mock-server/routes/assets.ts
@@ -59,8 +59,18 @@ app.post("/submission/true", async (c) => {
     formData: AssetFormData;
   };
 
-  if (!formData.templateId || !formData.collectionId) {
-    return c.json({ error: "Template and collection are required" }, 400);
+  // convert collectionId and templateId to numbers
+  formData.collectionId = Number(formData.collectionId);
+  formData.templateId = Number(formData.templateId);
+
+  if (
+    Number.isNaN(formData.collectionId) ||
+    Number.isNaN(formData.templateId)
+  ) {
+    return c.json(
+      { error: "valid templateId and collectionId are required" },
+      400
+    );
   }
 
   const titleWidgets = formData.title_1 as TextWidgetContent[];

--- a/src/components/SelectGroup/SelectGroup.vue
+++ b/src/components/SelectGroup/SelectGroup.vue
@@ -21,7 +21,7 @@
       readonly
       required
       @change="
-        $emit('update:modelValue', ($event.target as HTMLSelectElement).value)
+        handleUpdateSelection(($event.target as HTMLSelectElement).value)
       ">
       <option value="" disabled selected>{{ placeholder }}</option>
       <option v-for="opt in options" :key="opt.id" :value="opt.id">
@@ -36,7 +36,7 @@ import { CSSClass } from "@/types";
 
 withDefaults(
   defineProps<{
-    modelValue: string | number;
+    modelValue: string | number | null;
     label: string;
     options: Array<{
       id: string | number;
@@ -59,8 +59,24 @@ withDefaults(
   }
 );
 
-defineEmits<{
-  (e: "update:modelValue", value: string | number): void;
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string | number | null): void;
 }>();
+
+function handleUpdateSelection(value: string | number) {
+  // if the value is empty, set it to null
+  if (value === "") {
+    return emit("update:modelValue", null);
+  }
+
+  // if the value is a number, convert it to a number
+  const maybeNumber = Number(value);
+  if (Number.isInteger(maybeNumber)) {
+    return emit("update:modelValue", maybeNumber);
+  }
+
+  // otherwise, return the value as a string
+  return emit("update:modelValue", value);
+}
 </script>
 <style scoped></style>

--- a/src/components/SelectGroup/SelectGroup.vue
+++ b/src/components/SelectGroup/SelectGroup.vue
@@ -16,7 +16,7 @@
     </label>
     <select
       :id="id"
-      :value="modelValue"
+      :value="modelValue ?? ''"
       :class="cn(['rounded-md border-none bg-black/5 text-sm', selectClass])"
       readonly
       required

--- a/src/components/SelectGroup/SelectGroup.vue
+++ b/src/components/SelectGroup/SelectGroup.vue
@@ -36,10 +36,10 @@ import { CSSClass } from "@/types";
 
 withDefaults(
   defineProps<{
-    modelValue: string;
+    modelValue: string | number;
     label: string;
     options: Array<{
-      id: string;
+      id: string | number;
       label: string;
     }>;
     required?: boolean;
@@ -60,7 +60,7 @@ withDefaults(
 );
 
 defineEmits<{
-  (e: "update:modelValue", value: string): void;
+  (e: "update:modelValue", value: string | number): void;
 }>();
 </script>
 <style scoped></style>

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -3,7 +3,7 @@
     <form
       v-if="!assetId && !localAsset"
       class="flex flex-col gap-4 w-full max-w-sm mx-auto mt-12 bg-white rounded-md border border-neutral-900 p-4"
-      @submit.prevent="initAsset">
+      @submit.prevent>
       <SelectGroup
         v-model="selectedTemplateId"
         :options="templateOptions"
@@ -20,12 +20,14 @@
         variant="primary"
         class="block my-4 w-full"
         :disabled="!selectedTemplateId || !selectedCollectionId || !template"
-        @click="initAsset">
+        @click="initNewAsset">
         Continue
         <SpinnerIcon v-if="isTemplateLoading" />
       </Button>
     </form>
-    <div v-else-if="isLoading" class="flex justify-center items-center py-12">
+    <div
+      v-else-if="assetId && (isTemplateLoading || !hasInitialized)"
+      class="flex justify-center items-center py-12">
       <SpinnerIcon class="w-8 h-8 animate-spin" />
       <span class="ml-2">Loading...</span>
     </div>
@@ -97,7 +99,7 @@ const props = withDefaults(
 const assetEditor = useAssetEditor(() => props.assetId);
 
 const {
-  savedAsset,
+  hasInitialized,
   localAsset,
   template,
   selectedTemplateId,
@@ -105,26 +107,29 @@ const {
   isCreateMode,
   hasAssetChanged,
   isFormValid,
-  isLoading,
   isTemplateLoading,
+  isSavedAssetLoading,
   saveAssetStatus,
   templateOptions,
   collectionOptions,
-  defaultTemplateId,
-  defaultCollectionId,
   savedAssetTitle,
   localAssetTitle,
-  initAsset,
+  initNewAsset,
   handleSaveAsset,
   handleConfirmedTemplateIdUpdate,
   handleMigrateCollection,
-  setInitialValues,
   resetEditor,
   updateLocalAsset,
 } = assetEditor;
 
 onMounted(() => {
-  setInitialValues(defaultTemplateId.value, defaultCollectionId.value);
+  // if only 1 template or collection, set it as the default
+  if (templateOptions.value.length === 1) {
+    selectedTemplateId.value = templateOptions.value[0].id;
+  }
+  if (collectionOptions.value.length === 1) {
+    selectedCollectionId.value = collectionOptions.value[0].id;
+  }
 });
 
 const route = useRoute();
@@ -239,7 +244,6 @@ onBeforeRouteUpdate(async (to, _from, next) => {
 
   // reset the asset state
   resetEditor();
-  setInitialValues(defaultTemplateId.value, defaultCollectionId.value);
 
   next();
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -910,8 +910,8 @@ export interface AssetSummary {
   };
 }
 
-export interface SelectOption {
-  id: string;
+export interface SelectOption<idType = string> {
+  id: idType;
   label: string;
 }
 


### PR DESCRIPTION
- Fixes an issue where the collectionId would not be properly initialized when loading the EditAsset page.
- updates `<SelectGroup>` component to permit numeric ids instead of just strings.
- then retypes collectionId and templateId as number | null, and then adds stronger types to the asset editor to help catch mismatches.
- separate asset initialization for new and saved assets. Now the watcher will auto-initialize savedAssets once the data is ready, while the `initNewAsset()` can be invoked on the page when the user clicks continue.
- fixes an issue with the mock server, where collectionId and templateId were added as strings instead of ints to the mockDB, causing tests to fail.

on dev for testing
