### PR TITLE
add space around "no image yet" in asset editor

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditAssetForm/AssetSummary.vue
+++ b/src/pages/CreateOrEditAssetPage/EditAssetForm/AssetSummary.vue
@@ -2,12 +2,12 @@
   <div
     class="grid grid-cols-[1fr,auto] md:grid-cols-[auto,1fr] items-center md:items-start gap-4">
     <div
-      class="size-16 md:size-24 bg-black/10 rounded-lg overflow-hidden order-2 md:order-1 flex items-center justify-center">
+      class="size-16 md:size-24 bg-black/5 rounded-lg overflow-hidden order-2 md:order-1 flex items-center justify-center border border-black/10">
       <img
         v-if="typeof asset.firstFileHandlerId === 'string' && previewImageUrl"
         :src="previewImageUrl"
         class="w-full h-full object-cover" />
-      <p v-else class="text-xs">No image yet</p>
+      <p v-else class="text-[0.5rem] p-1">No image yet</p>
     </div>
     <div class="order-1 md:order-2">
       <Transition name="fade" mode="out-in">


### PR DESCRIPTION
before/after
<img width="400"  alt="ScreenShot 2025-08-16 at 23 03 22@2x" src="https://github.com/user-attachments/assets/cd7e5655-8ec3-483a-9b46-1e5b928e67dd" />
<img width="400" alt="ScreenShot 2025-08-16 at 23 04 13@2x" src="https://github.com/user-attachments/assets/6ab1a3ee-4ef1-4e19-8a80-f583908c6794" />
