### PR TITLE
use vue router for error modal and error page navigation

### DIFF
--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -18,7 +18,7 @@
 
           <div class="mt-1">
             <!-- using href for force app reload -->
-            <Button :href="BASE_URL" variant="tertiary">Go Home</Button>
+            <Button :to="{ name: 'home' }" variant="tertiary">Go Home</Button>
           </div>
         </Notification>
       </div>

--- a/src/pages/ErrorPage/ErrorPage.vue
+++ b/src/pages/ErrorPage/ErrorPage.vue
@@ -4,7 +4,7 @@
       <h1 class="text-8xl font-bold text-neutral-200">{{ errorCode }}</h1>
       <h2 class="text-4xl mb-8">{{ getMessage(errorCode) }}</h2>
       <p class="my-4">{{ getDetailedMessage(errorCode) }}</p>
-      <Button :href="config.instance.base.url" icon="home" iconPosition="start">
+      <Button :to="{ name: 'home' }" icon="home" iconPosition="start">
         Go Home
       </Button>
     </div>
@@ -13,7 +13,6 @@
 <script setup lang="ts">
 import Button from "@/components/Button/Button.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
-import config from "@/config";
 import { usePageTitle } from "@/helpers/usePageTitle";
 
 const statusMessages = {


### PR DESCRIPTION
Updates the error modal and error page "Back to Home" buttons to use vue routing instead of reloading the page.