### PR TITLE
(DRAFT) edit multiselect widget tests and fixes

### DIFF
--- a/mock-server/db/assets.ts
+++ b/mock-server/db/assets.ts
@@ -112,7 +112,7 @@ const assetSeeds: Asset[] = [
     title_1: [
       {
         isPrimary: false,
-        fieldContents: "Asset 2",
+        fieldContents: "All Fields Asset",
       },
     ],
     upload_1: [
@@ -172,7 +172,7 @@ const assetSeeds: Asset[] = [
     assetId: "687969fd9c90c709c1021d01",
     firstFileHandlerId: "687969f8f53caa21660c9eea",
     firstObjectId: null,
-    title: ["Asset 3"],
+    title: ["All Fields Asset"],
     titleObject: "title_1",
   },
 ];

--- a/mock-server/db/assets.ts
+++ b/mock-server/db/assets.ts
@@ -108,6 +108,73 @@ const assetSeeds: Asset[] = [
     title: ["Asset 2"],
     titleObject: "title_1",
   },
+  {
+    title_1: [
+      {
+        isPrimary: false,
+        fieldContents: "Asset 2",
+      },
+    ],
+    upload_1: [
+      {
+        loc: null,
+        fileId: "687969f8f53caa21660c9ee0",
+        fileType: "png",
+        sidecars: [],
+        isPrimary: false,
+        searchData: null,
+        fileDescription: "test_image.png",
+      },
+      {
+        loc: null,
+        fileId: "68796a06f53caa21660c9ee1",
+        fileType: "png",
+        sidecars: [],
+        isPrimary: false,
+        searchData: null,
+        fileDescription: "test_image_2.png",
+      },
+    ],
+    checkbox_1: [
+      {
+        isPrimary: false,
+        fieldContents: false,
+      },
+    ],
+    cascadeselect_1: [
+      {
+        isPrimary: false,
+        fieldContents: {
+          country: "usa",
+          stateorprovince: "minnesota",
+          city: "St. Paul",
+          neighborhood: "Summit Hill",
+        },
+      },
+    ],
+    relatedAssetCache: [],
+    templateId: 68,
+    readyForDisplay: true,
+    collectionId: 1,
+    availableAfter: null,
+    modified: {
+      date: "2025-07-17 21:25:26.000000",
+      timezone_type: 3,
+      timezone: "UTC",
+    },
+    modifiedBy: 1,
+    createdBy: "",
+    collectionMigration: null,
+    deleted: false,
+    deletedBy: null,
+    deletedAt: null,
+    csvBatch: null,
+    assetId: "687969fd9c90c709c1021d01",
+    firstFileHandlerId: "687969f8f53caa21660c9eea",
+    firstObjectId: null,
+    title: ["Asset 3"],
+    titleObject: "title_1",
+  },
 ];
 
 export function createAssetsTable({

--- a/mock-server/db/templates.ts
+++ b/mock-server/db/templates.ts
@@ -218,7 +218,7 @@ const templateSeeds: Template[] = [
         fieldData: {
           country: {
             usa: {
-              state: {
+              "State or Province": {
                 minnesota: {
                   city: {
                     mankato: {
@@ -227,6 +227,7 @@ const templateSeeds: Template[] = [
                     minneapolis: {
                       neighborhood: ["uptown", "downtown"],
                     },
+                    "St. Paul": [],
                   },
                 },
                 wisconsin: {
@@ -235,7 +236,7 @@ const templateSeeds: Template[] = [
               },
             },
             canada: {
-              state: {
+              "State or Province": {
                 quebec: {
                   city: ["montreal"],
                 },

--- a/mock-server/db/templates.ts
+++ b/mock-server/db/templates.ts
@@ -227,7 +227,9 @@ const templateSeeds: Template[] = [
                     minneapolis: {
                       neighborhood: ["uptown", "downtown"],
                     },
-                    "St. Paul": [],
+                    "St. Paul": {
+                      neighborhood: ["Summit Hill", "frogtown"],
+                    },
                   },
                 },
                 wisconsin: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,14 +54,14 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
   ],
 });

--- a/src/components/CascadeSelect/SimpleCascadeSelect.vue
+++ b/src/components/CascadeSelect/SimpleCascadeSelect.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class=""></div>
+</template>
+<script setup lang="ts">
+import {
+  type NestedOptionsObj,
+  useCascadeSelect,
+} from "@/composables/useCascadeSelect";
+import { MultiSelectWidgetContent } from "@/types";
+
+const props = defineProps<{
+  options: NestedOptionsObj;
+  modelValue: MultiSelectWidgetContent["fieldContents"];
+  selectClass?: Record<string, boolean> | string[] | string;
+  labelClass?: Record<string, boolean> | string[] | string;
+  initialSelectedValues?: string[];
+}>();
+
+defineEmits<{
+  (e: "update:modelValue", updated: MultiSelectWidgetContent["fieldContents"]);
+}>();
+</script>
+<style scoped></style>

--- a/src/components/CascadeSelect/SimpleCascadeSelect.vue
+++ b/src/components/CascadeSelect/SimpleCascadeSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="cascade-select flex flex-col gap-4">
-    <!-- show any curretly selected segments -->
+    <!-- show any currently selected segments -->
     <div class="flex flex-col gap-1">
       <template
         v-for="selectedSegment in cascadeSelect.selectedPath"

--- a/src/components/CascadeSelect/SimpleCascadeSelect.vue
+++ b/src/components/CascadeSelect/SimpleCascadeSelect.vue
@@ -1,23 +1,75 @@
 <template>
-  <div class=""></div>
+  <div class="cascade-select flex flex-col gap-4">
+    <!-- show any curretly selected segments -->
+    <div class="flex flex-col gap-1">
+      <template
+        v-for="selectedSegment in cascadeSelect.selectedPath"
+        :key="selectedSegment.id">
+        <SelectGroup
+          :label="
+            cascadeSelect.getLevelByDepth(selectedSegment.depth)?.label ??
+            `Category ${selectedSegment.depth + 1}`
+          "
+          :options="
+            cascadeSelect
+              .getOptionsByParentId(selectedSegment.parentId)
+              .map((opt) => ({
+                id: opt.id,
+                label: String(opt.value),
+              }))
+          "
+          :modelValue="selectedSegment.id"
+          placeholder="Select..."
+          @update:modelValue="handleSelectOption" />
+      </template>
+
+      <!-- show selector for next options if they exist -->
+      <SelectGroup
+        v-if="cascadeSelect.nextSelectOptions.length"
+        :label="
+          cascadeSelect.getLevelByDepth(cascadeSelect.selectedPath.length)
+            ?.label ?? `Category ${cascadeSelect.selectedPath.length + 1}`
+        "
+        :options="cascadeSelect.nextSelectOptions"
+        :modelValue="cascadeSelect.selectedOption?.id ?? null"
+        placeholder="Select..."
+        @update:modelValue="handleSelectOption" />
+    </div>
+  </div>
 </template>
 <script setup lang="ts">
 import {
+  FlatOption,
   type NestedOptionsObj,
   useCascadeSelect,
 } from "@/composables/useCascadeSelect";
 import { MultiSelectWidgetContent } from "@/types";
+import SelectGroup from "../SelectGroup/SelectGroup.vue";
+import { nextTick, toValue, onMounted } from "vue";
 
 const props = defineProps<{
   options: NestedOptionsObj;
   modelValue: MultiSelectWidgetContent["fieldContents"];
   selectClass?: Record<string, boolean> | string[] | string;
   labelClass?: Record<string, boolean> | string[] | string;
-  initialSelectedValues?: string[];
 }>();
 
-defineEmits<{
+const emit = defineEmits<{
   (e: "update:modelValue", updated: MultiSelectWidgetContent["fieldContents"]);
 }>();
+
+const cascadeSelect = useCascadeSelect(() => props.options);
+
+onMounted(() => {
+  // initialize cascadeSelect
+  cascadeSelect.selectOptionByWidgetFieldContents(props.modelValue);
+});
+
+function handleSelectOption(optionId: FlatOption["id"] | null) {
+  cascadeSelect.selectOption(optionId);
+  nextTick(() => {
+    emit("update:modelValue", toValue(cascadeSelect.widgetFieldContents ?? {}));
+  });
+}
 </script>
 <style scoped></style>

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -18,7 +18,7 @@
 
           <div class="mt-1">
             <!-- using href for force app reload -->
-            <Button :href="BASE_URL" variant="tertiary">Go Home</Button>
+            <Button :to="{ name: 'home' }" variant="tertiary">Go Home</Button>
           </div>
         </Notification>
       </div>

--- a/src/components/Widget/MultiSelectWidget/MultiSelectItem.vue
+++ b/src/components/Widget/MultiSelectWidget/MultiSelectItem.vue
@@ -47,13 +47,15 @@ const normalizedFieldContents = computed(() => {
 const getCategoryContent = (str: string | number) =>
   normalizedFieldContents.value[toNormedCategory(str)];
 
-const contentsUpToCategory = (targetCategory) => {
+const contentsUpToCategory = (targetCategory: string) => {
   const returnValue: string[] = [];
   const normedTargetCategory = toNormedCategory(targetCategory);
   for (const category of organizedSelectCategories.value) {
     const normedCategory = toNormedCategory(category);
-    returnValue.push(normedCategory);
-    if (category === normedTargetCategory) {
+    // Use the actual field content value instead of the category name
+    const categoryValue = getCategoryContent(category);
+    returnValue.push(String(categoryValue));
+    if (normedCategory === normedTargetCategory) {
       return returnValue.join(" : ");
     }
   }

--- a/src/components/Widget/MultiSelectWidget/MultiSelectWidget.ts
+++ b/src/components/Widget/MultiSelectWidget/MultiSelectWidget.ts
@@ -1,3 +1,11 @@
+/**
+ * Recursively traverses a nested object and collects keys from alternating levels.
+ * Note: Despite the name, this function does not sort - it extracts keys in traversal order.
+ * 
+ * @param inputObject - The object to traverse recursively
+ * @param skip - When true, skips current level keys; toggles for each recursive call
+ * @returns Flattened array of keys from alternating levels of the object hierarchy
+ */
 export const recursiveSort = (inputObject: object, skip: boolean): string[] => {
   let outputArray: string[] = [];
   for (const key in inputObject) {
@@ -11,6 +19,12 @@ export const recursiveSort = (inputObject: object, skip: boolean): string[] => {
   return outputArray.flat();
 };
 
+/**
+ * Removes duplicate values from an array of strings, preserving the first occurrence of each value.
+ * 
+ * @param inputArray - Array of strings that may contain duplicates
+ * @returns New array with only unique values, maintaining original order
+ */
 export const uniqueValues = (inputArray: string[]) => {
   return inputArray.filter((value, index, self) => {
     return self.indexOf(value) === index;

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  type FlatOption,
+  type Level,
+  type NestedOptionsObj,
+  useCascadeSelect,
+} from "./useCascadeSelect";
+
+const nestedOptions: NestedOptionsObj = {
+  country: {
+    usa: {
+      "State or Province": {
+        mn: [],
+        wi: [],
+        "South Dakota": [],
+      },
+    },
+    canada: {
+      "State or Province": ["quebec", "alberta"],
+    },
+  },
+};
+
+describe("useCascadeSelect", () => {
+  /**
+   * The CascadeSelect component takes an options object
+   * which alternates category -> value -> category -> value
+   * like { country: usa: { state: { minnesota: ... }}}
+   * so a category object contains value objects, which
+   * contain more category objects, and so on.
+   *
+   * This structure is complex to work with. So, the goal of
+   * this component is to act as an intercessor by turning
+   * the complext nested object into a flatter structure
+   * which we can filter.
+   */
+
+  it("converts a nested options object to a flat list of options sorted by level and value", () => {
+    const { flatOptions } = useCascadeSelect(() => nestedOptions);
+
+    expect(flatOptions.value).toEqual([
+      // countries
+      {
+        id: "country-canada",
+        level: 0,
+        value: "canada",
+        parentId: null,
+      },
+      {
+        id: "country-usa",
+        level: 0,
+        value: "usa",
+        parentId: null,
+      },
+
+      // states and provinces
+      {
+        id: "stateorprovince-alberta",
+        level: 1,
+        value: "alberta",
+        parentId: "country-canada",
+      },
+      {
+        id: "stateorprovince-mn",
+        level: 1,
+        value: "mn",
+        parentId: "country-usa",
+      },
+      {
+        id: "stateorprovince-quebec",
+        level: 1,
+        value: "quebec",
+        parentId: "country-canada",
+      },
+      {
+        id: "stateorprovince-southdakota",
+        level: 1,
+        value: "South Dakota",
+        parentId: "country-usa",
+      },
+      {
+        id: "stateorprovince-wi",
+        level: 1,
+        value: "wi",
+        parentId: "country-usa",
+      },
+    ]);
+  });
+
+  it("returns the levels of the nested options", () => {
+    const { levels } = useCascadeSelect(nestedOptions);
+
+    expect(levels.value).toEqual([
+      {
+        id: "country",
+        label: "country",
+        depth: 0,
+      },
+      {
+        id: "stateorprovince",
+        label: "State or Province",
+        depth: 1,
+      },
+    ]);
+  });
+
+  it("gets all options by a given level", () => {
+    const { getOptionsByDepth } = useCascadeSelect(nestedOptions);
+
+    const optionsAtLevel0 = getOptionsByDepth(0);
+    expect(optionsAtLevel0).toEqual([
+      {
+        id: "country-canada",
+        level: 0,
+        value: "canada",
+        parentId: null,
+      },
+      {
+        id: "country-usa",
+        level: 0,
+        value: "usa",
+        parentId: null,
+      },
+    ]);
+
+    const optionsAtLevel1 = getOptionsByDepth(1);
+    expect(optionsAtLevel1).toEqual([
+      {
+        id: "stateorprovince-alberta",
+        level: 1,
+        value: "alberta",
+        parentId: "country-canada",
+      },
+      {
+        id: "stateorprovince-mn",
+        level: 1,
+        value: "mn",
+        parentId: "country-usa",
+      },
+      {
+        id: "stateorprovince-quebec",
+        level: 1,
+        value: "quebec",
+        parentId: "country-canada",
+      },
+      {
+        id: "stateorprovince-southdakota",
+        level: 1,
+        value: "South Dakota",
+        parentId: "country-usa",
+      },
+      {
+        id: "stateorprovince-wi",
+        level: 1,
+        value: "wi",
+        parentId: "country-usa",
+      },
+    ]);
+  });
+});

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -215,4 +215,38 @@ describe("useCascadeSelect", () => {
       },
     ]);
   });
+
+  it("handles duplicate option names at the same level with different parents", () => {
+    // This test case reproduces the bug where options with the same name
+    // at the same level might not all show up because they have the same id
+    const duplicateNamesOptions: NestedOptionsObj = {
+      City: {
+        minneapolis: {
+          Neighborhood: ["downtown", "uptown", "northeast"],
+        },
+        mankato: {
+          Neighborhood: ["downtown", "eastside", "westside"],
+        },
+      },
+    };
+
+    const { getOptionsByDepth } = useCascadeSelect(duplicateNamesOptions);
+
+    // Should have 6 neighborhood options total (3 from each city)
+    const neighborhoodOptions = getOptionsByDepth(1);
+    expect(neighborhoodOptions).toHaveLength(6);
+
+    // Should include both "downtown" options with different parent IDs
+    const downtownOptions = neighborhoodOptions.filter(
+      (opt) => opt.value === "downtown"
+    );
+    expect(downtownOptions).toHaveLength(2);
+
+    // They should have different parent IDs
+    const parentIds = downtownOptions.map((opt) => opt.parentId);
+    expect(parentIds).toEqual(
+      expect.arrayContaining(["city-minneapolis", "city-mankato"])
+    );
+    expect(parentIds[0]).not.toBe(parentIds[1]);
+  });
 });

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -152,4 +152,67 @@ describe("useCascadeSelect", () => {
       },
     ]);
   });
+
+  it("captures deeper levels that only exist under later siblings", () => {
+    const tricky: NestedOptionsObj = {
+      category: {
+        // first sibling is a leaf (array) so depth ends here on this path
+        alpha: [],
+        // second sibling introduces a new deeper level
+        beta: {
+          Subcategory: {
+            one: [],
+            two: [],
+          },
+        },
+      },
+    };
+
+    const { levels, flatOptions, getOptionsByDepth } = useCascadeSelect(tricky);
+
+    expect(levels).toEqual([
+      { id: "category", label: "category", depth: 0 },
+      { id: "subcategory", label: "Subcategory", depth: 1 },
+    ]);
+
+    // level 0 options
+    expect(getOptionsByDepth(0)).toEqual([
+      { id: "category-alpha", depth: 0, value: "alpha", parentId: null },
+      { id: "category-beta", depth: 0, value: "beta", parentId: null },
+    ]);
+
+    // level 1 options (children of beta only)
+    expect(getOptionsByDepth(1)).toEqual([
+      {
+        id: "subcategory-one",
+        depth: 1,
+        value: "one",
+        parentId: "category-beta",
+      },
+      {
+        id: "subcategory-two",
+        depth: 1,
+        value: "two",
+        parentId: "category-beta",
+      },
+    ]);
+
+    // flat options should include all 4
+    expect(flatOptions).toEqual([
+      { id: "category-alpha", depth: 0, value: "alpha", parentId: null },
+      { id: "category-beta", depth: 0, value: "beta", parentId: null },
+      {
+        id: "subcategory-one",
+        depth: 1,
+        value: "one",
+        parentId: "category-beta",
+      },
+      {
+        id: "subcategory-two",
+        depth: 1,
+        value: "two",
+        parentId: "category-beta",
+      },
+    ]);
+  });
 });

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -36,13 +36,13 @@ describe("useCascadeSelect", () => {
     expect(flatOptions).toEqual([
       // countries
       {
-        id: "country-canada",
+        id: "canada",
         depth: 0,
         value: "canada",
         parentId: null,
       },
       {
-        id: "country-usa",
+        id: "usa",
         depth: 0,
         value: "usa",
         parentId: null,
@@ -50,34 +50,34 @@ describe("useCascadeSelect", () => {
 
       // states and provinces
       {
-        id: "stateorprovince-alberta",
+        id: "canada-alberta",
         depth: 1,
         value: "alberta",
-        parentId: "country-canada",
+        parentId: "canada",
       },
       {
-        id: "stateorprovince-mn",
+        id: "usa-mn",
         depth: 1,
         value: "mn",
-        parentId: "country-usa",
+        parentId: "usa",
       },
       {
-        id: "stateorprovince-quebec",
+        id: "canada-quebec",
         depth: 1,
         value: "quebec",
-        parentId: "country-canada",
+        parentId: "canada",
       },
       {
-        id: "stateorprovince-southdakota",
+        id: "usa-southdakota",
         depth: 1,
         value: "South Dakota",
-        parentId: "country-usa",
+        parentId: "usa",
       },
       {
-        id: "stateorprovince-wi",
+        id: "usa-wi",
         depth: 1,
         value: "wi",
-        parentId: "country-usa",
+        parentId: "usa",
       },
     ]);
   });
@@ -105,13 +105,13 @@ describe("useCascadeSelect", () => {
     const optionsAtLevel0 = getOptionsByDepth(0);
     expect(optionsAtLevel0).toEqual([
       {
-        id: "country-canada",
+        id: "canada",
         depth: 0,
         value: "canada",
         parentId: null,
       },
       {
-        id: "country-usa",
+        id: "usa",
         depth: 0,
         value: "usa",
         parentId: null,
@@ -121,34 +121,34 @@ describe("useCascadeSelect", () => {
     const optionsAtLevel1 = getOptionsByDepth(1);
     expect(optionsAtLevel1).toEqual([
       {
-        id: "stateorprovince-alberta",
+        id: "canada-alberta",
         depth: 1,
         value: "alberta",
-        parentId: "country-canada",
+        parentId: "canada",
       },
       {
-        id: "stateorprovince-mn",
+        id: "usa-mn",
         depth: 1,
         value: "mn",
-        parentId: "country-usa",
+        parentId: "usa",
       },
       {
-        id: "stateorprovince-quebec",
+        id: "canada-quebec",
         depth: 1,
         value: "quebec",
-        parentId: "country-canada",
+        parentId: "canada",
       },
       {
-        id: "stateorprovince-southdakota",
+        id: "usa-southdakota",
         depth: 1,
         value: "South Dakota",
-        parentId: "country-usa",
+        parentId: "usa",
       },
       {
-        id: "stateorprovince-wi",
+        id: "usa-wi",
         depth: 1,
         value: "wi",
-        parentId: "country-usa",
+        parentId: "usa",
       },
     ]);
   });
@@ -177,41 +177,41 @@ describe("useCascadeSelect", () => {
 
     // level 0 options
     expect(getOptionsByDepth(0)).toEqual([
-      { id: "category-alpha", depth: 0, value: "alpha", parentId: null },
-      { id: "category-beta", depth: 0, value: "beta", parentId: null },
+      { id: "alpha", depth: 0, value: "alpha", parentId: null },
+      { id: "beta", depth: 0, value: "beta", parentId: null },
     ]);
 
     // level 1 options (children of beta only)
     expect(getOptionsByDepth(1)).toEqual([
       {
-        id: "subcategory-one",
+        id: "beta-one",
         depth: 1,
         value: "one",
-        parentId: "category-beta",
+        parentId: "beta",
       },
       {
-        id: "subcategory-two",
+        id: "beta-two",
         depth: 1,
         value: "two",
-        parentId: "category-beta",
+        parentId: "beta",
       },
     ]);
 
     // flat options should include all 4
     expect(flatOptions).toEqual([
-      { id: "category-alpha", depth: 0, value: "alpha", parentId: null },
-      { id: "category-beta", depth: 0, value: "beta", parentId: null },
+      { id: "alpha", depth: 0, value: "alpha", parentId: null },
+      { id: "beta", depth: 0, value: "beta", parentId: null },
       {
-        id: "subcategory-one",
+        id: "beta-one",
         depth: 1,
         value: "one",
-        parentId: "category-beta",
+        parentId: "beta",
       },
       {
-        id: "subcategory-two",
+        id: "beta-two",
         depth: 1,
         value: "two",
-        parentId: "category-beta",
+        parentId: "beta",
       },
     ]);
   });
@@ -245,7 +245,7 @@ describe("useCascadeSelect", () => {
     // They should have different parent IDs
     const parentIds = downtownOptions.map((opt) => opt.parentId);
     expect(parentIds).toEqual(
-      expect.arrayContaining(["city-minneapolis", "city-mankato"])
+      expect.arrayContaining(["minneapolis", "mankato"])
     );
     expect(parentIds[0]).not.toBe(parentIds[1]);
   });

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  type FlatOption,
-  type Level,
-  type NestedOptionsObj,
-  useCascadeSelect,
-} from "./useCascadeSelect";
+import { type NestedOptionsObj, useCascadeSelect } from "./useCascadeSelect";
 
 const nestedOptions: NestedOptionsObj = {
   country: {

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -33,17 +33,17 @@ describe("useCascadeSelect", () => {
   it("converts a nested options object to a flat list of options sorted by level and value", () => {
     const { flatOptions } = useCascadeSelect(() => nestedOptions);
 
-    expect(flatOptions.value).toEqual([
+    expect(flatOptions).toEqual([
       // countries
       {
         id: "country-canada",
-        level: 0,
+        depth: 0,
         value: "canada",
         parentId: null,
       },
       {
         id: "country-usa",
-        level: 0,
+        depth: 0,
         value: "usa",
         parentId: null,
       },
@@ -51,31 +51,31 @@ describe("useCascadeSelect", () => {
       // states and provinces
       {
         id: "stateorprovince-alberta",
-        level: 1,
+        depth: 1,
         value: "alberta",
         parentId: "country-canada",
       },
       {
         id: "stateorprovince-mn",
-        level: 1,
+        depth: 1,
         value: "mn",
         parentId: "country-usa",
       },
       {
         id: "stateorprovince-quebec",
-        level: 1,
+        depth: 1,
         value: "quebec",
         parentId: "country-canada",
       },
       {
         id: "stateorprovince-southdakota",
-        level: 1,
+        depth: 1,
         value: "South Dakota",
         parentId: "country-usa",
       },
       {
         id: "stateorprovince-wi",
-        level: 1,
+        depth: 1,
         value: "wi",
         parentId: "country-usa",
       },
@@ -85,7 +85,7 @@ describe("useCascadeSelect", () => {
   it("returns the levels of the nested options", () => {
     const { levels } = useCascadeSelect(nestedOptions);
 
-    expect(levels.value).toEqual([
+    expect(levels).toEqual([
       {
         id: "country",
         label: "country",
@@ -106,13 +106,13 @@ describe("useCascadeSelect", () => {
     expect(optionsAtLevel0).toEqual([
       {
         id: "country-canada",
-        level: 0,
+        depth: 0,
         value: "canada",
         parentId: null,
       },
       {
         id: "country-usa",
-        level: 0,
+        depth: 0,
         value: "usa",
         parentId: null,
       },
@@ -122,31 +122,31 @@ describe("useCascadeSelect", () => {
     expect(optionsAtLevel1).toEqual([
       {
         id: "stateorprovince-alberta",
-        level: 1,
+        depth: 1,
         value: "alberta",
         parentId: "country-canada",
       },
       {
         id: "stateorprovince-mn",
-        level: 1,
+        depth: 1,
         value: "mn",
         parentId: "country-usa",
       },
       {
         id: "stateorprovince-quebec",
-        level: 1,
+        depth: 1,
         value: "quebec",
         parentId: "country-canada",
       },
       {
         id: "stateorprovince-southdakota",
-        level: 1,
+        depth: 1,
         value: "South Dakota",
         parentId: "country-usa",
       },
       {
         id: "stateorprovince-wi",
-        level: 1,
+        depth: 1,
         value: "wi",
         parentId: "country-usa",
       },

--- a/src/composables/useCascadeSelect.ts
+++ b/src/composables/useCascadeSelect.ts
@@ -1,0 +1,260 @@
+import { MultiSelectWidgetContent } from "@/types";
+import { isObject } from "@vueuse/core";
+import {
+  computed,
+  MaybeRefOrGetter,
+  ref,
+  toValue,
+  reactive,
+  toRefs,
+} from "vue";
+
+export interface NestedOptionsObj {
+  [category: string]: string[] | Record<string, NestedOptionsObj | []>;
+}
+
+export interface Level {
+  id: string;
+  label: string;
+  depth: number;
+}
+
+// tree node
+export interface FlatOption {
+  id: string;
+  level: number;
+  value: string | number;
+  parentId: FlatOption["id"] | null;
+}
+
+export type OptionsLookup = Map<FlatOption["id"], FlatOption>;
+export type LevelLookup = Map<Level["id"], Level>;
+
+const toAlphaNum = (str: string) => str.replace(/[^a-zA-Z0-9]/g, "");
+
+// recursively converts nested options to a flat list of options
+// returns a lookup of levels an a lookup of options
+function toFlatOptionsAndLevels(
+  nestedOptions: NestedOptionsObj,
+  levelDepth = 0,
+  parentId: FlatOption["id"] | null = null
+) {
+  const levelLookup: Map<Level["id"], Level> = new Map();
+  const optionsLookup: Map<FlatOption["id"], FlatOption> = new Map();
+
+  // get the levels from the nested options
+  const levelLabel = Object.keys(nestedOptions)[0];
+
+  // if no level label, we're done
+  if (!levelLabel) {
+    return { levelLookup, optionsLookup };
+  }
+
+  // otherwise, add the current level to the lookup
+  const levelId = toAlphaNum(levelLabel).toLowerCase();
+  const level: Level = {
+    id: levelId,
+    label: levelLabel,
+    depth: levelDepth,
+  };
+  levelLookup.set(levelId, level);
+
+  // then proces each option at this level
+  const options = nestedOptions[levelLabel];
+
+  // CASE 1: options is an array of strings
+  if (Array.isArray(options)) {
+    options.forEach((option) => {
+      const optionId = `${levelId}-${toAlphaNum(option).toLowerCase()}`;
+      const flatOption: FlatOption = {
+        id: optionId,
+        level: levelDepth,
+        value: option,
+        parentId,
+      };
+      optionsLookup.set(optionId, flatOption);
+    });
+
+    // an array means we're done with this level
+    return { levelLookup, optionsLookup };
+  }
+
+  // CASE 2: options is an object with nested options
+  if (isObject(options)) {
+    Object.entries(options).forEach(([value, moreNestedOptions]) => {
+      // add this option to the lookup
+      const optionId = `${levelId}-${toAlphaNum(value).toLowerCase()}`;
+      const flatOption: FlatOption = {
+        id: optionId,
+        level: levelDepth,
+        value,
+        parentId,
+      };
+      optionsLookup.set(optionId, flatOption);
+
+      // then recursively process the nested options
+      // if the nested options is an array, it means we're done with this level
+      if (Array.isArray(moreNestedOptions)) {
+        return;
+      }
+
+      // otherwise, recurse into the nested options
+      const {
+        levelLookup: nestedLevelLookup,
+        optionsLookup: nestedOptionsLookup,
+      } = toFlatOptionsAndLevels(moreNestedOptions, levelDepth + 1, optionId);
+
+      // merge the nested lookups into the main lookups
+      nestedLevelLookup.forEach((lvl) => levelLookup.set(lvl.id, lvl));
+      nestedOptionsLookup.forEach((opt) => optionsLookup.set(opt.id, opt));
+
+      return {
+        levelLookup,
+        optionsLookup,
+      };
+    });
+  }
+
+  // if we reach here, it means we have processed all options at this level
+  return { levelLookup, optionsLookup };
+}
+
+export const useCascadeSelect = (
+  nestedOptions: MaybeRefOrGetter<NestedOptionsObj>
+) => {
+  const state = reactive({
+    selectedOption: null as FlatOption | null,
+  });
+
+  const getters = {
+    lookups: computed(() => {
+      return toFlatOptionsAndLevels(toValue(nestedOptions));
+    }),
+
+    levelLookup: computed((): LevelLookup => {
+      return getters.lookups.value.levelLookup;
+    }),
+
+    optionsLookup: computed((): OptionsLookup => {
+      return getters.lookups.value.optionsLookup;
+    }),
+
+    widgetFieldContents: computed(() => {
+      if (!state.selectedOption) {
+        return null;
+      }
+
+      return getters.convertOptionToWidgetFieldContentsObject(
+        state.selectedOption
+      );
+    }),
+    flatOptions: computed((): FlatOption[] => {
+      const optionsLookup: OptionsLookup = getters.optionsLookup.value;
+      return Array.from(optionsLookup.values()).sort(
+        (a: FlatOption, b: FlatOption) => {
+          if (a.level !== b.level) {
+            // ascending level
+            return a.level - b.level;
+          }
+          // ascending value
+          return String(a.value).localeCompare(String(b.value));
+        }
+      );
+    }),
+
+    levels: computed((): Level[] => {
+      const levelLookup: LevelLookup = getters.levelLookup.value;
+      return Array.from(levelLookup.values()).sort((a, b) => {
+        // ascending depth
+        return a.depth - b.depth;
+      });
+    }),
+
+    getLevelByDepth: (depth: Level["depth"]) => {
+      return getters.levels.value.find((level) => level.depth === depth);
+    },
+
+    getOptionsByLevelId: (level: Level["id"]) => {
+      const levelLookup = getters.levelLookup.value;
+      return getters.flatOptions.value.filter(
+        (option) => option.level === levelLookup.get(level)?.depth
+      );
+    },
+
+    getOptionsByDepth: (depth: Level["depth"]) => {
+      const level = getters.getLevelByDepth(depth);
+      if (!level) {
+        return [];
+      }
+      return getters.getOptionsByLevelId(level.id);
+    },
+
+    getOptionsByParentId: (parentId: FlatOption["id"] | null) => {
+      return getters.flatOptions.value.filter(
+        (option) => option.parentId === parentId
+      );
+    },
+
+    getSelectedPath: (selectedOption: FlatOption | null) => {
+      if (!selectedOption) {
+        return [];
+      }
+      const optionsLookup = getters.optionsLookup.value;
+      const path: FlatOption[] = [];
+      let currentOption: FlatOption | null = selectedOption;
+      while (currentOption) {
+        // climb down the tree to the root to build the path
+        path.unshift(currentOption);
+        currentOption = currentOption.parentId
+          ? optionsLookup.get(currentOption.parentId) || null
+          : null;
+      }
+      return path;
+    },
+
+    convertOptionToWidgetFieldContentsObject: (
+      option: FlatOption
+    ): MultiSelectWidgetContent["fieldContents"] => {
+      return getters.getSelectedPath(option).reduce((acc, opt) => {
+        acc[opt.level] = acc[opt.level] || [];
+        acc[opt.level].push(opt.value);
+        return acc;
+      }, {} as MultiSelectWidgetContent["fieldContents"]);
+    },
+
+    getOptionById: (optionId: FlatOption["id"]) => {
+      return getters.getOptionById(optionId) || null;
+    },
+  };
+
+  const actions = {
+    selectOption(optionId: FlatOption["id"]) {
+      const option = getters.getOptionById(optionId);
+      if (option) {
+        state.selectedOption = option;
+      }
+    },
+
+    selectOptionByPath(path: FlatOption[]) {
+      if (path.length === 0) {
+        state.selectedOption = null;
+        return;
+      }
+      const lastOptionInPath = path[path.length - 1];
+      const option = getters.getOptionById(lastOptionInPath.id);
+      if (option) {
+        state.selectedOption = option;
+      }
+    },
+
+    clearSelection() {
+      state.selectedOption = null;
+    },
+  };
+
+  return {
+    ...toRefs(state),
+    ...getters,
+    ...actions,
+  };
+};

--- a/src/composables/useCascadeSelect.ts
+++ b/src/composables/useCascadeSelect.ts
@@ -27,8 +27,13 @@ export type OptionsLookup = Map<FlatOption["id"], FlatOption>;
 export type LevelLookup = Map<Level["id"], Level>;
 
 const toAlphaNum = (str: string) => str.replace(/[^a-zA-Z0-9]/g, "");
-const createOptionId = (levelId: string, rawValue: string | number) =>
-  `${levelId}-${toAlphaNum(String(rawValue)).toLowerCase()}`;
+const createOptionId = (
+  rawValue: string | number, 
+  parentId: string | null = null
+) => {
+  const valueId = toAlphaNum(String(rawValue)).toLowerCase();
+  return parentId ? `${parentId}-${valueId}` : valueId;
+};
 
 /**
  * Recursively converts a nested options structure into flat lookups for:
@@ -59,7 +64,7 @@ function toFlatOptionsAndLevels(
 
   if (Array.isArray(options)) {
     for (const option of options) {
-      const optionId = createOptionId(levelId, option);
+      const optionId = createOptionId(option, parentId);
       optionsLookup.set(optionId, {
         id: optionId,
         depth: levelDepth,
@@ -72,7 +77,7 @@ function toFlatOptionsAndLevels(
 
   if (isObject(options)) {
     for (const [value, moreNestedOptions] of Object.entries(options)) {
-      const optionId = createOptionId(levelId, value);
+      const optionId = createOptionId(value, parentId);
       optionsLookup.set(optionId, {
         id: optionId,
         depth: levelDepth,

--- a/src/composables/useCascadeSelect.ts
+++ b/src/composables/useCascadeSelect.ts
@@ -124,7 +124,7 @@ export const useCascadeSelect = (
     }
     const path: FlatOption[] = [];
     let currentOption: FlatOption | null = state.selectedOption;
-    // climb down the tree to the root to build the path
+    // climb up the tree to the root to build the path
     while (currentOption) {
       path.unshift(currentOption);
       currentOption = currentOption.parentId

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditMultiSelectWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditMultiSelectWidget.vue
@@ -18,7 +18,6 @@
         :id="`${item.id}-select`"
         :modelValue="item.fieldContents"
         :options="widgetDef.fieldData"
-        labelClass="font-medium"
         :showLabel="false"
         @update:modelValue="handleUpdateFieldContents(item.id, $event)" />
     </template>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditMultiSelectWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditMultiSelectWidget.vue
@@ -14,15 +14,13 @@
       )
     ">
     <template #fieldContents="{ item }">
-      <CascadeSelect
+      <SimpleCascadeSelect
         :id="`${item.id}-select`"
+        :modelValue="item.fieldContents"
         :options="widgetDef.fieldData"
-        :initialSelectedValues="
-          toCascadeSelectPath(widgetDef.fieldData, item.fieldContents as Type.MultiSelectWidgetContent['fieldContents'])
-        "
         labelClass="font-medium"
         :showLabel="false"
-        @change="(path) => handleFieldUpdate(item.id, path)" />
+        @update:modelValue="handleUpdateFieldContents(item.id, $event)" />
     </template>
   </EditWidgetLayout>
 </template>
@@ -31,8 +29,7 @@
 import * as Type from "@/types";
 import EditWidgetLayout from "./EditWidgetLayout.vue";
 import * as ops from "./helpers/editWidgetOps";
-import CascadeSelect from "@/components/CascadeSelect/CascadeSelect.vue";
-import { findDeepestPath } from "./helpers/findDeepestPath";
+import SimpleCascadeSelect from "@/components/CascadeSelect/SimpleCascadeSelect.vue";
 
 const props = defineProps<{
   widgetDef: Type.MultiSelectWidgetDef;
@@ -65,100 +62,20 @@ const handleSetPrimary = (id: string) =>
 const handleDelete = (id: string) =>
   updateWidgetContents(ops.deleteWidgetContent(props.widgetContents, id));
 
-const handleFieldUpdate = (itemId: string, path: string[]) => {
-  const hierarchy = getFieldHierarchy(props.widgetDef.fieldData);
-  const contents = toFieldContents(hierarchy, path);
-  updateWidgetContents(
-    ops.makeUpdateContentPayload(props.widgetContents, itemId, contents)
-  );
+const handleUpdateFieldContents = (
+  itemId: string,
+  updatedFieldContents: Type.MultiSelectWidgetContent["fieldContents"]
+) => {
+  const updated = props.widgetContents.map((contentItem) => {
+    if (contentItem.id !== itemId) return contentItem;
+
+    return {
+      ...contentItem,
+      fieldContents: updatedFieldContents,
+    };
+  });
+  emit("update:widgetContents", updated);
 };
-
-/**
- * Extracts the field hierarchy from the fieldData structure.
- * Finds the deepest possible path through the nested structure.
- *
- * @example
- * // For fieldData:
- * {
- *   country: {
- *     usa: {
- *       state: {
- *         california: { city: ["los angeles", "san francisco"] }
- *       }
- *     },
- *     canada: {
- *       province: {
- *         ontario: {} // Less deep branch
- *       }
- *     }
- *   }
- * }
- * // Returns: ["country", "state", "city"]
- *
- * @param fieldData - The nested field data structure
- * @returns Array of field type names in hierarchical order
- */
-function getFieldHierarchy(fieldData: Type.MultiSelectFieldData): string[] {
-  const deepestPath = findDeepestPath(fieldData);
-  // odd path keys are field types, even path keys are values
-  return deepestPath.filter((_, index) => index % 2 === 0);
-}
-
-/**
- * Converts fieldContents object to a path array for CascadeSelect.
- *
- * @example
- * // For fieldData structure that yields hierarchy ["country", "state", "city"]
- * // and fieldContents:
- * {
- *   country: "usa",
- *   state: "minnesota",
- *   city: "minneapolis"
- * }
- * // Returns: ["usa", "minnesota", "minneapolis"]
- */
-function toCascadeSelectPath(
-  fieldData: Type.MultiSelectFieldData,
-  fieldContents: Type.MultiSelectWidgetContent["fieldContents"]
-): string[] {
-  if (!fieldContents || Object.keys(fieldContents).length === 0) {
-    return [] as string[];
-  }
-
-  const hierarchy = getFieldHierarchy(fieldData);
-
-  return hierarchy
-    .map((level) => fieldContents[level])
-    .filter(Boolean) as string[];
-}
-
-/**
- * Converts a path array to a field contents object.
- *
- * @example
- * // For hierarchy: ["country", "state", "city"]
- * // and valuePath: ["usa", "california", "los angeles"]
- * // Returns:
- * {
- *   country: "usa",
- *   state: "california",
- *   city: "los angeles"
- * }
- */
-function toFieldContents(
-  hierarchy: string[],
-  valuePath: string[]
-): Record<string, string> {
-  if (!valuePath.length) return {};
-
-  return hierarchy.slice(0, valuePath.length).reduce(
-    (result, key, index) => ({
-      ...result,
-      [key]: valuePath[index],
-    }),
-    {}
-  );
-}
 </script>
 
 <style>

--- a/src/pages/ErrorPage/ErrorPage.vue
+++ b/src/pages/ErrorPage/ErrorPage.vue
@@ -4,7 +4,7 @@
       <h1 class="text-8xl font-bold text-neutral-200">{{ errorCode }}</h1>
       <h2 class="text-4xl mb-8">{{ getMessage(errorCode) }}</h2>
       <p class="my-4">{{ getDetailedMessage(errorCode) }}</p>
-      <Button :href="config.instance.base.url" icon="home" iconPosition="start">
+      <Button :to="{ name: 'home' }" icon="home" iconPosition="start">
         Go Home
       </Button>
     </div>
@@ -13,7 +13,6 @@
 <script setup lang="ts">
 import Button from "@/components/Button/Button.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
-import config from "@/config";
 import { usePageTitle } from "@/helpers/usePageTitle";
 
 const statusMessages = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -307,7 +307,7 @@ export interface UploadWidgetContent extends WidgetContent {
 }
 
 export interface MultiSelectWidgetContent extends WidgetContent {
-  fieldContents: object;
+  fieldContents: Record<string, string | number>;
 }
 
 export interface DateComponent {

--- a/tests/e2e/multiselect-cascade.spec.ts
+++ b/tests/e2e/multiselect-cascade.spec.ts
@@ -197,21 +197,21 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
         .locator(".edit-multiselect-widget")
         .filter({ hasText: "Cascade Select" });
       await expect(cascadeWidget.getByLabel("City")).toHaveValue(
-        "city-minneapolis"
+        "usa-minnesota-minneapolis"
       );
 
       // Demonstrate that city selection can be changed
       await cascadeWidget
         .getByLabel("City")
         .selectOption({ label: "St. Paul" });
-      await expect(cascadeWidget.getByLabel("City")).toHaveValue("city-stpaul");
+      await expect(cascadeWidget.getByLabel("City")).toHaveValue("usa-minnesota-stpaul");
 
       // Verify that changing back to original works too
       await cascadeWidget
         .getByLabel("City")
         .selectOption({ label: "minneapolis" });
       await expect(cascadeWidget.getByLabel("City")).toHaveValue(
-        "city-minneapolis"
+        "usa-minnesota-minneapolis"
       );
     });
 

--- a/tests/e2e/multiselect-cascade.spec.ts
+++ b/tests/e2e/multiselect-cascade.spec.ts
@@ -1,5 +1,60 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
+import type { CreateAssetRequestFormData } from "../../src/types";
+
+type CascadeValues = {
+  Country: string;
+  "State or Province": string;
+  City: string;
+  Neighborhood?: string;
+};
+
+type CascadeFieldContents = {
+  country: string;
+  stateorprovince: string;
+  city: string;
+  neighborhood?: string;
+};
+
+// Extend the base form data type to include our specific cascade select field
+type SubmissionFormData = CreateAssetRequestFormData & {
+  cascadeselect_1: Array<{
+    fieldContents: CascadeFieldContents;
+    isPrimary: boolean;
+  }>;
+};
+
+/**
+ * Creates an asset with cascade select values for testing.
+ * Uses template index 1 ("All Fields Test" - templateId 68) which contains the cascade select widget.
+ */
+async function createAssetWithCascadeValues(
+  page: Page,
+  title: string,
+  cascadeValues: CascadeValues
+) {
+  await page.goto("/assetManager/addAsset");
+
+  // Select "All Fields Test" template (index 1) which contains cascade select
+  await page.getByLabel("Template").selectOption({ index: 1 });
+  await page.getByLabel("Collection").selectOption({ index: 1 });
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page.getByLabel(/title/i).first().fill(title);
+
+  const cascadeWidget = page
+    .locator(".edit-multiselect-widget")
+    .filter({ hasText: "Cascade Select" });
+
+  // Fill cascade values in order (country -> state -> city -> neighborhood)
+  for (const [label, value] of Object.entries(cascadeValues)) {
+    if (value) {
+      await cascadeWidget.getByLabel(label).selectOption({ label: value });
+    }
+  }
+
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^/]+)/);
+}
 
 test.describe("MultiSelect Widget with Cascade Select", () => {
   test.describe("With Curator Permissions", () => {
@@ -17,234 +72,176 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
     test("can create asset with cascade multiselect, save, and verify on view", async ({
       page,
     }) => {
-      // Go directly to asset creation page to avoid menu navigation issues
+      /**
+       * Extracts form data from multipart POST data.
+       * The createAsset/updateAsset functions always send JSON in a 'formData' field.
+       */
+      function extractFormData(postData: string): SubmissionFormData | null {
+        // Extract the JSON from the formData field in multipart data
+        const match = postData.match(
+          /name="formData"\s*\r?\n\r?\n({.*?})\r?\n/s
+        );
+        if (!match) return null;
+
+        try {
+          return JSON.parse(match[1]) as SubmissionFormData;
+        } catch {
+          return null;
+        }
+      }
+
+      // Set up the asset creation form
       await page.goto("/assetManager/addAsset");
+      await page.getByLabel("Template").selectOption({ index: 1 });
+      await page.getByLabel("Collection").selectOption({ index: 1 });
+      await page.getByRole("button", { name: "Continue" }).click();
+      await page
+        .getByLabel(/title/i)
+        .first()
+        .fill("Test Asset with Cascade MultiSelect");
 
-      // Select template with multiselect (index 1 = "All Fields Test" which has the cascade select)
-      const templateSelect = page.getByLabel("Template");
-      await templateSelect.selectOption({ index: 1 });
-
-      const collectionSelect = page.getByLabel("Collection");
-      await collectionSelect.selectOption({ index: 1 });
-
-      // Continue to asset form
-      const continueButton = page.getByRole("button", { name: "Continue" });
-      await expect(continueButton).toBeEnabled({ timeout: 5000 });
-      await continueButton.click();
-
-      // Fill in required title field
-      const titleField = page.getByLabel(/title/i).first();
-      await titleField.fill("Test Asset with Cascade MultiSelect");
-
-      // Look for the Cascade Select widget section
-      const cascadeSelectWidget = page
+      const cascadeWidget = page
         .locator(".edit-multiselect-widget")
         .filter({ hasText: "Cascade Select" });
-      await expect(cascadeSelectWidget).toBeVisible({ timeout: 5000 });
 
-      // Find and select the Country dropdown
-      const countrySelect = cascadeSelectWidget.getByLabel("Country");
-      await expect(countrySelect).toBeVisible();
-      await countrySelect.selectOption({ label: "usa" });
+      await cascadeWidget.getByLabel("Country").selectOption({ label: "usa" });
+      await cascadeWidget
+        .getByLabel("State or Province")
+        .selectOption({ label: "minnesota" });
+      await cascadeWidget
+        .getByLabel("City")
+        .selectOption({ label: "St. Paul" });
 
-      // Wait for State or Province dropdown to appear and select minnesota
-      const stateSelect = cascadeSelectWidget.getByLabel("State or Province");
-      await expect(stateSelect).toBeVisible({ timeout: 2000 });
-      await stateSelect.selectOption({ label: "minnesota" });
+      // Wait for and capture the submission request when save is clicked
+      const [submissionRequest] = await Promise.all([
+        page.waitForRequest(
+          (request) =>
+            request.method() === "POST" &&
+            request.url().includes("submission") &&
+            !!extractFormData(request.postData() || "") &&
+            String(extractFormData(request.postData() || "")?.templateId) ===
+              "68"
+        ),
+        page.getByRole("button", { name: "Save" }).click(),
+      ]);
 
-      // Wait for City dropdown to appear and select St. Paul
-      const citySelect = cascadeSelectWidget.getByLabel("City");
-      await expect(citySelect).toBeVisible({ timeout: 2000 });
-      await citySelect.selectOption({ label: "St. Paul" });
-
-      // Save the asset
-      const saveButton = page.getByRole("button", { name: "Save" });
-      await expect(saveButton).toBeEnabled();
-      await saveButton.click();
-
-      // Should redirect to edit mode
+      // Should redirect to edit mode after save
       await expect(page).toHaveURL(/\/assetManager\/editAsset\/.+/, {
         timeout: 5000,
       });
 
-      // First, verify that the cascade values were actually selected and saved by checking edit mode
-      // Reload the edit page to see if values persisted
-      await page.reload();
+      // Validate the intercepted submission request data
+      const postData = submissionRequest.postData();
+      expect(postData).toBeTruthy();
 
-      // Check if our cascade values are still selected in edit mode
-      const cascadeSelectWidgetReload = page
+      const formData = extractFormData(postData!);
+      expect(formData).toBeTruthy();
+      expect(formData!.templateId).toBe("68");
+      expect(formData!.cascadeselect_1).toEqual([
+        {
+          isPrimary: false,
+          fieldContents: {
+            country: "usa",
+            stateorprovince: "minnesota",
+            city: "St. Paul",
+          },
+        },
+      ]);
+
+      // Verify values persist after reload
+      await page.reload();
+      const cascadeWidgetReload = page
         .locator(".edit-multiselect-widget")
         .filter({ hasText: "Cascade Select" });
-      await expect(cascadeSelectWidgetReload).toBeVisible();
 
-      // Verify the selected values are still there (they will be in normalized form)
-      const countrySelectReload =
-        cascadeSelectWidgetReload.getByLabel("Country");
-      await expect(countrySelectReload.locator("option:checked")).toHaveText(
-        "usa"
-      );
+      await expect(
+        cascadeWidgetReload.getByLabel("Country").locator("option:checked")
+      ).toHaveText("usa");
+      await expect(
+        cascadeWidgetReload
+          .getByLabel("State or Province")
+          .locator("option:checked")
+      ).toHaveText("minnesota");
+      await expect(
+        cascadeWidgetReload.getByLabel("City").locator("option:checked")
+      ).toHaveText("St. Paul");
 
-      const stateSelectReload =
-        cascadeSelectWidgetReload.getByLabel("State or Province");
-      await expect(stateSelectReload.locator("option:checked")).toHaveText(
-        "minnesota"
-      );
-
-      const citySelectReload = cascadeSelectWidgetReload.getByLabel("City");
-      await expect(citySelectReload.locator("option:checked")).toHaveText(
-        "St. Paul"
-      );
-
-      console.log(
-        "✅ Successfully created asset with cascade multiselect values: usa > minnesota > St. Paul"
-      );
-      console.log(
-        "✅ Verified cascade values persist in edit mode after save and reload"
-      );
-
-      // Extract asset ID
-      const currentUrl = page.url();
-      const assetIdMatch = currentUrl.match(/\/editAsset\/([^/]+)/);
-      if (!assetIdMatch) {
-        throw new Error(`Could not extract asset ID from URL: ${currentUrl}`);
+      // Verify values appear on view page
+      const assetId = page.url().match(/\/editAsset\/([^/]+)/)?.[1];
+      if (!assetId) {
+        throw new Error(`Could not extract asset ID from URL: ${page.url()}`);
       }
-      const assetId = assetIdMatch[1];
 
-      // Now verify the cascade values appear on the view asset page
       await page.goto(`/asset/viewAsset/${assetId}`);
       await page.waitForLoadState("networkidle");
 
-      // Check if the view page loaded successfully
-      const pageTitle = await page.title();
-      if (pageTitle.includes("Page not found")) {
-        console.log(
-          "ℹ️ Asset view page returned 404 - may not be accessible in test environment"
-        );
+      if ((await page.title()).includes("Page not found")) {
         return;
       }
-
-      console.log(`✅ View page loaded: ${pageTitle}`);
 
       await expect(page.getByText("usa")).toBeVisible();
       await expect(page.getByText("minnesota")).toBeVisible();
       await expect(page.getByText("St. Paul")).toBeVisible();
     });
 
-    test("can edit existing multiselect cascade values and verify persistence", async ({
-      page,
-    }) => {
-      // First create an asset with multiselect values
-      await page.goto("/assetManager/addAsset");
+    test("can edit existing multiselect cascade values", async ({ page }) => {
+      await createAssetWithCascadeValues(page, "Test Asset for Editing", {
+        Country: "usa",
+        "State or Province": "minnesota",
+        City: "minneapolis",
+      });
 
-      const templateSelect = page.getByLabel("Template");
-      await templateSelect.selectOption({ index: 1 });
-
-      const collectionSelect = page.getByLabel("Collection");
-      await collectionSelect.selectOption({ index: 1 });
-
-      const continueButton = page.getByRole("button", { name: "Continue" });
-      await continueButton.click();
-
-      const titleField = page.getByLabel(/title/i).first();
-      await titleField.fill("Test Asset for Editing Cascade Values");
-
-      // Set initial cascade values: usa > minnesota > minneapolis
-      const cascadeSelectWidget = page
-        .locator(".edit-multiselect-widget")
-        .filter({ hasText: "Cascade Select" });
-      await expect(cascadeSelectWidget).toBeVisible();
-
-      // Select Country: usa
-      const countrySelect = cascadeSelectWidget.getByLabel("Country");
-      await countrySelect.selectOption({ label: "usa" });
-
-      // Select State or Province: minnesota
-      const stateSelect = cascadeSelectWidget.getByLabel("State or Province");
-      await expect(stateSelect).toBeVisible({ timeout: 2000 });
-      await stateSelect.selectOption({ label: "minnesota" });
-
-      // Select City: minneapolis
-      const citySelect = cascadeSelectWidget.getByLabel("City");
-      await expect(citySelect).toBeVisible({ timeout: 2000 });
-      await citySelect.selectOption({ label: "minneapolis" });
-
-      // Save the asset
-      const saveButton = page.getByRole("button", { name: "Save" });
-      await saveButton.click();
-
-      // Wait for redirect to edit page
-      await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^/]+)/);
-
-      // Extract asset ID
-      const currentUrl = page.url();
-      const assetIdMatch = currentUrl.match(/\/editAsset\/([^/]+)/);
-      if (!assetIdMatch) {
-        throw new Error(`Could not extract asset ID from URL: ${currentUrl}`);
-      }
-      const assetId = assetIdMatch[1];
-
-      // Verify initial values are saved by reloading edit page
+      // Verify initial values after reload
       await page.reload();
-      const cascadeSelectWidgetCheck = page
+      const cascadeWidget = page
         .locator(".edit-multiselect-widget")
         .filter({ hasText: "Cascade Select" });
-      const citySelectCheck = cascadeSelectWidgetCheck.getByLabel("City");
-      await expect(citySelectCheck).toHaveValue("minneapolis");
+      await expect(cascadeWidget.getByLabel("City")).toHaveValue(
+        "city-minneapolis"
+      );
 
-      // Now demonstrate changing the city selection to St. Paul
-      const cascadeSelectWidgetEdit = page
-        .locator(".edit-multiselect-widget")
-        .filter({ hasText: "Cascade Select" });
-      const citySelectEdit = cascadeSelectWidgetEdit.getByLabel("City");
+      // Demonstrate that city selection can be changed
+      await cascadeWidget
+        .getByLabel("City")
+        .selectOption({ label: "St. Paul" });
+      await expect(cascadeWidget.getByLabel("City")).toHaveValue("city-stpaul");
 
-      // Verify we can change the selection
-      await citySelectEdit.selectOption({ label: "St. Paul" });
-      await expect(citySelectEdit).toHaveValue("St. Paul");
-
-      // Test viewing the asset with current values (minneapolis)
-      await page.goto(`/asset/viewAsset/${assetId}`);
-      await page.waitForLoadState("networkidle");
-
-      expect(page.getByText("usa")).toBeVisible();
-      expect(page.getByText("minnesota")).toBeVisible();
-      expect(page.getByText("St. Paul")).toBeVisible();
+      // Verify that changing back to original works too
+      await cascadeWidget
+        .getByLabel("City")
+        .selectOption({ label: "minneapolis" });
+      await expect(cascadeWidget.getByLabel("City")).toHaveValue(
+        "city-minneapolis"
+      );
     });
 
     test("existing asset with cascade values displays correct values not category names", async ({
       page,
     }) => {
-      // Navigate directly to the existing "All Fields Asset" that has cascade select data
-      const existingAssetId = "687969fd9c90c709c1021d01"; // "All Fields Asset" from assets.ts
-
+      // Navigate to the pre-seeded "All Fields Asset" that contains cascade select data
+      const existingAssetId = "687969fd9c90c709c1021d01"; // From assets.ts seed data
       await page.goto(`/asset/viewAsset/${existingAssetId}`);
       await page.waitForLoadState("networkidle");
 
-      // Verify the page loaded
-      const pageTitle = await page.title();
-      if (pageTitle.includes("Page not found")) {
+      if ((await page.title()).includes("Page not found")) {
         throw new Error(
-          `Asset view page not found for existing asset ${existingAssetId}`
+          `Asset view page not found for asset ${existingAssetId}`
         );
       }
 
-      // Find links for each cascade value
+      // Check that minnesota link URL should contain actual values
       const minnesotaLink = page.getByRole("link", { name: "minnesota" });
       await expect(minnesotaLink).toBeVisible();
       const mnHref = await minnesotaLink.getAttribute("href");
-      expect(mnHref).toBeTruthy();
-
-      // and check that the last segment of the url is
-      // `usa : minnesota` (but url encoded)
       const mnLastSegment = mnHref?.split("/").pop()?.toLowerCase();
-      await expect(mnLastSegment).toBe(encodeURIComponent("usa : minnesota"));
+      expect(mnLastSegment).toBe(encodeURIComponent("usa : minnesota"));
 
-      // and let's check the last "Summit Hill" link
+      // Check that Summit Hill link URL should contain actual values
       const summitLink = page.getByRole("link", { name: "Summit Hill" });
       await expect(summitLink).toBeVisible();
       const summitHref = await summitLink.getAttribute("href");
-      expect(summitHref).toBeTruthy();
       const summitLastSegment = summitHref?.split("/").pop()?.toLowerCase();
-      await expect(summitLastSegment).toBe(
+      expect(summitLastSegment).toBe(
         encodeURIComponent("usa : minnesota : St. Paul : Summit Hill")
       );
     });

--- a/tests/e2e/multiselect-cascade.spec.ts
+++ b/tests/e2e/multiselect-cascade.spec.ts
@@ -234,7 +234,7 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
       await expect(minnesotaLink).toBeVisible();
       const mnHref = await minnesotaLink.getAttribute("href");
       const mnLastSegment = mnHref?.split("/").pop()?.toLowerCase();
-      expect(mnLastSegment).toBe(encodeURIComponent("usa : minnesota"));
+      expect(mnLastSegment).toBe(encodeURIComponent("usa : minnesota").toLowerCase());
 
       // Check that Summit Hill link URL should contain actual values
       const summitLink = page.getByRole("link", { name: "Summit Hill" });
@@ -242,7 +242,7 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
       const summitHref = await summitLink.getAttribute("href");
       const summitLastSegment = summitHref?.split("/").pop()?.toLowerCase();
       expect(summitLastSegment).toBe(
-        encodeURIComponent("usa : minnesota : St. Paul : Summit Hill")
+        encodeURIComponent("usa : minnesota : St. Paul : Summit Hill").toLowerCase()
       );
     });
   });

--- a/tests/e2e/multiselect-cascade.spec.ts
+++ b/tests/e2e/multiselect-cascade.spec.ts
@@ -37,21 +37,23 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
       await titleField.fill("Test Asset with Cascade MultiSelect");
 
       // Look for the Cascade Select widget section
-      const cascadeSelectWidget = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      const cascadeSelectWidget = page
+        .locator(".edit-multiselect-widget")
+        .filter({ hasText: "Cascade Select" });
       await expect(cascadeSelectWidget).toBeVisible({ timeout: 5000 });
 
       // Find and select the Country dropdown
-      const countrySelect = cascadeSelectWidget.getByLabel('Country');
+      const countrySelect = cascadeSelectWidget.getByLabel("Country");
       await expect(countrySelect).toBeVisible();
       await countrySelect.selectOption({ label: "usa" });
 
       // Wait for State or Province dropdown to appear and select minnesota
-      const stateSelect = cascadeSelectWidget.getByLabel('State or Province');
+      const stateSelect = cascadeSelectWidget.getByLabel("State or Province");
       await expect(stateSelect).toBeVisible({ timeout: 2000 });
       await stateSelect.selectOption({ label: "minnesota" });
 
       // Wait for City dropdown to appear and select St. Paul
-      const citySelect = cascadeSelectWidget.getByLabel('City');
+      const citySelect = cascadeSelectWidget.getByLabel("City");
       await expect(citySelect).toBeVisible({ timeout: 2000 });
       await citySelect.selectOption({ label: "St. Paul" });
 
@@ -61,67 +63,71 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
       await saveButton.click();
 
       // Should redirect to edit mode
-      await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^\/]+)/, { timeout: 5000 });
+      await expect(page).toHaveURL(/\/assetManager\/editAsset\/.+/, {
+        timeout: 5000,
+      });
+
+      // First, verify that the cascade values were actually selected and saved by checking edit mode
+      // Reload the edit page to see if values persisted
+      await page.reload();
+
+      // Check if our cascade values are still selected in edit mode
+      const cascadeSelectWidgetReload = page
+        .locator(".edit-multiselect-widget")
+        .filter({ hasText: "Cascade Select" });
+      await expect(cascadeSelectWidgetReload).toBeVisible();
+
+      // Verify the selected values are still there (they will be in normalized form)
+      const countrySelectReload =
+        cascadeSelectWidgetReload.getByLabel("Country");
+      await expect(countrySelectReload.locator("option:checked")).toHaveText(
+        "usa"
+      );
+
+      const stateSelectReload =
+        cascadeSelectWidgetReload.getByLabel("State or Province");
+      await expect(stateSelectReload.locator("option:checked")).toHaveText(
+        "minnesota"
+      );
+
+      const citySelectReload = cascadeSelectWidgetReload.getByLabel("City");
+      await expect(citySelectReload.locator("option:checked")).toHaveText(
+        "St. Paul"
+      );
+
+      console.log(
+        "✅ Successfully created asset with cascade multiselect values: usa > minnesota > St. Paul"
+      );
+      console.log(
+        "✅ Verified cascade values persist in edit mode after save and reload"
+      );
 
       // Extract asset ID
       const currentUrl = page.url();
-      const assetIdMatch = currentUrl.match(/\/editAsset\/([^\/]+)/);
+      const assetIdMatch = currentUrl.match(/\/editAsset\/([^/]+)/);
       if (!assetIdMatch) {
         throw new Error(`Could not extract asset ID from URL: ${currentUrl}`);
       }
       const assetId = assetIdMatch[1];
 
-      // First, verify that the cascade values were actually selected and saved by checking edit mode
-      // Reload the edit page to see if values persisted
-      await page.reload();
-      
-      // Check if our cascade values are still selected in edit mode
-      const cascadeSelectWidgetReload = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
-      await expect(cascadeSelectWidgetReload).toBeVisible();
-      
-      // Verify the selected values are still there (they will be in normalized form)
-      const countrySelectReload = cascadeSelectWidgetReload.getByLabel('Country');
-      await expect(countrySelectReload).toHaveValue('country-usa');
-      
-      const stateSelectReload = cascadeSelectWidgetReload.getByLabel('State or Province');
-      await expect(stateSelectReload).toHaveValue('stateorprovince-minnesota');
-      
-      const citySelectReload = cascadeSelectWidgetReload.getByLabel('City');
-      await expect(citySelectReload).toHaveValue('city-stpaul');
-
-      console.log('✅ Successfully created asset with cascade multiselect values: usa > minnesota > St. Paul');
-      console.log('✅ Verified cascade values persist in edit mode after save and reload');
-
       // Now verify the cascade values appear on the view asset page
       await page.goto(`/asset/viewAsset/${assetId}`);
-      await page.waitForLoadState('networkidle');
-      
+      await page.waitForLoadState("networkidle");
+
       // Check if the view page loaded successfully
       const pageTitle = await page.title();
-      if (pageTitle.includes('Page not found')) {
-        console.log('ℹ️ Asset view page returned 404 - may not be accessible in test environment');
+      if (pageTitle.includes("Page not found")) {
+        console.log(
+          "ℹ️ Asset view page returned 404 - may not be accessible in test environment"
+        );
         return;
       }
-      
+
       console.log(`✅ View page loaded: ${pageTitle}`);
-      
-      // Look for cascade values in the view page
-      // They should be displayed as "usa : minnesota : St. Paul" based on MultiSelectItem.vue
-      const bodyText = await page.locator('body').textContent() || '';
-      
-      const hasUsa = bodyText.includes('usa');
-      const hasMinnesota = bodyText.includes('minnesota');
-      const hasStPaul = bodyText.includes('St. Paul');
-      
-      if (hasUsa && hasMinnesota && hasStPaul) {
-        await expect(page.getByText('usa')).toBeVisible();
-        await expect(page.getByText('minnesota')).toBeVisible();
-        await expect(page.getByText('St. Paul')).toBeVisible();
-        console.log('✅ All cascade values (usa, minnesota, St. Paul) found on view page');
-      } else {
-        console.log(`ℹ️ Cascade values on view page: usa=${hasUsa}, minnesota=${hasMinnesota}, St. Paul=${hasStPaul}`);
-        // Values might be displayed in a different format or not configured to show
-      }
+
+      await expect(page.getByText("usa")).toBeVisible();
+      await expect(page.getByText("minnesota")).toBeVisible();
+      await expect(page.getByText("St. Paul")).toBeVisible();
     });
 
     test("can edit existing multiselect cascade values and verify persistence", async ({
@@ -143,20 +149,22 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
       await titleField.fill("Test Asset for Editing Cascade Values");
 
       // Set initial cascade values: usa > minnesota > minneapolis
-      const cascadeSelectWidget = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      const cascadeSelectWidget = page
+        .locator(".edit-multiselect-widget")
+        .filter({ hasText: "Cascade Select" });
       await expect(cascadeSelectWidget).toBeVisible();
 
       // Select Country: usa
-      const countrySelect = cascadeSelectWidget.getByLabel('Country');
+      const countrySelect = cascadeSelectWidget.getByLabel("Country");
       await countrySelect.selectOption({ label: "usa" });
 
       // Select State or Province: minnesota
-      const stateSelect = cascadeSelectWidget.getByLabel('State or Province');
+      const stateSelect = cascadeSelectWidget.getByLabel("State or Province");
       await expect(stateSelect).toBeVisible({ timeout: 2000 });
       await stateSelect.selectOption({ label: "minnesota" });
 
       // Select City: minneapolis
-      const citySelect = cascadeSelectWidget.getByLabel('City');
+      const citySelect = cascadeSelectWidget.getByLabel("City");
       await expect(citySelect).toBeVisible({ timeout: 2000 });
       await citySelect.selectOption({ label: "minneapolis" });
 
@@ -165,11 +173,11 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
       await saveButton.click();
 
       // Wait for redirect to edit page
-      await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^\/]+)/);
+      await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^/]+)/);
 
       // Extract asset ID
       const currentUrl = page.url();
-      const assetIdMatch = currentUrl.match(/\/editAsset\/([^\/]+)/);
+      const assetIdMatch = currentUrl.match(/\/editAsset\/([^/]+)/);
       if (!assetIdMatch) {
         throw new Error(`Could not extract asset ID from URL: ${currentUrl}`);
       }
@@ -177,45 +185,68 @@ test.describe("MultiSelect Widget with Cascade Select", () => {
 
       // Verify initial values are saved by reloading edit page
       await page.reload();
-      const cascadeSelectWidgetCheck = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
-      const citySelectCheck = cascadeSelectWidgetCheck.getByLabel('City');
-      await expect(citySelectCheck).toHaveValue('city-minneapolis');
+      const cascadeSelectWidgetCheck = page
+        .locator(".edit-multiselect-widget")
+        .filter({ hasText: "Cascade Select" });
+      const citySelectCheck = cascadeSelectWidgetCheck.getByLabel("City");
+      await expect(citySelectCheck).toHaveValue("minneapolis");
 
       // Now demonstrate changing the city selection to St. Paul
-      const cascadeSelectWidgetEdit = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
-      const citySelectEdit = cascadeSelectWidgetEdit.getByLabel('City');
-      
+      const cascadeSelectWidgetEdit = page
+        .locator(".edit-multiselect-widget")
+        .filter({ hasText: "Cascade Select" });
+      const citySelectEdit = cascadeSelectWidgetEdit.getByLabel("City");
+
       // Verify we can change the selection
       await citySelectEdit.selectOption({ label: "St. Paul" });
-      await expect(citySelectEdit).toHaveValue('city-stpaul');
-      
-      // Verify we can change it back to minneapolis to show the cascade select is working
-      await citySelectEdit.selectOption({ label: "minneapolis" });
-      await expect(citySelectEdit).toHaveValue('city-minneapolis');
-      
-      console.log('✅ Successfully demonstrated editing cascade multiselect values (minneapolis <-> St. Paul)');
+      await expect(citySelectEdit).toHaveValue("St. Paul");
 
       // Test viewing the asset with current values (minneapolis)
       await page.goto(`/asset/viewAsset/${assetId}`);
-      await page.waitForLoadState('networkidle');
-      
+      await page.waitForLoadState("networkidle");
+
+      expect(page.getByText("usa")).toBeVisible();
+      expect(page.getByText("minnesota")).toBeVisible();
+      expect(page.getByText("St. Paul")).toBeVisible();
+    });
+
+    test("existing asset with cascade values displays correct values not category names", async ({
+      page,
+    }) => {
+      // Navigate directly to the existing "All Fields Asset" that has cascade select data
+      const existingAssetId = "687969fd9c90c709c1021d01"; // "All Fields Asset" from assets.ts
+
+      await page.goto(`/asset/viewAsset/${existingAssetId}`);
+      await page.waitForLoadState("networkidle");
+
+      // Verify the page loaded
       const pageTitle = await page.title();
-      if (!pageTitle.includes('Page not found')) {
-        console.log(`✅ View page loaded for edited asset: ${pageTitle}`);
-        
-        const bodyText = await page.locator('body').textContent() || '';
-        const hasMinneapolis = bodyText.includes('minneapolis');
-        const hasUsa = bodyText.includes('usa');
-        const hasMinnesota = bodyText.includes('minnesota');
-        
-        console.log(`ℹ️ View page shows edited values: usa=${hasUsa}, minnesota=${hasMinnesota}, minneapolis=${hasMinneapolis}`);
-        
-        if (hasUsa && hasMinnesota && hasMinneapolis) {
-          console.log('✅ All edited cascade values found on view page');
-        }
-      } else {
-        console.log('ℹ️ Asset view page returned 404 for edited asset');
+      if (pageTitle.includes("Page not found")) {
+        throw new Error(
+          `Asset view page not found for existing asset ${existingAssetId}`
+        );
       }
+
+      // Find links for each cascade value
+      const minnesotaLink = page.getByRole("link", { name: "minnesota" });
+      await expect(minnesotaLink).toBeVisible();
+      const mnHref = await minnesotaLink.getAttribute("href");
+      expect(mnHref).toBeTruthy();
+
+      // and check that the last segment of the url is
+      // `usa : minnesota` (but url encoded)
+      const mnLastSegment = mnHref?.split("/").pop()?.toLowerCase();
+      await expect(mnLastSegment).toBe(encodeURIComponent("usa : minnesota"));
+
+      // and let's check the last "Summit Hill" link
+      const summitLink = page.getByRole("link", { name: "Summit Hill" });
+      await expect(summitLink).toBeVisible();
+      const summitHref = await summitLink.getAttribute("href");
+      expect(summitHref).toBeTruthy();
+      const summitLastSegment = summitHref?.split("/").pop()?.toLowerCase();
+      await expect(summitLastSegment).toBe(
+        encodeURIComponent("usa : minnesota : St. Paul : Summit Hill")
+      );
     });
   });
 });

--- a/tests/e2e/multiselect-cascade.spec.ts
+++ b/tests/e2e/multiselect-cascade.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
+
+test.describe("MultiSelect Widget with Cascade Select", () => {
+  test.describe("With Curator Permissions", () => {
+    test.beforeEach(async ({ page, request }) => {
+      const workerId = test.info().workerIndex.toString();
+      await setupWorkerHTTPHeader({ page, workerId });
+
+      // Refresh database and login as curator (has canManageAssets: true)
+      await refreshDatabase({ request, workerId });
+      await loginUser({ request, page, workerId, username: "curator" });
+
+      await page.goto("/");
+    });
+
+    test("can create asset with cascade multiselect, save, and verify on view", async ({
+      page,
+    }) => {
+      // Go directly to asset creation page to avoid menu navigation issues
+      await page.goto("/assetManager/addAsset");
+
+      // Select template with multiselect (index 1 = "All Fields Test" which has the cascade select)
+      const templateSelect = page.getByLabel("Template");
+      await templateSelect.selectOption({ index: 1 });
+
+      const collectionSelect = page.getByLabel("Collection");
+      await collectionSelect.selectOption({ index: 1 });
+
+      // Continue to asset form
+      const continueButton = page.getByRole("button", { name: "Continue" });
+      await expect(continueButton).toBeEnabled({ timeout: 5000 });
+      await continueButton.click();
+
+      // Fill in required title field
+      const titleField = page.getByLabel(/title/i).first();
+      await titleField.fill("Test Asset with Cascade MultiSelect");
+
+      // Look for the Cascade Select widget section
+      const cascadeSelectWidget = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      await expect(cascadeSelectWidget).toBeVisible({ timeout: 5000 });
+
+      // Find and select the Country dropdown
+      const countrySelect = cascadeSelectWidget.getByLabel('Country');
+      await expect(countrySelect).toBeVisible();
+      await countrySelect.selectOption({ label: "usa" });
+
+      // Wait for State or Province dropdown to appear and select minnesota
+      const stateSelect = cascadeSelectWidget.getByLabel('State or Province');
+      await expect(stateSelect).toBeVisible({ timeout: 2000 });
+      await stateSelect.selectOption({ label: "minnesota" });
+
+      // Wait for City dropdown to appear and select St. Paul
+      const citySelect = cascadeSelectWidget.getByLabel('City');
+      await expect(citySelect).toBeVisible({ timeout: 2000 });
+      await citySelect.selectOption({ label: "St. Paul" });
+
+      // Save the asset
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await expect(saveButton).toBeEnabled();
+      await saveButton.click();
+
+      // Should redirect to edit mode
+      await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^\/]+)/, { timeout: 5000 });
+
+      // Extract asset ID
+      const currentUrl = page.url();
+      const assetIdMatch = currentUrl.match(/\/editAsset\/([^\/]+)/);
+      if (!assetIdMatch) {
+        throw new Error(`Could not extract asset ID from URL: ${currentUrl}`);
+      }
+      const assetId = assetIdMatch[1];
+
+      // First, verify that the cascade values were actually selected and saved by checking edit mode
+      // Reload the edit page to see if values persisted
+      await page.reload();
+      
+      // Check if our cascade values are still selected in edit mode
+      const cascadeSelectWidgetReload = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      await expect(cascadeSelectWidgetReload).toBeVisible();
+      
+      // Verify the selected values are still there (they will be in normalized form)
+      const countrySelectReload = cascadeSelectWidgetReload.getByLabel('Country');
+      await expect(countrySelectReload).toHaveValue('country-usa');
+      
+      const stateSelectReload = cascadeSelectWidgetReload.getByLabel('State or Province');
+      await expect(stateSelectReload).toHaveValue('stateorprovince-minnesota');
+      
+      const citySelectReload = cascadeSelectWidgetReload.getByLabel('City');
+      await expect(citySelectReload).toHaveValue('city-stpaul');
+
+      console.log('✅ Successfully created asset with cascade multiselect values: usa > minnesota > St. Paul');
+      console.log('✅ Verified cascade values persist in edit mode after save and reload');
+
+      // Now verify the cascade values appear on the view asset page
+      await page.goto(`/asset/viewAsset/${assetId}`);
+      await page.waitForLoadState('networkidle');
+      
+      // Check if the view page loaded successfully
+      const pageTitle = await page.title();
+      if (pageTitle.includes('Page not found')) {
+        console.log('ℹ️ Asset view page returned 404 - may not be accessible in test environment');
+        return;
+      }
+      
+      console.log(`✅ View page loaded: ${pageTitle}`);
+      
+      // Look for cascade values in the view page
+      // They should be displayed as "usa : minnesota : St. Paul" based on MultiSelectItem.vue
+      const bodyText = await page.locator('body').textContent() || '';
+      
+      const hasUsa = bodyText.includes('usa');
+      const hasMinnesota = bodyText.includes('minnesota');
+      const hasStPaul = bodyText.includes('St. Paul');
+      
+      if (hasUsa && hasMinnesota && hasStPaul) {
+        await expect(page.getByText('usa')).toBeVisible();
+        await expect(page.getByText('minnesota')).toBeVisible();
+        await expect(page.getByText('St. Paul')).toBeVisible();
+        console.log('✅ All cascade values (usa, minnesota, St. Paul) found on view page');
+      } else {
+        console.log(`ℹ️ Cascade values on view page: usa=${hasUsa}, minnesota=${hasMinnesota}, St. Paul=${hasStPaul}`);
+        // Values might be displayed in a different format or not configured to show
+      }
+    });
+
+    test("can edit existing multiselect cascade values and verify persistence", async ({
+      page,
+    }) => {
+      // First create an asset with multiselect values
+      await page.goto("/assetManager/addAsset");
+
+      const templateSelect = page.getByLabel("Template");
+      await templateSelect.selectOption({ index: 1 });
+
+      const collectionSelect = page.getByLabel("Collection");
+      await collectionSelect.selectOption({ index: 1 });
+
+      const continueButton = page.getByRole("button", { name: "Continue" });
+      await continueButton.click();
+
+      const titleField = page.getByLabel(/title/i).first();
+      await titleField.fill("Test Asset for Editing Cascade Values");
+
+      // Set initial cascade values: usa > minnesota > minneapolis
+      const cascadeSelectWidget = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      await expect(cascadeSelectWidget).toBeVisible();
+
+      // Select Country: usa
+      const countrySelect = cascadeSelectWidget.getByLabel('Country');
+      await countrySelect.selectOption({ label: "usa" });
+
+      // Select State or Province: minnesota
+      const stateSelect = cascadeSelectWidget.getByLabel('State or Province');
+      await expect(stateSelect).toBeVisible({ timeout: 2000 });
+      await stateSelect.selectOption({ label: "minnesota" });
+
+      // Select City: minneapolis
+      const citySelect = cascadeSelectWidget.getByLabel('City');
+      await expect(citySelect).toBeVisible({ timeout: 2000 });
+      await citySelect.selectOption({ label: "minneapolis" });
+
+      // Save the asset
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await saveButton.click();
+
+      // Wait for redirect to edit page
+      await expect(page).toHaveURL(/\/assetManager\/editAsset\/([^\/]+)/);
+
+      // Extract asset ID
+      const currentUrl = page.url();
+      const assetIdMatch = currentUrl.match(/\/editAsset\/([^\/]+)/);
+      if (!assetIdMatch) {
+        throw new Error(`Could not extract asset ID from URL: ${currentUrl}`);
+      }
+      const assetId = assetIdMatch[1];
+
+      // Verify initial values are saved by reloading edit page
+      await page.reload();
+      const cascadeSelectWidgetCheck = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      const citySelectCheck = cascadeSelectWidgetCheck.getByLabel('City');
+      await expect(citySelectCheck).toHaveValue('city-minneapolis');
+
+      // Now demonstrate changing the city selection to St. Paul
+      const cascadeSelectWidgetEdit = page.locator('.edit-multiselect-widget').filter({ hasText: 'Cascade Select' });
+      const citySelectEdit = cascadeSelectWidgetEdit.getByLabel('City');
+      
+      // Verify we can change the selection
+      await citySelectEdit.selectOption({ label: "St. Paul" });
+      await expect(citySelectEdit).toHaveValue('city-stpaul');
+      
+      // Verify we can change it back to minneapolis to show the cascade select is working
+      await citySelectEdit.selectOption({ label: "minneapolis" });
+      await expect(citySelectEdit).toHaveValue('city-minneapolis');
+      
+      console.log('✅ Successfully demonstrated editing cascade multiselect values (minneapolis <-> St. Paul)');
+
+      // Test viewing the asset with current values (minneapolis)
+      await page.goto(`/asset/viewAsset/${assetId}`);
+      await page.waitForLoadState('networkidle');
+      
+      const pageTitle = await page.title();
+      if (!pageTitle.includes('Page not found')) {
+        console.log(`✅ View page loaded for edited asset: ${pageTitle}`);
+        
+        const bodyText = await page.locator('body').textContent() || '';
+        const hasMinneapolis = bodyText.includes('minneapolis');
+        const hasUsa = bodyText.includes('usa');
+        const hasMinnesota = bodyText.includes('minnesota');
+        
+        console.log(`ℹ️ View page shows edited values: usa=${hasUsa}, minnesota=${hasMinnesota}, minneapolis=${hasMinneapolis}`);
+        
+        if (hasUsa && hasMinnesota && hasMinneapolis) {
+          console.log('✅ All edited cascade values found on view page');
+        }
+      } else {
+        console.log('ℹ️ Asset view page returned 404 for edited asset');
+      }
+    });
+  });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -88,7 +88,7 @@ test.describe("Search Input Functionality", () => {
       .first();
     await expect(resultsContainer).toBeVisible();
     const searchResults = page.locator(".search-result-card");
-    await expect(searchResults).toHaveCount(2); // Should match our mock data (2 assets)
+    await expect(searchResults).toHaveCount(3); // Should match our mock data (2 assets)
   });
 
   test("keyboard shortcuts work correctly", async ({ page }) => {

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -88,7 +88,7 @@ test.describe("Search Input Functionality", () => {
       .first();
     await expect(resultsContainer).toBeVisible();
     const searchResults = page.locator(".search-result-card");
-    await expect(searchResults).toHaveCount(3); // Should match our mock data (2 assets)
+    await expect(searchResults).toHaveCount(3); // Should match our mock data (3 assets)
   });
 
   test("keyboard shortcuts work correctly", async ({ page }) => {


### PR DESCRIPTION
WIP - stashing as draft PR.

This adds tests and fixes for some multiselect widget and cascade select component.
 
- fixes multiselect data structure in save requests. Spaces and special characters are now removed from the fieldContents keys to match legacy ui behavior.
- fixes options with the same name and at the same level not appearing. For example, `minneapolis > downtown` and `mankato > downtown` wouldn't both appear. 
- extracts CascadeSelect logic to a composable `useCascadeSelect` for easier testability.
- add unit tests for `useCascadeSelect`
- creates a new `<SimpleCascadeSelect>` component using the new composable. The existing CascadeSelect is left in place as it's used
- add e2e tests for editing multiselect widget
- add mock data for testing cascade select and multiselect functions

