### PR TITLE
add `useAssetValidation` composable for centralized asset editor validation

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,6 +1,7 @@
 import { LngLat } from "@/types";
 import type { InjectionKey, ComputedRef } from "vue";
-import { type AssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
+import { useAssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
+import { useAssetValidationProvider } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation";
 
 export const UMN_LNGLAT: LngLat = {
   lat: 44.972109,
@@ -43,4 +44,11 @@ export const TEMPLATE_SHOW_PROPERTY_POSITIONS = {
 } as const;
 
 export const SAVE_RELATED_ASSET_TYPE = "SAVE_RELATED_ASSET_MESSAGE" as const;
-export const ASSET_EDITOR_PROVIDE_KEY = Symbol() as InjectionKey<AssetEditor>;
+
+export const ASSET_EDITOR_PROVIDE_KEY = Symbol() as InjectionKey<
+  ReturnType<typeof useAssetEditor>
+>;
+
+export const ASSET_VALIDATION_PROVIDE_KEY = Symbol() as InjectionKey<
+  ReturnType<typeof useAssetValidationProvider>
+>;

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation.ts
@@ -1,0 +1,356 @@
+import * as T from "@/types";
+import { hasWidgetContent } from "@/helpers/hasWidgetContent";
+import { isDateWidgetContent } from "@/types/guards";
+import {
+  computed,
+  ComputedRef,
+  inject,
+  MaybeRefOrGetter,
+  provide,
+  toValue,
+  ref,
+  watch,
+} from "vue";
+import { useDebounceFn } from "@vueuse/core";
+import { ASSET_VALIDATION_PROVIDE_KEY } from "@/constants/constants";
+import invariant from "tiny-invariant";
+
+interface WidgetValidation {
+  id: T.WidgetInstanceId;
+  label: T.WidgetDef["label"];
+  isRequired: T.WidgetDef["required"];
+  isEmpty: boolean;
+  isValid: boolean;
+  status: "valid" | "invalid" | "empty";
+  errors: ReturnType<typeof createErrorsObject>;
+}
+
+interface WidgetContentWithDef {
+  content: T.WithId<T.WidgetContent>[];
+  def: T.WidgetDef;
+}
+
+const createErrorsObject = () => {
+  const errors = new Map<string, Map<string, string[]>>();
+
+  const getItemErrors = (itemId: string) => {
+    return errors.get(itemId) || new Map<string, string[]>();
+  };
+
+  const getItemFieldErrors = (itemId: string, fieldName: string) => {
+    const itemErrors = errors.get(itemId);
+    return itemErrors?.get(fieldName) || [];
+  };
+
+  const clearItemFieldErrors = (itemId: string, fieldName: string) => {
+    const itemErrors = errors.get(itemId);
+    if (itemErrors) {
+      itemErrors.delete(fieldName);
+    }
+  };
+
+  const clearItemErrors = (itemId: string) => {
+    errors.delete(itemId);
+  };
+
+  const updateItemFieldErrors = (
+    itemId: string,
+    fieldName: string,
+    fieldErrors: string[]
+  ) => {
+    if (!errors.has(itemId)) {
+      errors.set(itemId, new Map<string, string[]>());
+    }
+    errors.get(itemId)!.set(fieldName, fieldErrors);
+  };
+
+  const hasItemErrors = (itemId: string) => {
+    const itemErrors = errors.get(itemId);
+    if (!itemErrors) return false;
+
+    for (const fieldErrors of itemErrors.values()) {
+      if (fieldErrors.length > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const addItemFieldError = (
+    itemId: string,
+    fieldname: string,
+    error: string
+  ) => {
+    const itemFieldErrors = getItemFieldErrors(itemId, fieldname);
+    updateItemFieldErrors(itemId, fieldname, [...itemFieldErrors, error]);
+  };
+
+  const hasItemFieldErrors = (itemId: string, fieldName: string) => {
+    const fieldErrors = getItemFieldErrors(itemId, fieldName);
+    return fieldErrors.length > 0;
+  };
+
+  const clearAll = () => {
+    errors.clear();
+  };
+
+  return {
+    getItemErrors,
+    getItemFieldErrors,
+    updateItemFieldErrors,
+    addItemFieldError,
+    clearItemErrors,
+    clearItemFieldErrors,
+    hasItemErrors,
+    hasItemFieldErrors,
+    clearAll,
+  };
+};
+
+// Validation functions
+function validateDateWidget({
+  content,
+  def: _def,
+}: WidgetContentWithDef): ReturnType<typeof createErrorsObject> {
+  const errors = createErrorsObject();
+
+  content.forEach((contentItem) => {
+    if (!isDateWidgetContent(contentItem)) {
+      const error = "Not a date widget.";
+      errors.addItemFieldError(contentItem.id, "global", error);
+      return;
+    }
+
+    const { start, end } = contentItem;
+    const hasStartText = !!start.text?.trim();
+    const isValidStart = hasStartText && start.numeric !== null;
+
+    if (hasStartText && !isValidStart) {
+      errors.addItemFieldError(contentItem.id, "start", "Invalid start date.");
+    }
+
+    const hasEndText = !!end.text?.trim();
+    const isValidEnd = !hasEndText || end.numeric !== null;
+    if (hasEndText && !isValidEnd) {
+      errors.addItemFieldError(contentItem.id, "end", "Invalid end date");
+    }
+
+    const isStartAfterEnd =
+      hasStartText &&
+      hasEndText &&
+      isValidStart &&
+      isValidEnd &&
+      start.numeric &&
+      end.numeric &&
+      BigInt(start.numeric) > BigInt(end.numeric);
+
+    if (isStartAfterEnd) {
+      errors.addItemFieldError(
+        contentItem.id,
+        "end",
+        "End date must be after start date"
+      );
+    }
+  });
+
+  return errors;
+}
+
+function fallbackValidator({
+  content,
+  def,
+  getWidgetInstanceId,
+}: WidgetContentWithDef & {
+  getWidgetInstanceId: (id: number) => T.WidgetInstanceId;
+}) {
+  const errors = createErrorsObject();
+  const hasContent = hasWidgetContent(content, def.type);
+  const id = getWidgetInstanceId(def.widgetId);
+  if (!hasContent && def.required) {
+    errors.addItemFieldError(id, "global", `${def.label} fields required.`);
+  }
+  return errors;
+}
+
+function validateWidget({
+  content,
+  def,
+  getWidgetInstanceId,
+}: WidgetContentWithDef & {
+  getWidgetInstanceId: (id: number) => T.WidgetInstanceId;
+}) {
+  switch (def.type) {
+    case "date":
+      return validateDateWidget({ content, def });
+    default:
+      return fallbackValidator({ content, def, getWidgetInstanceId });
+  }
+}
+
+function isDateContentValid({ content, def }: WidgetContentWithDef) {
+  const errors = validateDateWidget({ content, def });
+
+  // Check if any content item has errors
+  for (const contentItem of content) {
+    if (errors.hasItemErrors(contentItem.id)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isWidgetValid({ content, def }: WidgetContentWithDef): boolean {
+  switch (def.type) {
+    case "date":
+      return isDateContentValid({ content, def });
+    case "checkbox":
+      return true; // unchecked OR checked is valid
+    default:
+      return hasWidgetContent(content, def.type);
+  }
+}
+
+/**
+ * Creates validation for a single widget
+ */
+function createWidgetValidation(
+  widgetData: WidgetContentWithDef,
+  getWidgetInstanceId: (id: number) => T.WidgetInstanceId
+): WidgetValidation {
+  const { content, def } = widgetData;
+  const errors = validateWidget({ content, def, getWidgetInstanceId });
+  const isValid = isWidgetValid({ content, def });
+  const isEmpty = !hasWidgetContent(content, def.type);
+  const status = isValid ? "valid" : isEmpty ? "empty" : "invalid";
+
+  return {
+    id: getWidgetInstanceId(def.widgetId),
+    label: def.label,
+    isRequired: def.required,
+    isEmpty,
+    isValid,
+    status,
+    errors,
+  };
+}
+
+/**
+ * Simple asset validation provider
+ */
+export function useAssetValidationProvider(
+  assetRefOrGetter: MaybeRefOrGetter<T.Asset | T.UnsavedAsset | null>,
+  templateRefOrGetter: MaybeRefOrGetter<T.Template | null>,
+  getWidgetInstanceId: (widgetId: T.WidgetDef["widgetId"]) => T.WidgetInstanceId
+): {
+  widgetValidations: ComputedRef<WidgetValidation[]>;
+  widgetIdsWithContent: ComputedRef<T.WidgetDef["widgetId"][]>;
+  isBlank: ComputedRef<boolean>;
+  isAssetValid: ComputedRef<boolean>;
+  missingRequiredFields: ComputedRef<string[]>;
+  invalidFields: ComputedRef<string[]>;
+} {
+  const asset = computed(() => toValue(assetRefOrGetter));
+  const template = computed(() => toValue(templateRefOrGetter));
+  const widgetDefs = computed(() => template.value?.widgetArray ?? []);
+
+  // storing validation results as ref instead of
+  // computed so that we can debounce
+  const validationResults = ref<WidgetValidation[]>([]);
+
+  const computeValidations = () => {
+    const results: WidgetValidation[] = [];
+
+    widgetDefs.value.forEach((def) => {
+      const content =
+        (asset.value?.[def.fieldTitle] as T.WithId<T.WidgetContent>[]) || [];
+      const validation = createWidgetValidation(
+        { content, def },
+        getWidgetInstanceId
+      );
+      results.push(validation);
+    });
+
+    validationResults.value = results;
+  };
+
+  // Debounce validation computation to reduce excessive recalculation during rapid typing
+  const debouncedComputeValidations = useDebounceFn(computeValidations, 100);
+
+  // Watch for changes and trigger debounced validation
+  watch(
+    [asset, widgetDefs],
+    () => {
+      debouncedComputeValidations();
+    },
+    { deep: true }
+  );
+
+  // Run initial validation immediately
+  computeValidations();
+
+  // Return computed that just returns the current results
+  const widgetValidations = computed(() => validationResults.value);
+
+  const widgetIdsWithContent = computed((): T.WidgetDef["widgetId"][] => {
+    if (!template.value || !asset.value) return [];
+
+    return template.value.widgetArray
+      .filter((widgetDef) => {
+        const widgetContents = (asset.value?.[widgetDef.fieldTitle] ??
+          []) as T.WithId<T.WidgetContent>[];
+        return hasWidgetContent(widgetContents, widgetDef.type);
+      })
+      .map((widgetDef) => widgetDef.widgetId);
+  });
+
+  const isBlank = computed((): boolean => {
+    if (!asset.value || !template.value) return true;
+    return widgetIdsWithContent.value.length === 0;
+  });
+
+  const isAssetValid = computed(() => {
+    return widgetValidations.value.every(
+      (validation) => !validation.isRequired || validation.isValid
+    );
+  });
+
+  const missingRequiredFields = computed(() => {
+    return widgetValidations.value
+      .filter((validation) => validation.isRequired && validation.isEmpty)
+      .map((validation) => validation.label);
+  });
+
+  const invalidFields = computed(() => {
+    return widgetValidations.value
+      .filter((validation) => !validation.isEmpty && !validation.isValid)
+      .map((validation) => validation.label);
+  });
+
+  provide(ASSET_VALIDATION_PROVIDE_KEY, {
+    widgetValidations,
+    widgetIdsWithContent,
+    isBlank,
+    isAssetValid,
+    missingRequiredFields,
+    invalidFields,
+  });
+
+  return {
+    widgetValidations,
+    widgetIdsWithContent,
+    isBlank,
+    isAssetValid,
+    missingRequiredFields,
+    invalidFields,
+  };
+}
+
+export function useAssetValidation() {
+  const assetValidation = inject(ASSET_VALIDATION_PROVIDE_KEY);
+  invariant(
+    assetValidation,
+    "useAssetValidation must be used within a component (or parent) that calls useAssetValidationProvider"
+  );
+  return assetValidation;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,6 @@ import {
 } from "@/constants/constants";
 import { AxiosRequestConfig } from "axios";
 import { CascaderSelectOptions } from "@/components/CascadeSelect/CascadeSelect.vue";
-import { AssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
 
 export * from "./TimelineJSTypes";
 
@@ -987,5 +986,18 @@ export interface ApiAssetSubmissionResponse {
 // multiple inline editors on the same page may have the same widget id
 // so we need to make a unique id for this instance or we could wind up
 // with shared state between instances
-export type WidgetInstanceId =
-  `${AssetEditor["editorId"]}-${WidgetDef["widgetId"]}`;
+type AssetEditorId = string;
+export type WidgetInstanceId = `${AssetEditorId}-${WidgetDef["widgetId"]}`;
+
+export interface WidgetValidationState {
+  isValid: boolean;
+  errors: string[];
+}
+
+export interface TocItem {
+  id: string;
+  label: string;
+  isRequired?: boolean;
+  hasContent?: boolean;
+  isValid?: boolean;
+}


### PR DESCRIPTION
- Create useAssetValidation composable with debounced validation.

This is part of a series of PRs, which refactor asset validation. 

This is a stage-setting PR, with no intended change to functionality.

## Background

Asset editor validation state is needed in several places throughout the create/edit pages:
- Save button: to determine if an asset is savable and which error messages to show.
- Sidebar Table of Contents: to show iconography about widget validation state
- widget container component: again, to show iconography about widget validation state
- widget content item: individual field errors

Currently, we check for missing required fields and if content is blank or not. But, some components have more nuanced validation, like (dates need to be valid and end dates need to be after start dates). 

The `useAssetEditor` composable is already has sprawling responsibilities, and some of the validation checks were done within individual components. This led to inconsistencies in validation state. For example, a widget item might have an invalid end date and show and error message within the component (which is correct), meanwhile the widget container and table of contents would show a green check (incorrect), meanwhile the save button would be disabled and show the error messages (correct).

This PR consolidates the asset validation business logic in a single composable, which can be consumed by component children that need this info.

## Details

- `useAssetValidationProvider()`: provides validation information to child components. This only needs to be used in the parent.
- `useAssetValidation()`: for accessing widget validation and related computed variables.

A widget validation has this shape:
```ts
interface WidgetValidation {
  id: WidgetInstanceId; 
  label: WidgetDef["label"];
  isRequired: WidgetDef["required"];
  isEmpty: boolean; // does the widget have ANY fields with content?
  isValid: boolean; // are all fields valid (saveable)
  status: "valid" | "invalid" | "empty";
  errors: ErrorsObject; // for getting errors by itemId and fieldName 
}
```
Debouncing is added to the validation checks.

