### PR TITLE
validate start and end dates in date widget (stacked on #348)

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,6 +1,7 @@
 import { LngLat } from "@/types";
 import type { InjectionKey, ComputedRef } from "vue";
-import { type AssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
+import { useAssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
+import { useAssetValidationProvider } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation";
 
 export const UMN_LNGLAT: LngLat = {
   lat: 44.972109,
@@ -43,4 +44,11 @@ export const TEMPLATE_SHOW_PROPERTY_POSITIONS = {
 } as const;
 
 export const SAVE_RELATED_ASSET_TYPE = "SAVE_RELATED_ASSET_MESSAGE" as const;
-export const ASSET_EDITOR_PROVIDE_KEY = Symbol() as InjectionKey<AssetEditor>;
+
+export const ASSET_EDITOR_PROVIDE_KEY = Symbol() as InjectionKey<
+  ReturnType<typeof useAssetEditor>
+>;
+
+export const ASSET_VALIDATION_PROVIDE_KEY = Symbol() as InjectionKey<
+  ReturnType<typeof useAssetValidationProvider>
+>;

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -121,6 +121,7 @@ import { fetchTemplateComparison } from "@/api/fetchers";
 import { isEmpty } from "ramda";
 import { ASSET_EDITOR_PROVIDE_KEY } from "@/constants/constants";
 import { useToastStore } from "@/stores/toastStore";
+import { useAssetValidationProvider } from "./useAssetEditor/useAssetValidation";
 
 const props = withDefaults(
   defineProps<{
@@ -135,6 +136,13 @@ const props = withDefaults(
 
 // Use the asset editor composable
 const assetEditor = useAssetEditor();
+
+useAssetValidationProvider(
+  () => assetEditor.localAsset,
+  () => assetEditor.template,
+  assetEditor.getWidgetInstanceId
+);
+
 const toastStore = useToastStore();
 
 watch(

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditDateWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditDateWidget.vue
@@ -33,6 +33,7 @@
     <template #fieldContents="{ item }">
       <EditDateWidgetContentItem
         :modelValue="(item as Type.WithId<Type.DateWidgetContent>)"
+        :widgetDef="widgetDef"
         @update:modelValue="handleItemUpdate" />
     </template>
   </EditWidgetLayout>

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation.test.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation.test.ts
@@ -1,0 +1,454 @@
+import { describe, it, expect, vi } from "vitest";
+import { ref, nextTick } from "vue";
+import { useAssetValidationProvider } from "./useAssetValidation";
+import type { 
+  UnsavedAsset, 
+  Template, 
+  WidgetDef, 
+  PHPDateTime, 
+  WidgetInstanceId,
+  TextWidgetContent,
+  DateWidgetContent
+} from "@/types";
+
+// Mock the hasWidgetContent function
+vi.mock("@/helpers/hasWidgetContent", () => ({
+  hasWidgetContent: vi.fn((content: unknown[], widgetType: string) => {
+    if (widgetType === "text") {
+      return content.some((item) => {
+        const textItem = item as TextWidgetContent;
+        return textItem.fieldContents && textItem.fieldContents.trim() !== "";
+      });
+    }
+    if (widgetType === "date") {
+      return content.some((item) => {
+        const dateItem = item as DateWidgetContent;
+        return (
+          (dateItem.start?.text && dateItem.start.text.trim() !== "") ||
+          (dateItem.end?.text && dateItem.end.text.trim() !== "") ||
+          (dateItem.label && dateItem.label.trim() !== "")
+        );
+      });
+    }
+    return content.length > 0;
+  }),
+}));
+
+// Mock the date widget content guard
+vi.mock("@/types/guards", () => ({
+  isDateWidgetContent: vi.fn((content: unknown) => {
+    return (
+      content &&
+      typeof content === "object" &&
+      content !== null &&
+      "start" in content &&
+      "end" in content
+    );
+  }),
+}));
+
+const createMockPHPDateTime = (): PHPDateTime => ({
+  date: "2025-01-01 00:00:00.000000",
+  timezone: "UTC",
+  timezone_type: 3,
+});
+
+const createMockAsset = (
+  fieldData: Record<string, unknown> = {}
+): UnsavedAsset => ({
+  assetId: null,
+  templateId: 1,
+  readyForDisplay: false,
+  collectionId: 1,
+  availableAfter: null,
+  modified: createMockPHPDateTime(),
+  modifiedBy: 1,
+  createdBy: 1,
+  deletedBy: null,
+  relatedAssetCache: null,
+  ...fieldData,
+});
+
+const createMockTemplate = (widgets: Partial<WidgetDef>[] = []): Template => ({
+  templateId: 1,
+  templateName: "Test Template",
+  showCollection: false,
+  showTemplate: false,
+  showCollectionPosition: 1,
+  showTemplatePosition: 1,
+  widgetArray: widgets.map((widget, index) => ({
+    widgetId: index + 1,
+    type: "text" as const,
+    allowMultiple: false,
+    attemptAutocomplete: false,
+    fieldTitle: `field_${index + 1}`,
+    label: `Field ${index + 1}`,
+    tooltip: "",
+    fieldData: [],
+    display: true,
+    displayInPreview: false,
+    required: false,
+    searchable: false,
+    directSearch: false,
+    clickToSearch: false,
+    clickToSearchType: 1,
+    viewOrder: index + 1,
+    templateOrder: index + 1,
+    ...widget,
+  })) as WidgetDef[],
+});
+
+const mockGetWidgetInstanceId = (widgetId: number): WidgetInstanceId =>
+  `test-editor-${widgetId}` as WidgetInstanceId;
+
+describe("useAssetValidation", () => {
+  it("should validate empty text widget as empty", async () => {
+    const asset = ref(
+      createMockAsset({
+        field_1: [],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "field_1",
+          type: "text",
+          label: "Text Field",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    expect(widgetValidations.value).toHaveLength(1);
+    expect(widgetValidations.value[0]).toMatchObject({
+      id: mockGetWidgetInstanceId(1),
+      label: "Text Field",
+      isRequired: false,
+      isEmpty: true,
+      isValid: false,
+      status: "empty",
+    });
+  });
+
+  it("should validate text widget with content as valid", async () => {
+    const asset = ref(
+      createMockAsset({
+        field_1: [{ id: "1", fieldContents: "Hello World" }],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "field_1",
+          type: "text",
+          label: "Text Field",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    expect(widgetValidations.value[0]).toMatchObject({
+      isEmpty: false,
+      isValid: true,
+      status: "valid",
+    });
+  });
+
+  it("should validate required empty widget as invalid", async () => {
+    const asset = ref(
+      createMockAsset({
+        field_1: [],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "field_1",
+          type: "text",
+          label: "Required Field",
+          required: true,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    expect(widgetValidations.value[0]).toMatchObject({
+      isRequired: true,
+      isEmpty: true,
+      isValid: false,
+      status: "empty",
+    });
+  });
+
+  it("should validate date widget with valid dates", async () => {
+    const asset = ref(
+      createMockAsset({
+        date_field_1: [
+          {
+            id: "1",
+            label: "Test Date",
+            start: { text: "2024-01-01", numeric: "1704067200" },
+            end: { text: "2024-01-02", numeric: "1704153600" },
+          },
+        ],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "date_field_1",
+          type: "date",
+          label: "Date Field",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    expect(widgetValidations.value[0]).toMatchObject({
+      isEmpty: false,
+      isValid: true,
+      status: "valid",
+    });
+  });
+
+  it("should validate date widget with invalid date range", async () => {
+    const asset = ref(
+      createMockAsset({
+        date_field_1: [
+          {
+            id: "1",
+            label: "Test Date",
+            start: { text: "2024-01-02", numeric: "1704153600" },
+            end: { text: "2024-01-01", numeric: "1704067200" },
+          },
+        ],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "date_field_1",
+          type: "date",
+          label: "Date Field",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    expect(widgetValidations.value[0]).toMatchObject({
+      isEmpty: false,
+      isValid: false,
+      status: "invalid",
+    });
+
+    // Check that there are date range errors
+    const validation = widgetValidations.value[0];
+    const endErrors = validation.errors.getItemFieldErrors("1", "end");
+    expect(endErrors).toContain("End date must be after start date");
+  });
+
+  it("should only revalidate changed widgets for performance", async () => {
+    const asset = ref(
+      createMockAsset({
+        field_1: [{ id: "1", fieldContents: "Text 1" }],
+        field_2: [{ id: "2", fieldContents: "Text 2" }],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "field_1",
+          type: "text",
+          label: "Field 1",
+          required: false,
+        },
+        {
+          fieldTitle: "field_2",
+          type: "text",
+          label: "Field 2",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    // Initial validation
+    const initialValidations = [...widgetValidations.value];
+    expect(initialValidations).toHaveLength(2);
+
+    // Change only field_1
+    asset.value = createMockAsset({
+      field_1: [{ id: "1", fieldContents: "Changed Text 1" }],
+      field_2: [{ id: "2", fieldContents: "Text 2" }], // unchanged
+    });
+
+    await nextTick();
+
+    // Should have new validations
+    const newValidations = widgetValidations.value;
+    expect(newValidations).toHaveLength(2);
+
+    // Field 1 should be revalidated, Field 2 should use cached result
+    const widgetInstanceId1 = mockGetWidgetInstanceId(1);
+    const widgetInstanceId2 = mockGetWidgetInstanceId(2);
+    expect(newValidations.find((v) => v.id === widgetInstanceId1)?.id).toBe(
+      widgetInstanceId1
+    );
+    expect(newValidations.find((v) => v.id === widgetInstanceId2)?.id).toBe(
+      widgetInstanceId2
+    );
+  });
+
+  it("should debounce validation updates", async () => {
+    const asset = ref(
+      createMockAsset({
+        field_1: [{ id: "1", fieldContents: "initial" }],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "field_1",
+          type: "text",
+          label: "Text Field",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    // Initial validation
+    expect(widgetValidations.value[0].isValid).toBe(true);
+
+    // Make rapid changes - these should be debounced
+    asset.value = createMockAsset({
+      field_1: [{ id: "1", fieldContents: "change1" }],
+    });
+
+    asset.value = createMockAsset({
+      field_1: [{ id: "1", fieldContents: "change2" }],
+    });
+
+    asset.value = createMockAsset({
+      field_1: [{ id: "1", fieldContents: "final" }],
+    });
+
+    // Wait for debounced validation to complete
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    // Should have the final validation result
+    expect(widgetValidations.value[0].isValid).toBe(true);
+  });
+
+  it("should handle template changes", async () => {
+    const asset = ref(
+      createMockAsset({
+        field_1: [{ id: "1", fieldContents: "Text 1" }],
+        field_2: [{ id: "2", fieldContents: "Text 2" }],
+      })
+    );
+
+    const template = ref(
+      createMockTemplate([
+        {
+          fieldTitle: "field_1",
+          type: "text",
+          label: "Field 1",
+          required: false,
+        },
+        {
+          fieldTitle: "field_2",
+          type: "text",
+          label: "Field 2",
+          required: false,
+        },
+      ])
+    );
+
+    const { widgetValidations } = useAssetValidationProvider(
+      asset,
+      template,
+      mockGetWidgetInstanceId
+    );
+
+    await nextTick();
+
+    expect(widgetValidations.value).toHaveLength(2);
+
+    // Remove one widget from template
+    template.value = createMockTemplate([
+      {
+        fieldTitle: "field_1",
+        type: "text",
+        label: "Field 1",
+        required: false,
+      },
+    ]);
+
+    // Wait for debounced update
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    expect(widgetValidations.value).toHaveLength(1);
+    expect(widgetValidations.value[0].id).toBe(mockGetWidgetInstanceId(1));
+  });
+});

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation.ts
@@ -1,0 +1,356 @@
+import * as T from "@/types";
+import { hasWidgetContent } from "@/helpers/hasWidgetContent";
+import { isDateWidgetContent } from "@/types/guards";
+import {
+  computed,
+  ComputedRef,
+  inject,
+  MaybeRefOrGetter,
+  provide,
+  toValue,
+  ref,
+  watch,
+} from "vue";
+import { useDebounceFn } from "@vueuse/core";
+import { ASSET_VALIDATION_PROVIDE_KEY } from "@/constants/constants";
+import invariant from "tiny-invariant";
+
+interface WidgetValidation {
+  id: T.WidgetInstanceId;
+  label: T.WidgetDef["label"];
+  isRequired: T.WidgetDef["required"];
+  isEmpty: boolean;
+  isValid: boolean;
+  status: "valid" | "invalid" | "empty";
+  errors: ReturnType<typeof createErrorsObject>;
+}
+
+interface WidgetContentWithDef {
+  content: T.WithId<T.WidgetContent>[];
+  def: T.WidgetDef;
+}
+
+const createErrorsObject = () => {
+  const errors = new Map<string, Map<string, string[]>>();
+
+  const getItemErrors = (itemId: string) => {
+    return errors.get(itemId) || new Map<string, string[]>();
+  };
+
+  const getItemFieldErrors = (itemId: string, fieldName: string) => {
+    const itemErrors = errors.get(itemId);
+    return itemErrors?.get(fieldName) || [];
+  };
+
+  const clearItemFieldErrors = (itemId: string, fieldName: string) => {
+    const itemErrors = errors.get(itemId);
+    if (itemErrors) {
+      itemErrors.delete(fieldName);
+    }
+  };
+
+  const clearItemErrors = (itemId: string) => {
+    errors.delete(itemId);
+  };
+
+  const updateItemFieldErrors = (
+    itemId: string,
+    fieldName: string,
+    fieldErrors: string[]
+  ) => {
+    if (!errors.has(itemId)) {
+      errors.set(itemId, new Map<string, string[]>());
+    }
+    errors.get(itemId)!.set(fieldName, fieldErrors);
+  };
+
+  const hasItemErrors = (itemId: string) => {
+    const itemErrors = errors.get(itemId);
+    if (!itemErrors) return false;
+
+    for (const fieldErrors of itemErrors.values()) {
+      if (fieldErrors.length > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const addItemFieldError = (
+    itemId: string,
+    fieldname: string,
+    error: string
+  ) => {
+    const itemFieldErrors = getItemFieldErrors(itemId, fieldname);
+    updateItemFieldErrors(itemId, fieldname, [...itemFieldErrors, error]);
+  };
+
+  const hasItemFieldErrors = (itemId: string, fieldName: string) => {
+    const fieldErrors = getItemFieldErrors(itemId, fieldName);
+    return fieldErrors.length > 0;
+  };
+
+  const clearAll = () => {
+    errors.clear();
+  };
+
+  return {
+    getItemErrors,
+    getItemFieldErrors,
+    updateItemFieldErrors,
+    addItemFieldError,
+    clearItemErrors,
+    clearItemFieldErrors,
+    hasItemErrors,
+    hasItemFieldErrors,
+    clearAll,
+  };
+};
+
+// Validation functions
+function validateDateWidget({
+  content,
+  def: _def,
+}: WidgetContentWithDef): ReturnType<typeof createErrorsObject> {
+  const errors = createErrorsObject();
+
+  content.forEach((contentItem) => {
+    if (!isDateWidgetContent(contentItem)) {
+      const error = "Not a date widget.";
+      errors.addItemFieldError(contentItem.id, "global", error);
+      return;
+    }
+
+    const { start, end } = contentItem;
+    const hasStartText = !!start.text?.trim();
+    const isValidStart = hasStartText && start.numeric !== null;
+
+    if (hasStartText && !isValidStart) {
+      errors.addItemFieldError(contentItem.id, "start", "Invalid start date.");
+    }
+
+    const hasEndText = !!end.text?.trim();
+    const isValidEnd = !hasEndText || end.numeric !== null;
+    if (hasEndText && !isValidEnd) {
+      errors.addItemFieldError(contentItem.id, "end", "Invalid end date");
+    }
+
+    const isStartAfterEnd =
+      hasStartText &&
+      hasEndText &&
+      isValidStart &&
+      isValidEnd &&
+      start.numeric &&
+      end.numeric &&
+      BigInt(start.numeric) > BigInt(end.numeric);
+
+    if (isStartAfterEnd) {
+      errors.addItemFieldError(
+        contentItem.id,
+        "end",
+        "End date must be after start date"
+      );
+    }
+  });
+
+  return errors;
+}
+
+function fallbackValidator({
+  content,
+  def,
+  getWidgetInstanceId,
+}: WidgetContentWithDef & {
+  getWidgetInstanceId: (id: number) => T.WidgetInstanceId;
+}) {
+  const errors = createErrorsObject();
+  const hasContent = hasWidgetContent(content, def.type);
+  const id = getWidgetInstanceId(def.widgetId);
+  if (!hasContent && def.required) {
+    errors.addItemFieldError(id, "global", `${def.label} fields required.`);
+  }
+  return errors;
+}
+
+function validateWidget({
+  content,
+  def,
+  getWidgetInstanceId,
+}: WidgetContentWithDef & {
+  getWidgetInstanceId: (id: number) => T.WidgetInstanceId;
+}) {
+  switch (def.type) {
+    case "date":
+      return validateDateWidget({ content, def });
+    default:
+      return fallbackValidator({ content, def, getWidgetInstanceId });
+  }
+}
+
+function isDateContentValid({ content, def }: WidgetContentWithDef) {
+  const errors = validateDateWidget({ content, def });
+
+  // Check if any content item has errors
+  for (const contentItem of content) {
+    if (errors.hasItemErrors(contentItem.id)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isWidgetValid({ content, def }: WidgetContentWithDef): boolean {
+  switch (def.type) {
+    case "date":
+      return isDateContentValid({ content, def });
+    case "checkbox":
+      return true; // unchecked OR checked is valid
+    default:
+      return hasWidgetContent(content, def.type);
+  }
+}
+
+/**
+ * Creates validation for a single widget
+ */
+function createWidgetValidation(
+  widgetData: WidgetContentWithDef,
+  getWidgetInstanceId: (id: number) => T.WidgetInstanceId
+): WidgetValidation {
+  const { content, def } = widgetData;
+  const errors = validateWidget({ content, def, getWidgetInstanceId });
+  const isValid = isWidgetValid({ content, def });
+  const isEmpty = !hasWidgetContent(content, def.type);
+  const status = isValid ? "valid" : isEmpty ? "empty" : "invalid";
+
+  return {
+    id: getWidgetInstanceId(def.widgetId),
+    label: def.label,
+    isRequired: def.required,
+    isEmpty,
+    isValid,
+    status,
+    errors,
+  };
+}
+
+/**
+ * Simple asset validation provider
+ */
+export function useAssetValidationProvider(
+  assetRefOrGetter: MaybeRefOrGetter<T.Asset | T.UnsavedAsset | null>,
+  templateRefOrGetter: MaybeRefOrGetter<T.Template | null>,
+  getWidgetInstanceId: (widgetId: T.WidgetDef["widgetId"]) => T.WidgetInstanceId
+): {
+  widgetValidations: ComputedRef<WidgetValidation[]>;
+  widgetIdsWithContent: ComputedRef<T.WidgetDef["widgetId"][]>;
+  isBlank: ComputedRef<boolean>;
+  isAssetValid: ComputedRef<boolean>;
+  missingRequiredFields: ComputedRef<string[]>;
+  invalidFields: ComputedRef<string[]>;
+} {
+  const asset = computed(() => toValue(assetRefOrGetter));
+  const template = computed(() => toValue(templateRefOrGetter));
+  const widgetDefs = computed(() => template.value?.widgetArray ?? []);
+
+  // storing validation results as ref instead of
+  // computed so that we can debounce
+  const validationResults = ref<WidgetValidation[]>([]);
+
+  const computeValidations = () => {
+    const results: WidgetValidation[] = [];
+
+    widgetDefs.value.forEach((def) => {
+      const content =
+        (asset.value?.[def.fieldTitle] as T.WithId<T.WidgetContent>[]) || [];
+      const validation = createWidgetValidation(
+        { content, def },
+        getWidgetInstanceId
+      );
+      results.push(validation);
+    });
+
+    validationResults.value = results;
+  };
+
+  // Debounce validation computation to reduce excessive recalculation during rapid typing
+  const debouncedComputeValidations = useDebounceFn(computeValidations, 100);
+
+  // Watch for changes and trigger debounced validation
+  watch(
+    [asset, widgetDefs],
+    () => {
+      debouncedComputeValidations();
+    },
+    { deep: true }
+  );
+
+  // Run initial validation immediately
+  computeValidations();
+
+  // Return computed that just returns the current results
+  const widgetValidations = computed(() => validationResults.value);
+
+  const widgetIdsWithContent = computed((): T.WidgetDef["widgetId"][] => {
+    if (!template.value || !asset.value) return [];
+
+    return template.value.widgetArray
+      .filter((widgetDef) => {
+        const widgetContents = (asset.value?.[widgetDef.fieldTitle] ??
+          []) as T.WithId<T.WidgetContent>[];
+        return hasWidgetContent(widgetContents, widgetDef.type);
+      })
+      .map((widgetDef) => widgetDef.widgetId);
+  });
+
+  const isBlank = computed((): boolean => {
+    if (!asset.value || !template.value) return true;
+    return widgetIdsWithContent.value.length === 0;
+  });
+
+  const isAssetValid = computed(() => {
+    return widgetValidations.value.every(
+      (validation) => !validation.isRequired || validation.isValid
+    );
+  });
+
+  const missingRequiredFields = computed(() => {
+    return widgetValidations.value
+      .filter((validation) => validation.isRequired && validation.isEmpty)
+      .map((validation) => validation.label);
+  });
+
+  const invalidFields = computed(() => {
+    return widgetValidations.value
+      .filter((validation) => !validation.isEmpty && !validation.isValid)
+      .map((validation) => validation.label);
+  });
+
+  provide(ASSET_VALIDATION_PROVIDE_KEY, {
+    widgetValidations,
+    widgetIdsWithContent,
+    isBlank,
+    isAssetValid,
+    missingRequiredFields,
+    invalidFields,
+  });
+
+  return {
+    widgetValidations,
+    widgetIdsWithContent,
+    isBlank,
+    isAssetValid,
+    missingRequiredFields,
+    invalidFields,
+  };
+}
+
+export function useAssetValidation() {
+  const assetValidation = inject(ASSET_VALIDATION_PROVIDE_KEY);
+  invariant(
+    assetValidation,
+    "useAssetValidation must be used within a component (or parent) that calls useAssetValidationProvider"
+  );
+  return assetValidation;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,6 @@ import {
 } from "@/constants/constants";
 import { AxiosRequestConfig } from "axios";
 import { CascaderSelectOptions } from "@/components/CascadeSelect/CascadeSelect.vue";
-import { AssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
 
 export * from "./TimelineJSTypes";
 
@@ -987,5 +986,18 @@ export interface ApiAssetSubmissionResponse {
 // multiple inline editors on the same page may have the same widget id
 // so we need to make a unique id for this instance or we could wind up
 // with shared state between instances
-export type WidgetInstanceId =
-  `${AssetEditor["editorId"]}-${WidgetDef["widgetId"]}`;
+type AssetEditorId = string;
+export type WidgetInstanceId = `${AssetEditorId}-${WidgetDef["widgetId"]}`;
+
+export interface WidgetValidationState {
+  isValid: boolean;
+  errors: string[];
+}
+
+export interface TocItem {
+  id: string;
+  label: string;
+  isRequired?: boolean;
+  hasContent?: boolean;
+  isValid?: boolean;
+}


### PR DESCRIPTION
- updates the date widget and the widget container to use the `useAssetValidation`
- fixes an error when the DateWidgetContentItem is using a non-existent `range` prop.
- clears end date if user changes from `range` to `moment`.
