### PR TITLE
fix: delete asset option not showing on edit page

### DIFF
--- a/src/composables/usePageAssetId.ts
+++ b/src/composables/usePageAssetId.ts
@@ -1,0 +1,15 @@
+import { PAGE_ASSET_ID } from "@/constants/constants";
+import { Asset } from "@/types";
+import { computed, inject, MaybeRefOrGetter, toValue } from "vue";
+import { provide } from "vue";
+
+export const usePageAssetIdProvider = (
+  maybeAssetId: MaybeRefOrGetter<Asset["assetId"] | null>
+) => {
+  const assetId = computed(() => toValue(maybeAssetId));
+  provide(PAGE_ASSET_ID, assetId);
+};
+
+export const usePageAssetId = () => {
+  return inject(PAGE_ASSET_ID);
+};

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,4 +1,4 @@
-import { LngLat } from "@/types";
+import { Asset, LngLat } from "@/types";
 import type { InjectionKey, ComputedRef } from "vue";
 import { useAssetEditor } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor";
 import { useAssetValidationProvider } from "@/pages/CreateOrEditAssetPage/useAssetEditor/useAssetValidation";
@@ -51,4 +51,8 @@ export const ASSET_EDITOR_PROVIDE_KEY = Symbol() as InjectionKey<
 
 export const ASSET_VALIDATION_PROVIDE_KEY = Symbol() as InjectionKey<
   ReturnType<typeof useAssetValidationProvider>
+>;
+
+export const PAGE_ASSET_ID = Symbol() as InjectionKey<
+  ComputedRef<Asset["assetId"] | null>
 >;

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -121,6 +121,7 @@ import { isEmpty } from "ramda";
 import { ASSET_EDITOR_PROVIDE_KEY } from "@/constants/constants";
 import { useToastStore } from "@/stores/toastStore";
 import { useAssetValidationProvider } from "./useAssetEditor/useAssetValidation";
+import { usePageAssetIdProvider } from "@/composables/usePageAssetId";
 
 const props = withDefaults(
   defineProps<{
@@ -363,6 +364,8 @@ async function updateTemplateId() {
 // (e.g. with inline asset editing, we want to save the
 // inline asset before the parent saves)
 provide(ASSET_EDITOR_PROVIDE_KEY, assetEditor);
+
+usePageAssetIdProvider(() => props.assetId ?? null);
 
 onBeforeRouteUpdate(async (to, _from, next) => {
   if (to.fullPath !== "/assetManager/addAsset") {


### PR DESCRIPTION
This resolves an issue where the "Delete Asset" option was not showing up when the user was on the asset editor page since no assetId was being passed from the page.

Now, the assetId is provided from the page level with `usePageAssetIdProvider(), and injected into the component via `usePageAssetId()`. We use provide/inject to avoid multiple levels of prop passing (aka "prop drilling").

On dev.

<img width="500" alt="ScreenShot 2025-08-25 at 08 55 44@2x" src="https://github.com/user-attachments/assets/aae5d293-df22-49ed-91a7-c137e04355c8" />

