### PR TITLE
fix: don't create inline related asset if no content

### DIFF
--- a/src/pages/CreateOrEditAssetPage/InlineCreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/InlineCreateOrEditAssetPage.vue
@@ -107,14 +107,6 @@ const assetEditor = useAssetEditor();
 // Provide this inline editor to child components
 provide(ASSET_EDITOR_PROVIDE_KEY, assetEditor);
 
-function hasAssetContent(asset: T.UnsavedAsset, template: T.Template): boolean {
-  // check widget for any content
-  return template.widgetArray.every((widgetDef) => {
-    const contents = asset[widgetDef.fieldTitle] as T.WidgetContent[];
-    return hasWidgetContent(contents, widgetDef.type);
-  });
-}
-
 onMounted(async () => {
   invariant(parentAssetEditor);
 
@@ -123,7 +115,11 @@ onMounted(async () => {
     // TODO: There's a bug where `assetEditor.hasAssetChanged`
     // can sometimes be incorrect. Provided the asset isn't
     // blank, we'll always save when the parent is saved to avoid
-    // losing changes.
+    // losing changes. Once this is fixed, we can update this to
+    // only save if the asset is Not blank and has changed.
+
+    // NOTE: unchecked checkbox widget are considered
+    // content, so the form will save if there are any
     if (assetEditor.isBlank) {
       return;
     }

--- a/src/pages/CreateOrEditAssetPage/InlineCreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/InlineCreateOrEditAssetPage.vue
@@ -107,12 +107,26 @@ const assetEditor = useAssetEditor();
 // Provide this inline editor to child components
 provide(ASSET_EDITOR_PROVIDE_KEY, assetEditor);
 
+function hasAssetContent(asset: T.UnsavedAsset, template: T.Template): boolean {
+  // check widget for any content
+  return template.widgetArray.every((widgetDef) => {
+    const contents = asset[widgetDef.fieldTitle] as T.WidgetContent[];
+    return hasWidgetContent(contents, widgetDef.type);
+  });
+}
+
 onMounted(async () => {
   invariant(parentAssetEditor);
 
   // register a hook to save the current asset whenever the parent asset is saved
   parentAssetEditor.onBeforeSave(async (): Promise<void> => {
-    if (!assetEditor.hasAssetChanged) return;
+    // TODO: There's a bug where `assetEditor.hasAssetChanged`
+    // can sometimes be incorrect. Provided the asset isn't
+    // blank, we'll always save when the parent is saved to avoid
+    // losing changes.
+    if (assetEditor.isBlank) {
+      return;
+    }
     return handleSaveAsset();
   });
 

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -112,6 +112,8 @@ export const useAssetEditor = () => {
     );
   });
 
+  // NOTE: unchecked checkbox widgets are considered content,
+  // So, if the asset contains any, the widget will not be considered blank.
   const isBlank = computed((): boolean => {
     if (!state.localAsset || !state.template) return true;
 

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -112,6 +112,21 @@ export const useAssetEditor = () => {
     );
   });
 
+  const isBlank = computed((): boolean => {
+    if (!state.localAsset || !state.template) return true;
+
+    const someWidgetHasContent = state.template.widgetArray.some(
+      (widgetDef) => {
+        invariant(state.localAsset);
+        const contents = (state.localAsset[widgetDef.fieldTitle] ??
+          []) as T.WidgetContent[];
+        return hasWidgetContent(contents, widgetDef.type);
+      }
+    );
+
+    return !someWidgetHasContent;
+  });
+
   // ACTIONS
   /**
    * Reset the state to initial values
@@ -367,6 +382,7 @@ export const useAssetEditor = () => {
     hasAssetChanged,
     isFormValid,
     widgetIdsWithContent,
+    isBlank,
 
     // actions
     reset,


### PR DESCRIPTION
Checks if the inline related asset form is blank, and if so – we'll skip saving to avoid creating a blank asset.

One note: we're considering unchecked checkbox widgets as content, so if an inline asset form contains them, the asset will appear non-blank and save.

This also removes a check for `assetEditor.hasAssetChanged` since the value is sometimes off. So, we save the inline asset regardless of whether a change is detected or not (provided it has _some_ content).
