### PR TITLE
fix: normalize the multiselect fieldContent keys

### DIFF
--- a/src/components/CascadeSelect/SimpleCascadeSelect.vue
+++ b/src/components/CascadeSelect/SimpleCascadeSelect.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="cascade-select flex flex-col gap-4">
+    <!-- show any currently selected segments -->
+    <div class="flex flex-col gap-1">
+      <template
+        v-for="selectedSegment in cascadeSelect.selectedPath"
+        :key="selectedSegment.id">
+        <SelectGroup
+          :label="
+            cascadeSelect.getLevelByDepth(selectedSegment.depth)?.label ??
+            `Category ${selectedSegment.depth + 1}`
+          "
+          :options="
+            cascadeSelect
+              .getOptionsByParentId(selectedSegment.parentId)
+              .map((opt) => ({
+                id: opt.id,
+                label: String(opt.value),
+              }))
+          "
+          :modelValue="selectedSegment.id"
+          placeholder="Select..."
+          @update:modelValue="handleSelectOption" />
+      </template>
+
+      <!-- show selector for next options if they exist -->
+      <SelectGroup
+        v-if="cascadeSelect.nextSelectOptions.length"
+        :label="
+          cascadeSelect.getLevelByDepth(cascadeSelect.selectedPath.length)
+            ?.label ?? `Category ${cascadeSelect.selectedPath.length + 1}`
+        "
+        :options="cascadeSelect.nextSelectOptions"
+        :modelValue="cascadeSelect.selectedOption?.id ?? null"
+        placeholder="Select..."
+        @update:modelValue="handleSelectOption" />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import {
+  FlatOption,
+  type NestedOptionsObj,
+  useCascadeSelect,
+} from "@/composables/useCascadeSelect";
+import { MultiSelectWidgetContent } from "@/types";
+import SelectGroup from "../SelectGroup/SelectGroup.vue";
+import { nextTick, toValue, onMounted } from "vue";
+
+const props = defineProps<{
+  options: NestedOptionsObj;
+  modelValue: MultiSelectWidgetContent["fieldContents"];
+  selectClass?: Record<string, boolean> | string[] | string;
+  labelClass?: Record<string, boolean> | string[] | string;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", updated: MultiSelectWidgetContent["fieldContents"]);
+}>();
+
+const cascadeSelect = useCascadeSelect(() => props.options);
+
+onMounted(() => {
+  // initialize cascadeSelect
+  cascadeSelect.selectOptionByWidgetFieldContents(props.modelValue);
+});
+
+function handleSelectOption(optionId: FlatOption["id"] | null) {
+  cascadeSelect.selectOption(optionId);
+  nextTick(() => {
+    emit("update:modelValue", toValue(cascadeSelect.widgetFieldContents ?? {}));
+  });
+}
+</script>
+<style scoped></style>

--- a/src/components/Widget/MultiSelectWidget/MultiSelectItem.vue
+++ b/src/components/Widget/MultiSelectWidget/MultiSelectItem.vue
@@ -1,11 +1,11 @@
 <template>
   <ul>
     <template v-for="category in organizedSelectCategories" :key="category">
-      <li v-if="content.fieldContents[category]">
+      <li v-if="getCategoryContent(category)">
         <ClickToSearchLink
           :widget="widget"
           :linkText="contentsUpToCategory(category)">
-          {{ content.fieldContents[category] }}
+          {{ getCategoryContent(category) }}
         </ClickToSearchLink>
       </li>
     </template>
@@ -13,33 +13,49 @@
 </template>
 
 <script setup lang="ts">
-import { recursiveSort, uniqueValues } from "./MultiSelectWidget";
+import { collectAlternatingKeys, uniqueValues } from "./MultiSelectWidget";
 import { computed } from "vue";
 import { MultiSelectWidgetContent, MultiSelectWidgetDef } from "@/types";
 import ClickToSearchLink from "@/components/ClickToSearchLink/ClickToSearchLink.vue";
 
-interface Props {
+const props = defineProps<{
   widget: MultiSelectWidgetDef;
   content: MultiSelectWidgetContent;
-}
-
-const props = defineProps<Props>();
+}>();
 
 const organizedSelectCategories = computed(() => {
-  return uniqueValues(recursiveSort(props.widget.fieldData, false)).map(
-    makeSafeForTitle
+  return uniqueValues(collectAlternatingKeys(props.widget.fieldData, false)).map(
+    toAlphaNum
   );
 });
 
-const makeSafeForTitle = (title) => {
-  return title.replace(/[^a-zA-Z0-9]+/, "");
-};
+const toAlphaNum = (str: string) => str.replace(/[^a-zA-Z0-9]+/, "");
 
-const contentsUpToCategory = (targetCategory) => {
+const toNormedCategory = (str: string | number) =>
+  toAlphaNum(String(str)).toLowerCase();
+
+// normalize field content keys
+const normalizedFieldContents = computed(() => {
+  // make keys alphanumeric and lowercase
+  return Object.fromEntries(
+    Object.entries(props.content.fieldContents).map(([key, value]) => {
+      return [toNormedCategory(key), value];
+    })
+  );
+});
+
+const getCategoryContent = (str: string | number) =>
+  normalizedFieldContents.value[toNormedCategory(str)];
+
+const contentsUpToCategory = (targetCategory: string) => {
   const returnValue: string[] = [];
+  const normedTargetCategory = toNormedCategory(targetCategory);
   for (const category of organizedSelectCategories.value) {
-    returnValue.push(props.content.fieldContents[category]);
-    if (category == targetCategory) {
+    const normedCategory = toNormedCategory(category);
+    // Use the actual field content value instead of the category name
+    const categoryValue = getCategoryContent(category);
+    returnValue.push(String(categoryValue));
+    if (normedCategory === normedTargetCategory) {
       return returnValue.join(" : ");
     }
   }

--- a/src/components/Widget/MultiSelectWidget/MultiSelectWidget.ts
+++ b/src/components/Widget/MultiSelectWidget/MultiSelectWidget.ts
@@ -1,11 +1,17 @@
-export const recursiveSort = (inputObject: object, skip: boolean): string[] => {
+/**
+ * Recursively traverses a nested object and collects
+ * keys from alternating levels.
+ * Note: Despite the name, this function does not sort.
+ * It extracts keys in traversal order.
+ */
+export const collectAlternatingKeys = (inputObject: object, skip: boolean): string[] => {
   let outputArray: string[] = [];
   for (const key in inputObject) {
     if (!skip) {
       outputArray.push(key);
     }
     if (typeof inputObject[key] === "object") {
-      outputArray = outputArray.concat(recursiveSort(inputObject[key], !skip));
+      outputArray = outputArray.concat(collectAlternatingKeys(inputObject[key], !skip));
     }
   }
   return outputArray.flat();

--- a/src/composables/useCascadeSelect.test.ts
+++ b/src/composables/useCascadeSelect.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from "vitest";
+import { type NestedOptionsObj, useCascadeSelect } from "./useCascadeSelect";
+
+const nestedOptions: NestedOptionsObj = {
+  country: {
+    usa: {
+      "State or Province": {
+        mn: [],
+        wi: [],
+        "South Dakota": [],
+      },
+    },
+    canada: {
+      "State or Province": ["quebec", "alberta"],
+    },
+  },
+};
+
+describe("useCascadeSelect", () => {
+  /**
+   * The CascadeSelect component takes an options object
+   * which alternates category -> value -> category -> value
+   * like { country: usa: { state: { minnesota: ... }}}
+   * so a category object contains value objects, which
+   * contain more category objects, and so on.
+   *
+   * This structure is complex to work with. So, the goal of
+   * this component is to act as an intercessor by turning
+   * the complext nested object into a flatter structure
+   * which we can filter.
+   */
+
+  it("converts a nested options object to a flat list of options sorted by level and value", () => {
+    const { flatOptions } = useCascadeSelect(() => nestedOptions);
+
+    expect(flatOptions).toEqual([
+      // countries
+      {
+        id: "canada",
+        depth: 0,
+        value: "canada",
+        parentId: null,
+      },
+      {
+        id: "usa",
+        depth: 0,
+        value: "usa",
+        parentId: null,
+      },
+
+      // states and provinces
+      {
+        id: "canada-alberta",
+        depth: 1,
+        value: "alberta",
+        parentId: "canada",
+      },
+      {
+        id: "usa-mn",
+        depth: 1,
+        value: "mn",
+        parentId: "usa",
+      },
+      {
+        id: "canada-quebec",
+        depth: 1,
+        value: "quebec",
+        parentId: "canada",
+      },
+      {
+        id: "usa-southdakota",
+        depth: 1,
+        value: "South Dakota",
+        parentId: "usa",
+      },
+      {
+        id: "usa-wi",
+        depth: 1,
+        value: "wi",
+        parentId: "usa",
+      },
+    ]);
+  });
+
+  it("returns the levels of the nested options", () => {
+    const { levels } = useCascadeSelect(nestedOptions);
+
+    expect(levels).toEqual([
+      {
+        id: "country",
+        label: "country",
+        depth: 0,
+      },
+      {
+        id: "stateorprovince",
+        label: "State or Province",
+        depth: 1,
+      },
+    ]);
+  });
+
+  it("gets all options by a given level", () => {
+    const { getOptionsByDepth } = useCascadeSelect(nestedOptions);
+
+    const optionsAtLevel0 = getOptionsByDepth(0);
+    expect(optionsAtLevel0).toEqual([
+      {
+        id: "canada",
+        depth: 0,
+        value: "canada",
+        parentId: null,
+      },
+      {
+        id: "usa",
+        depth: 0,
+        value: "usa",
+        parentId: null,
+      },
+    ]);
+
+    const optionsAtLevel1 = getOptionsByDepth(1);
+    expect(optionsAtLevel1).toEqual([
+      {
+        id: "canada-alberta",
+        depth: 1,
+        value: "alberta",
+        parentId: "canada",
+      },
+      {
+        id: "usa-mn",
+        depth: 1,
+        value: "mn",
+        parentId: "usa",
+      },
+      {
+        id: "canada-quebec",
+        depth: 1,
+        value: "quebec",
+        parentId: "canada",
+      },
+      {
+        id: "usa-southdakota",
+        depth: 1,
+        value: "South Dakota",
+        parentId: "usa",
+      },
+      {
+        id: "usa-wi",
+        depth: 1,
+        value: "wi",
+        parentId: "usa",
+      },
+    ]);
+  });
+
+  it("captures deeper levels that only exist under later siblings", () => {
+    const tricky: NestedOptionsObj = {
+      category: {
+        // first sibling is a leaf (array) so depth ends here on this path
+        alpha: [],
+        // second sibling introduces a new deeper level
+        beta: {
+          Subcategory: {
+            one: [],
+            two: [],
+          },
+        },
+      },
+    };
+
+    const { levels, flatOptions, getOptionsByDepth } = useCascadeSelect(tricky);
+
+    expect(levels).toEqual([
+      { id: "category", label: "category", depth: 0 },
+      { id: "subcategory", label: "Subcategory", depth: 1 },
+    ]);
+
+    // level 0 options
+    expect(getOptionsByDepth(0)).toEqual([
+      { id: "alpha", depth: 0, value: "alpha", parentId: null },
+      { id: "beta", depth: 0, value: "beta", parentId: null },
+    ]);
+
+    // level 1 options (children of beta only)
+    expect(getOptionsByDepth(1)).toEqual([
+      {
+        id: "beta-one",
+        depth: 1,
+        value: "one",
+        parentId: "beta",
+      },
+      {
+        id: "beta-two",
+        depth: 1,
+        value: "two",
+        parentId: "beta",
+      },
+    ]);
+
+    // flat options should include all 4
+    expect(flatOptions).toEqual([
+      { id: "alpha", depth: 0, value: "alpha", parentId: null },
+      { id: "beta", depth: 0, value: "beta", parentId: null },
+      {
+        id: "beta-one",
+        depth: 1,
+        value: "one",
+        parentId: "beta",
+      },
+      {
+        id: "beta-two",
+        depth: 1,
+        value: "two",
+        parentId: "beta",
+      },
+    ]);
+  });
+
+  it("handles duplicate option names at the same level with different parents", () => {
+    // This test case reproduces the bug where options with the same name
+    // at the same level might not all show up because they have the same id
+    const duplicateNamesOptions: NestedOptionsObj = {
+      City: {
+        minneapolis: {
+          Neighborhood: ["downtown", "uptown", "northeast"],
+        },
+        mankato: {
+          Neighborhood: ["downtown", "eastside", "westside"],
+        },
+      },
+    };
+
+    const { getOptionsByDepth } = useCascadeSelect(duplicateNamesOptions);
+
+    // Should have 6 neighborhood options total (3 from each city)
+    const neighborhoodOptions = getOptionsByDepth(1);
+    expect(neighborhoodOptions).toHaveLength(6);
+
+    // Should include both "downtown" options with different parent IDs
+    const downtownOptions = neighborhoodOptions.filter(
+      (opt) => opt.value === "downtown"
+    );
+    expect(downtownOptions).toHaveLength(2);
+
+    // They should have different parent IDs
+    const parentIds = downtownOptions.map((opt) => opt.parentId);
+    expect(parentIds).toEqual(
+      expect.arrayContaining(["minneapolis", "mankato"])
+    );
+    expect(parentIds[0]).not.toBe(parentIds[1]);
+  });
+});

--- a/src/composables/useCascadeSelect.ts
+++ b/src/composables/useCascadeSelect.ts
@@ -1,0 +1,320 @@
+import { MultiSelectWidgetContent, SelectOption } from "@/types";
+import { isObject } from "@vueuse/core";
+import { isNotNil } from "ramda";
+import invariant from "tiny-invariant";
+import { computed, MaybeRefOrGetter, toValue, reactive, toRefs } from "vue";
+
+export interface NestedOptionsObj {
+  [category: string]: string[] | Record<string, NestedOptionsObj | []>;
+}
+// Example:
+// { Country: { usa: { State: { mn: [], wi: [] } }, canada: { State: ["quebec"] } } }
+
+export interface Level {
+  id: string;
+  label: string;
+  depth: number;
+}
+
+// tree node
+export interface FlatOption {
+  id: string | number;
+  depth: Level["depth"];
+  value: string | number;
+  parentId: FlatOption["id"] | null;
+}
+
+export type OptionsLookup = Map<FlatOption["id"], FlatOption>;
+export type LevelLookup = Map<Level["id"], Level>;
+
+const toAlphaNum = (str: string) => str.replace(/[^a-zA-Z0-9]/g, "");
+const createOptionId = (
+  rawValue: string | number,
+  parentId: string | number | null = null
+) => {
+  const valueId = toAlphaNum(String(rawValue)).toLowerCase();
+  return parentId !== null ? `${parentId}-${valueId}` : valueId;
+};
+
+/**
+ * Recursively converts a nested options structure into flat lookups for:
+ *  - levels (category metadata per depth)
+ *  - options (each concrete selectable value with parent linkage)
+ *
+ *  Each branching object layer has exactly one "category label" key whose value
+ *  is either an array of terminal option strings OR an object whose keys are
+ *  option values and whose values are the next category object (again with a
+ *  single key) or an empty array to terminate that branch.
+ */
+function toFlatOptionsAndLevels(
+  nestedOptions: NestedOptionsObj,
+  levelDepth = 0,
+  parentId: FlatOption["id"] | null = null
+): { levelLookup: LevelLookup; optionsLookup: OptionsLookup } {
+  const levelLookup: Map<Level["id"], Level> = new Map();
+  const optionsLookup: Map<FlatOption["id"], FlatOption> = new Map();
+
+  const levelLabel = Object.keys(nestedOptions)[0];
+  if (!levelLabel) return { levelLookup, optionsLookup };
+
+  const levelId = toAlphaNum(levelLabel).toLowerCase();
+  const level: Level = { id: levelId, label: levelLabel, depth: levelDepth };
+  levelLookup.set(levelId, level);
+
+  const options = nestedOptions[levelLabel];
+
+  if (Array.isArray(options)) {
+    for (const option of options) {
+      const optionId = createOptionId(option, parentId);
+      optionsLookup.set(optionId, {
+        id: optionId,
+        depth: levelDepth,
+        value: option,
+        parentId,
+      });
+    }
+    return { levelLookup, optionsLookup };
+  }
+
+  if (isObject(options)) {
+    for (const [value, moreNestedOptions] of Object.entries(options)) {
+      const optionId = createOptionId(value, parentId);
+      optionsLookup.set(optionId, {
+        id: optionId,
+        depth: levelDepth,
+        value,
+        parentId,
+      });
+
+      if (!Array.isArray(moreNestedOptions)) {
+        const {
+          levelLookup: nestedLevelLookup,
+          optionsLookup: nestedOptionsLookup,
+        } = toFlatOptionsAndLevels(moreNestedOptions, levelDepth + 1, optionId);
+        nestedLevelLookup.forEach((lvl) => levelLookup.set(lvl.id, lvl));
+        nestedOptionsLookup.forEach((opt) => optionsLookup.set(opt.id, opt));
+      }
+    }
+  }
+
+  return { levelLookup, optionsLookup };
+}
+
+export const useCascadeSelect = (
+  nestedOptions: MaybeRefOrGetter<NestedOptionsObj>
+) => {
+  const state = reactive({
+    selectedOption: null as FlatOption | null,
+  });
+
+  const lookups = computed(() => {
+    return toFlatOptionsAndLevels(toValue(nestedOptions));
+  });
+
+  const levelLookup = computed((): LevelLookup => {
+    return lookups.value.levelLookup;
+  });
+
+  const optionsLookup = computed((): OptionsLookup => {
+    return lookups.value.optionsLookup;
+  });
+
+  const selectedPath = computed((): FlatOption[] => {
+    if (!state.selectedOption) {
+      return [];
+    }
+    const path: FlatOption[] = [];
+    let currentOption: FlatOption | null = state.selectedOption;
+    // climb up the tree to the root to build the path
+    while (currentOption) {
+      path.unshift(currentOption);
+      currentOption = currentOption.parentId
+        ? optionsLookup.value.get(currentOption.parentId) || null
+        : null;
+    }
+    return path;
+  });
+
+  const getOptionsByParentId = (
+    parentId: FlatOption["id"] | null
+  ): FlatOption[] =>
+    flatOptions.value.filter((option) => option.parentId === parentId);
+
+  const getLabelForOption = (option: FlatOption) => {
+    const label = getLevelByDepth(option.depth)?.label;
+    invariant(label, `No level found for depth ${option.depth}`);
+    return label;
+  };
+
+  const currentSelectOptions = computed((): SelectOption<string | number>[] => {
+    const currentParentId = state.selectedOption?.parentId ?? null;
+    // get the options that are children of the selected option
+    return getOptionsByParentId(currentParentId).map(mapOptionToSelect);
+  });
+
+  const nextSelectOptions = computed((): SelectOption<string | number>[] => {
+    // if no selected option, return empty array
+    return getOptionsByParentId(state.selectedOption?.id ?? null).map(
+      mapOptionToSelect
+    );
+  });
+
+  // Derived computeds that can reference the base ones
+  const getLevel = (levelId: Level["id"]): Level | null =>
+    levelLookup.value.get(levelId) || null;
+
+  const widgetFieldContents = computed(() => {
+    if (!state.selectedOption) {
+      return null;
+    }
+
+    return selectedPath.value.reduce((acc, opt) => {
+      // get label for opt
+      const label = getLabelForOption(opt);
+
+      // widget content keys are alphanumeric version of
+      // the level label (spaces and special characters removed
+      // so that they can be persisted in a database)
+      const widgetContentKey = toAlphaNum(label).toLowerCase();
+      return {
+        ...acc,
+        [widgetContentKey]: opt.value,
+      };
+    }, {} as MultiSelectWidgetContent["fieldContents"]);
+  });
+
+  const flatOptions = computed((): FlatOption[] =>
+    Array.from(optionsLookup.value.values()).sort((a, b) =>
+      a.depth === b.depth
+        ? String(a.value).localeCompare(String(b.value))
+        : a.depth - b.depth
+    )
+  );
+
+  const levels = computed((): Level[] =>
+    Array.from(levelLookup.value.values()).sort((a, b) => a.depth - b.depth)
+  );
+
+  const getLevelByDepth = (depth: Level["depth"]): Level | undefined =>
+    levels.value.find((level) => level.depth === depth);
+
+  const getOptionsByLevelId = (level: Level["id"]): FlatOption[] =>
+    flatOptions.value.filter(
+      (option) => option.depth === levelLookup.value.get(level)?.depth
+    );
+
+  const getOptionsByDepth = (depth: Level["depth"]): FlatOption[] => {
+    const level = getLevelByDepth(depth);
+    return level ? getOptionsByLevelId(level.id) : [];
+  };
+
+  const getOption = (optionId: FlatOption["id"]): FlatOption | null =>
+    optionsLookup.value.get(optionId) || null;
+
+  const mapOptionToSelect = (
+    option: FlatOption
+  ): SelectOption<string | number> => ({
+    id: option.id,
+    label: String(option.value),
+  });
+
+  const actions = {
+    selectOption(optionId: FlatOption["id"] | null) {
+      if (!optionId) {
+        state.selectedOption = null;
+        return;
+      }
+      const option = getOption(optionId);
+      if (option) {
+        state.selectedOption = option;
+      }
+    },
+
+    selectOptionByPath(path: FlatOption[]) {
+      if (path.length === 0) {
+        state.selectedOption = null;
+        return;
+      }
+      const lastOptionInPath = path[path.length - 1];
+      const option = getOption(lastOptionInPath.id);
+      if (option) {
+        state.selectedOption = option;
+      }
+    },
+
+    clearSelection() {
+      state.selectedOption = null;
+    },
+
+    selectOptionByWidgetFieldContents(
+      fieldContents: MultiSelectWidgetContent["fieldContents"]
+    ) {
+      if (!fieldContents) {
+        state.selectedOption = null;
+        return;
+      }
+
+      // normalize the field content keys to lowercase
+      // alphanumeric strings
+      const normFieldContents: Record<string, string | number> = {};
+      for (const key in fieldContents) {
+        const normKey = toAlphaNum(key).toLowerCase();
+        normFieldContents[normKey] = fieldContents[key];
+      }
+
+      // iterate over levels in order of depth
+      const path: FlatOption[] = [];
+      let parentId: FlatOption["id"] | null = null;
+
+      // note that levels are already sorted by depth
+      for (const level of levels.value) {
+        // the field contents key is the level label converted to alphanumeric
+        const normFieldContentsKey = toAlphaNum(level.label).toLowerCase();
+
+        const valueAtLevel = normFieldContents[normFieldContentsKey];
+
+        // if there's no value for this level, we're done
+        if (!valueAtLevel) {
+          break;
+        }
+
+        // now find the option in this level that matches the value and parentId
+        const options = getOptionsByParentId(parentId);
+        const matchingOption = options.find(
+          (opt) => opt.value === valueAtLevel
+        );
+
+        // if no matching option, we can't continue, so break
+        if (!matchingOption) {
+          break;
+        }
+
+        // add the matching option to the path
+        path.push(matchingOption);
+        // update parentId for the next level
+        parentId = matchingOption.id;
+      }
+
+      // the last option in the constructed path is the selected option
+      actions.selectOptionByPath(path);
+    },
+  };
+
+  // wrapping in reactive to auto-unwrap refs
+  return reactive({
+    ...toRefs(state),
+    flatOptions,
+    levels,
+    selectedPath,
+    widgetFieldContents,
+    currentSelectOptions,
+    nextSelectOptions,
+    getLevel,
+    getLevelByDepth,
+    getOption,
+    getOptionsByLevelId,
+    getOptionsByDepth,
+    getOptionsByParentId,
+    ...actions,
+  });
+};

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditMultiSelectWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditMultiSelectWidget.vue
@@ -14,15 +14,12 @@
       )
     ">
     <template #fieldContents="{ item }">
-      <CascadeSelect
+      <SimpleCascadeSelect
         :id="`${item.id}-select`"
+        :modelValue="item.fieldContents"
         :options="widgetDef.fieldData"
-        :initialSelectedValues="
-          toCascadeSelectPath(widgetDef.fieldData, item.fieldContents as Type.MultiSelectWidgetContent['fieldContents'])
-        "
-        labelClass="font-medium"
         :showLabel="false"
-        @change="(path) => handleFieldUpdate(item.id, path)" />
+        @update:modelValue="handleUpdateFieldContents(item.id, $event)" />
     </template>
   </EditWidgetLayout>
 </template>
@@ -31,8 +28,7 @@
 import * as Type from "@/types";
 import EditWidgetLayout from "./EditWidgetLayout.vue";
 import * as ops from "./helpers/editWidgetOps";
-import CascadeSelect from "@/components/CascadeSelect/CascadeSelect.vue";
-import { findDeepestPath } from "./helpers/findDeepestPath";
+import SimpleCascadeSelect from "@/components/CascadeSelect/SimpleCascadeSelect.vue";
 
 const props = defineProps<{
   widgetDef: Type.MultiSelectWidgetDef;
@@ -65,100 +61,20 @@ const handleSetPrimary = (id: string) =>
 const handleDelete = (id: string) =>
   updateWidgetContents(ops.deleteWidgetContent(props.widgetContents, id));
 
-const handleFieldUpdate = (itemId: string, path: string[]) => {
-  const hierarchy = getFieldHierarchy(props.widgetDef.fieldData);
-  const contents = toFieldContents(hierarchy, path);
-  updateWidgetContents(
-    ops.makeUpdateContentPayload(props.widgetContents, itemId, contents)
-  );
+const handleUpdateFieldContents = (
+  itemId: string,
+  updatedFieldContents: Type.MultiSelectWidgetContent["fieldContents"]
+) => {
+  const updated = props.widgetContents.map((contentItem) => {
+    if (contentItem.id !== itemId) return contentItem;
+
+    return {
+      ...contentItem,
+      fieldContents: updatedFieldContents,
+    };
+  });
+  emit("update:widgetContents", updated);
 };
-
-/**
- * Extracts the field hierarchy from the fieldData structure.
- * Finds the deepest possible path through the nested structure.
- *
- * @example
- * // For fieldData:
- * {
- *   country: {
- *     usa: {
- *       state: {
- *         california: { city: ["los angeles", "san francisco"] }
- *       }
- *     },
- *     canada: {
- *       province: {
- *         ontario: {} // Less deep branch
- *       }
- *     }
- *   }
- * }
- * // Returns: ["country", "state", "city"]
- *
- * @param fieldData - The nested field data structure
- * @returns Array of field type names in hierarchical order
- */
-function getFieldHierarchy(fieldData: Type.MultiSelectFieldData): string[] {
-  const deepestPath = findDeepestPath(fieldData);
-  // odd path keys are field types, even path keys are values
-  return deepestPath.filter((_, index) => index % 2 === 0);
-}
-
-/**
- * Converts fieldContents object to a path array for CascadeSelect.
- *
- * @example
- * // For fieldData structure that yields hierarchy ["country", "state", "city"]
- * // and fieldContents:
- * {
- *   country: "usa",
- *   state: "minnesota",
- *   city: "minneapolis"
- * }
- * // Returns: ["usa", "minnesota", "minneapolis"]
- */
-function toCascadeSelectPath(
-  fieldData: Type.MultiSelectFieldData,
-  fieldContents: Type.MultiSelectWidgetContent["fieldContents"]
-): string[] {
-  if (!fieldContents || Object.keys(fieldContents).length === 0) {
-    return [] as string[];
-  }
-
-  const hierarchy = getFieldHierarchy(fieldData);
-
-  return hierarchy
-    .map((level) => fieldContents[level])
-    .filter(Boolean) as string[];
-}
-
-/**
- * Converts a path array to a field contents object.
- *
- * @example
- * // For hierarchy: ["country", "state", "city"]
- * // and valuePath: ["usa", "california", "los angeles"]
- * // Returns:
- * {
- *   country: "usa",
- *   state: "california",
- *   city: "los angeles"
- * }
- */
-function toFieldContents(
-  hierarchy: string[],
-  valuePath: string[]
-): Record<string, string> {
-  if (!valuePath.length) return {};
-
-  return hierarchy.slice(0, valuePath.length).reduce(
-    (result, key, index) => ({
-      ...result,
-      [key]: valuePath[index],
-    }),
-    {}
-  );
-}
 </script>
 
 <style>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -307,7 +307,7 @@ export interface UploadWidgetContent extends WidgetContent {
 }
 
 export interface MultiSelectWidgetContent extends WidgetContent {
-  fieldContents: object;
+  fieldContents: Record<string, string | number>;
 }
 
 export interface DateComponent {


### PR DESCRIPTION
This addresses an issue where multiselect widget fieldContent keys were being saved with "spaces". The legacy data does not have spaces in keys.

We now normalize the keys to be alphanumeric with no spaces.

To properly test this, we extracted the `useCascadeSelect` logic into its own composable, and then create a separate `SimpleCascadeSelect` component using that composable. The existing `CascadeSelect` component, which is used by advanced search, is left unchange for now.

Internally, the new `useCascadeSelect` flattens the complex nested cascade options object for easier searching and filtering.