### PR TITLE
fix view related asset button href in asset editor

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditRelatedAssetWidget/EditRelatedAssetContentItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditRelatedAssetWidget/EditRelatedAssetContentItem.vue
@@ -94,7 +94,7 @@
         <Tooltip tip="View related asset">
           <Button
             variant="tertiary"
-            :to="`${BASE_URL}/asset/viewAsset/${modelValue.targetAssetId}`"
+            :href="`${BASE_URL}/asset/viewAsset/${modelValue.targetAssetId}`"
             target="_blank">
             <span class="sr-only">View</span>
             <ArrowRightIcon class="size-4" />


### PR DESCRIPTION
resolves an issue where clicking the view related asset button send the user to a broken url.