### PR TITLE
fix: update primary file handler id after save

### DIFF
--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -264,11 +264,12 @@ async function handleSaveAsset() {
       },
     });
   } catch (error) {
+    invariant(error instanceof Error);
     // handle error, e.g. show a toast
     console.error("Error saving asset:", error);
     toastStore.addToast({
       title: "Error",
-      message: "Failed to save asset. Please try again.",
+      message: `Failed to save asset: ${error.message}`,
       variant: "error",
     });
   }

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -237,9 +237,7 @@ export const useAssetEditor = () => {
       state.localAsset.modifiedBy = savedAsset.modifiedBy;
       state.localAsset.firstFileHandlerId = savedAsset.firstFileHandlerId;
 
-      // update the local assetId with the returned objectId
       state.saveAssetStatus = "success";
-
       setTimeout(() => {
         state.saveAssetStatus = "idle"; // Reset status after a delay
       }, 3000);

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -199,9 +199,7 @@ export const useAssetEditor = () => {
   /**
    * Save the current local asset to the backend
    */
-  async function saveAsset({
-    refresh,
-  }: { refresh?: boolean } = {}): Promise<void> {
+  async function saveAsset(): Promise<void> {
     invariant(state.localAsset, "Cannot save: no local asset");
     invariant(state.template, "Cannot save: no template");
     invariant(
@@ -224,17 +222,27 @@ export const useAssetEditor = () => {
       const { objectId } = await fetchers.updateAsset(formData);
       invariant(objectId, "Expected objectId to be defined after saveAsset");
 
+      const savedAsset = await fetchers.fetchAsset(objectId);
+      invariant(
+        savedAsset,
+        "Expected saved asset to be defined after saveAsset"
+      );
+
+      state.savedAsset = savedAsset;
+
+      // make some targeted updates to the local asset to avoid unnecessary reactivity
+      state.localAsset.assetId = savedAsset.assetId;
+      state.localAsset.title = savedAsset.title;
+      state.localAsset.modified = savedAsset.modified;
+      state.localAsset.modifiedBy = savedAsset.modifiedBy;
+      state.localAsset.firstFileHandlerId = savedAsset.firstFileHandlerId;
+
       // update the local assetId with the returned objectId
-      state.localAsset.assetId = objectId;
       state.saveAssetStatus = "success";
 
       setTimeout(() => {
         state.saveAssetStatus = "idle"; // Reset status after a delay
       }, 3000);
-
-      if (refresh) {
-        return refreshAsset();
-      }
     } catch (err) {
       console.error(`Cannot save asset: ${err}`);
 


### PR DESCRIPTION
After saving, the primary file handler id may need to be updated. This fetches the asset after saving, and then updates primary file hander id (and a few other fields).
