### PR TITLE
fix: related asset search scoping on CreateOrEditAssetPage

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -304,6 +304,35 @@ export async function fetchSearchResults(
   return res.data;
 }
 
+export async function fetchRelatedAssetSearchResults({
+  query,
+  templateIds = [],
+}: {
+  query: string;
+  templateIds?: number[];
+}): Promise<SearchResultsResponse> {
+  const formdata = new FormData();
+
+  // always suppress recent and show hidden for related assets
+  formdata.append("suppressRecent", String(true));
+  formdata.append("showHidden", String(true));
+  formdata.append(
+    "searchQuery",
+    JSON.stringify({
+      searchText: query,
+    })
+  );
+
+  templateIds.forEach((id) => formdata.append("templateId[]", String(id)));
+
+  const res = await axios.post<SearchResultsResponse>(
+    `${BASE_URL}/search/searchResults`,
+    formdata
+  );
+
+  return res.data;
+}
+
 export async function fetchSearchId(
   query: string,
   opts: Omit<SearchRequestOptions, "searchText"> = {}

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditRelatedAssetWidget/EditRelatedAssetContentItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditRelatedAssetWidget/EditRelatedAssetContentItem.vue
@@ -150,6 +150,7 @@ import Tooltip from "@/components/Tooltip/Tooltip.vue";
 import { isSaveRelatedAssetMessage } from "@/types/guards";
 import config from "@/config";
 import { ASSET_EDITOR_PROVIDE_KEY } from "@/constants/constants";
+import { useSearchRelatedAssetsQuery } from "@/queries/useSearchRelatedAssetsQuery";
 
 const props = defineProps<{
   modelValue: Type.WithId<Type.RelatedAssetWidgetContent>;
@@ -170,9 +171,14 @@ const debouncedSearchInput = useDebounce(searchInput, 300);
 
 const BASE_URL = config.instance.base.url;
 
-const { data: matches, isFetching } = useSearchAssetsQuery(
-  debouncedSearchInput
-);
+const matchAgainstTemplateIds = computed(() => {
+  return props.widgetDef.fieldData.matchAgainst ?? [];
+});
+
+const { data: matches, isFetching } = useSearchRelatedAssetsQuery({
+  query: debouncedSearchInput,
+  templateIds: matchAgainstTemplateIds,
+});
 
 // Show loading when user is typing or when query is fetching
 const isLoading = computed(() => {
@@ -243,6 +249,7 @@ function handleSelectItem(targetAssetId: string | null) {
     targetAssetId,
   });
 }
+
 const broadcastChannel = new BroadcastChannel(channelName.value);
 function handleMessageEvent(event: MessageEvent) {
   const message = event.data;

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -3,4 +3,5 @@ export const ASSETS_QUERY_KEY = "assets";
 export const TEMPLATES_QUERY_KEY = "templates";
 export const COLLECTIONS_QUERY_KEY = "collections";
 export const SEARCH_QUERY_ID = "search";
+export const RELATED_ASSETS_SEARCH_QUERY_ID = "relatedAssets";
 export const FILE_METADATA_QUERY_KEY = "fileMetadata";

--- a/src/queries/useSearchRelatedAssetsQuery.ts
+++ b/src/queries/useSearchRelatedAssetsQuery.ts
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import { RELATED_ASSETS_SEARCH_QUERY_ID } from "./queryKeys";
+import { SearchResultMatch } from "@/types";
+
+export function useSearchRelatedAssetsQuery(
+  {
+    query = "",
+    templateIds = [],
+  }: {
+    query: MaybeRefOrGetter<string>;
+    templateIds?: MaybeRefOrGetter<number[]>;
+  },
+  options = {}
+) {
+  // convert the query to a ref to ensure reactivity
+  const queryRef = computed(() => toValue(query).trim());
+  const templateIdsRef = computed(() => toValue(templateIds));
+
+  return useQuery({
+    queryKey: [RELATED_ASSETS_SEARCH_QUERY_ID, templateIdsRef, queryRef],
+    initialData: [],
+    queryFn: async (): Promise<SearchResultMatch[]> => {
+      const query = queryRef.value;
+      const templateIds = templateIdsRef.value;
+
+      if (!query) {
+        return [];
+      }
+
+      const searchResult = await fetchers.fetchRelatedAssetSearchResults({
+        query,
+        templateIds,
+      });
+
+      return searchResult?.matches ?? [];
+    },
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}


### PR DESCRIPTION
This fixes an issue where related asset search was not using `matchAgainst` in the widget definition to scope the research to particular templates.