### PR TITLE
preserve scroll when saving assetEditor

### DIFF
--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -262,6 +262,9 @@ async function handleSaveAsset() {
       params: {
         assetId: savedAssetId,
       },
+      state: {
+        preserveScroll: true,
+      },
     });
   } catch (error) {
     invariant(error instanceof Error);

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,6 +16,10 @@ import LogoutPage from "./pages/LogoutPage/LogoutPage.vue";
 import ExcerptViewPage from "./pages/ExcerptViewPage/ExcerptViewPage.vue";
 import SearchResultsEmbedPage from "./pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue";
 
+interface RouterHistoryState {
+  preserveScroll?: boolean;
+}
+
 function parseIntFromParam(
   param: string | string[] | undefined
 ): number | null {
@@ -82,6 +86,15 @@ const router = createRouter({
 
     // if we're navigating to the same page, don't scroll
     if (to.path === from.path) return false;
+
+    // preserveScroll flag is set, don't scroll
+    const historyState = router.options.history.state as
+      | RouterHistoryState
+      | undefined;
+
+    if (historyState?.preserveScroll) {
+      return false;
+    }
 
     // otherwise scroll to the top of the page
     return {


### PR DESCRIPTION
Fixes an issue where the asset editor would scroll to top on upload.

Whenever a route changes with vue router, our app is set to scroll to top. 

When a new asset is created, once a file is uploaded, the asset will automatically be saved. This save changes routes from addAsset to editAsset, and thus would automatically scroll to top.

In this, we add `preserveScroll` property to `history.state`. Then, in the routing logic, we check history.state.preserveScroll. If truthy, we'll skip scrolling to top.

on dev