### PR TITLE
Debounce asset editor saves

### DIFF
--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -133,8 +133,7 @@ const channelName = computed(() => route.query.channelName as string);
 async function handleSaveAsset() {
   const data = await saveAsset();
   invariant(data, "Expected data to be defined after saveAsset");
-  console.log("Asset saved:", { data });
-  invariant(!!data, "Expected data to be defined after saveAsset");
+
   if (!isCreateMode.value) {
     return;
   }

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -3,7 +3,7 @@
     <form
       v-if="!assetId && !localAsset"
       class="flex flex-col gap-4 w-full max-w-sm mx-auto mt-12 bg-white rounded-md border border-neutral-900 p-4"
-      @submit.prevent>
+      @submit.prevent="initNewAsset">
       <SelectGroup
         v-model="selectedTemplateId"
         :options="templateOptions"
@@ -19,8 +19,7 @@
         type="submit"
         variant="primary"
         class="block my-4 w-full"
-        :disabled="!selectedTemplateId || !selectedCollectionId || !template"
-        @click="initNewAsset">
+        :disabled="!selectedTemplateId || !selectedCollectionId || !template">
         Continue
         <SpinnerIcon v-if="isTemplateLoading" />
       </Button>
@@ -43,7 +42,7 @@
         class="flex-1"
         @update:templateId="updateTemplateId($event)"
         @migrateCollection="handleMigrateCollectionWithNavigation($event)"
-        @save="handleSaveAssetWithNavigation"
+        @save="handleSaveAsset"
         @update:asset="updateLocalAsset($event)" />
     </Transition>
     <ConfirmModal
@@ -78,6 +77,7 @@ import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import { useConfirmation } from "./useConfirmation";
 import SpinnerIcon from "@/icons/SpinnerIcon.vue";
 import { useAssetEditor } from "./useAssetEditor/useAssetEditor";
+import invariant from "tiny-invariant";
 
 const props = withDefaults(
   defineProps<{
@@ -130,8 +130,11 @@ const route = useRoute();
 const router = useRouter();
 const channelName = computed(() => route.query.channelName as string);
 
-async function handleSaveAssetWithNavigation() {
+async function handleSaveAsset() {
   const data = await saveAsset();
+  invariant(data, "Expected data to be defined after saveAsset");
+  console.log("Asset saved:", { data });
+  invariant(!!data, "Expected data to be defined after saveAsset");
   if (!isCreateMode.value) {
     return;
   }

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="edit-upload-widget-item">
     <div class="grid grid-cols-3 gap-4 mb-2">
       <div class="w-full aspect-square rounded-md overflow-hidden relative">
         <img

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -33,8 +33,7 @@
         <textarea
           :id="`${item.id}-description`"
           :value="item.fileDescription"
-          placeholder="Enter a description for this file"
-          class="bg-black/5 border-none rounded-md w-full text-sm font-mono flex-1"
+          class="bg-black/5 border-none rounded-md w-full text-sm font-mono flex-1 placeholder:text-neutral-400"
           @input="handleDescriptionUpdate" />
       </div>
       <EditUploadWidgetItemSidecars

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -30,6 +30,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "start", fileRecord: Type.FileUploadRecord): void;
   (e: "complete", fileRecord: Type.FileUploadRecord): void;
+  (e: "allComplete"): void;
   (e: "error", error: Error): void;
 }>();
 
@@ -192,8 +193,9 @@ const uppy = new Uppy({
 });
 
 // clear upload state on success
-uppy.on("complete", ({ successful, failed }) => {
+uppy.on("complete", ({ successful, _failed }) => {
   successful?.forEach((file) => uppy.removeFile(file.id));
+  emit("allComplete");
 });
 
 uppy.on("error", (error) => {

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditWidgetLayout.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditWidgetLayout.vue
@@ -12,17 +12,22 @@
       :class="{
         'sticky top-[5rem] z-10': isOpen,
       }">
-      <button type="button" class="text-left" @click.stop="toggleExpand">
+      <button
+        type="button"
+        class="text-left"
+        :aria-expanded="isOpen"
+        :aria-controls="`widget-${widgetDef.widgetId}-content`"
+        @click.stop="toggleExpand">
         <div class="flex gap-2">
           <ChevronDownIcon v-if="isOpen" class="!size-4" />
           <ChevronRightIcon v-else class="!size-4" />
-          <span class="sr-only">
-            {{ isOpen ? "Collapse" : "Expand" }}
-          </span>
           <h2 class="text-base font-bold leading-none">
             {{ widgetDef.label }}
             <span v-if="widgetDef.required" class="text-red-500">*</span>
           </h2>
+          <span class="sr-only">
+            {{ isOpen ? "collapse" : "expand" }} section
+          </span>
         </div>
       </button>
       <div>
@@ -38,6 +43,7 @@
     </div>
     <div
       ref="editLayoutContents"
+      :aria-labelledby="`widget-${widgetDef.widgetId}-heading`"
       :class="{
         'opacity-50': !isOpen,
       }">

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -18,6 +18,7 @@ import type {
 } from "@/types";
 import invariant from "tiny-invariant";
 import { MutationStatus } from "@tanstack/vue-query";
+import { useDebounceFn } from "@vueuse/core";
 
 export const useAssetEditor = (assetId: MaybeRefOrGetter<string | null>) => {
   const instanceStore = useInstanceStore();
@@ -198,6 +199,8 @@ export const useAssetEditor = (assetId: MaybeRefOrGetter<string | null>) => {
     });
   }
 
+  const debouncedSaveAsset = useDebounceFn(saveAsset, 500);
+
   function updateTemplateId(newTemplateId: number) {
     invariant(localAsset.value, "Cannot change template: no asset.");
 
@@ -267,7 +270,7 @@ export const useAssetEditor = (assetId: MaybeRefOrGetter<string | null>) => {
 
     // Actions
     initNewAsset,
-    saveAsset,
+    saveAsset: debouncedSaveAsset,
     updateTemplateId,
     migrateCollection,
     resetEditor,

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -18,7 +18,6 @@ import type {
 } from "@/types";
 import invariant from "tiny-invariant";
 import { MutationStatus } from "@tanstack/vue-query";
-import { useDebounceFn } from "@vueuse/core";
 
 export const useAssetEditor = (assetId: MaybeRefOrGetter<string | null>) => {
   const instanceStore = useInstanceStore();
@@ -197,18 +196,6 @@ export const useAssetEditor = (assetId: MaybeRefOrGetter<string | null>) => {
     }
   }
 
-  const debouncedSaveAsset = useDebounceFn(
-    (): Promise<ApiAssetSubmissionResponse> => {
-      return saveAsset();
-    },
-    1000,
-    {
-      maxWait: 5000,
-      // don't reject the promise if a call is cancelled due to debounce
-      rejectOnCancel: true,
-    }
-  );
-
   function updateTemplateId(newTemplateId: number) {
     invariant(localAsset.value, "Cannot change template: no asset.");
 
@@ -279,7 +266,6 @@ export const useAssetEditor = (assetId: MaybeRefOrGetter<string | null>) => {
     // Actions
     initNewAsset,
     saveAsset,
-    debouncedSaveAsset,
     updateTemplateId,
     migrateCollection,
     resetEditor,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -291,7 +291,7 @@ export interface UploadWidgetContent extends WidgetContent {
   fileDescription: string;
   fileType: string;
   searchData: string | null;
-  loc: unknown | null;
+  loc: string | null;
   sidecars: {
     ppm?: number | null; // pixels per millimeter
     iframe?: string | null; // iframe url

--- a/tests/e2e/multiple-file-upload.spec.ts
+++ b/tests/e2e/multiple-file-upload.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+
+test.describe("Multiple File Upload", () => {
+  test.beforeEach(async ({ page, request }) => {
+    // Block ArcGIS requests
+    await page.route("**/arcgis.com/**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.route("**/basemaps-api.arcgis.com/**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    });
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+    await page.goto("/assetManager/addAsset");
+  });
+
+  test("should upload multiple files simultaneously and verify persistence", async ({
+    page,
+  }) => {
+    await expect(page).toHaveURL(/\/assetManager\/addAsset/);
+
+    // Select template and collection
+    const templateSelect = page.getByLabel("Template");
+    await templateSelect.selectOption({ index: 1 });
+
+    const collectionSelect = page.getByLabel("Collection");
+    await collectionSelect.selectOption({ index: 1 });
+
+    const continueButton = page.getByRole("button", { name: "Continue" });
+    await expect(continueButton).toBeEnabled({ timeout: 5000 });
+    await continueButton.click();
+
+    // Wait for form to load
+    await expect(
+      page.getByRole("heading", { name: "Create Asset" })
+    ).toBeVisible();
+
+    // Fill required title field
+    await page
+      .getByLabel("Title")
+      .fill("Test Asset with Multiple File Uploads");
+
+    // const fileInput = page.locator('input[type="file"]').first();
+    // await fileInput.setInputFiles(testFiles);
+    const imageWidget = page.locator("section.edit-widget-layout").filter({
+      has: page.getByRole("heading", { name: "Image" }),
+    });
+    await imageWidget.scrollIntoViewIfNeeded();
+    await expect(imageWidget).toBeVisible();
+
+    const fileChooserPromise = page.waitForEvent("filechooser");
+
+    await imageWidget.getByRole("button", { name: "browse files" }).click();
+
+    const fileChooser = await fileChooserPromise;
+    // Upload multiple files simultaneously
+    const testFiles = [
+      "test-image.jpg",
+      "goldy-mn.png",
+      "visit-jones-hall.png",
+      "yolo.png",
+    ].map((filename) => path.join(testDir, "..", "fixtures", filename));
+
+    await fileChooser.setFiles(testFiles);
+
+    // verify that the image widget now has 4 entries
+    const imageEntries = imageWidget.locator(".edit-upload-widget-item");
+    await expect(imageEntries).toHaveCount(4);
+
+    // wait for network requests to complete
+    await page.waitForLoadState("networkidle");
+
+    // // Do a full page refresh to verify persistence
+    await page.reload();
+
+    // we sould be on the edit asset page now
+    await expect(page).toHaveURL(/\/assetManager\/editAsset/);
+
+    // Verify the title is still filled
+    await expect(page.getByLabel("Title")).toHaveValue(
+      "Test Asset with Multiple File Uploads"
+    );
+    // and that the image widget has 4 entries
+    await expect(imageWidget.locator(".edit-upload-widget-item")).toHaveCount(
+      4
+    );
+  });
+});

--- a/tests/e2e/upload-widget.spec.ts
+++ b/tests/e2e/upload-widget.spec.ts
@@ -8,6 +8,10 @@ const __dirname = path.dirname(__filename);
 
 test.describe("EditUploadWidget", () => {
   test.beforeEach(async ({ page, request }) => {
+    // Block ArcGIS requests
+    await page.route("**/arcgis.com/**", (route) => route.abort());
+    await page.route("**/basemaps-api.arcgis.com/**", (route) => route.abort());
+
     const workerId = test.info().workerIndex.toString();
     await setupWorkerHTTPHeader({ page, workerId });
     await refreshDatabase({ request, workerId });


### PR DESCRIPTION
This supersedes #321 

- saves uploads when the begin, not just when they complete to avoid orphaned uploads.
- debounce save emits to cut down on requests (~2s, max: 5s)
- adds test for uploading multiple assets
- fixes a warning when submitting form (handler was attached to button, not the form's submit event)
- block arcgis requests when testing
- refactor some useAssetEditor methods to use promises instead of callbacks
- renames some functions so they're more distinct from in-component handler names
