### PR TITLE
fix z-index conflicts between uppy and error modal

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -226,6 +226,8 @@ uppy.on("error", (error) => {
 <style>
 .file-uploader {
   & .uppy-Dashboard-inner {
+    /* prevent uppy z-index conflicts with our modals */
+    isolation: isolate;
     border: 0;
   }
   & .uppy-Dashboard-dropFilesHereHint {


### PR DESCRIPTION
Some of uppy's z-indices are inconsistent and interfere with our modal z-indices during errors. 

This PR creates a new stacking context, so that uppy's z-index doesn't trump our ui z-index.

Before:
<img width="400" alt="ScreenShot 2025-08-25 at 13 55 41@2x" src="https://github.com/user-attachments/assets/46b70dd7-de5b-42fc-8296-933912b3f1f6" />

After
<img width="400" alt="ScreenShot 2025-08-25 at 14 06 06@2x" src="https://github.com/user-attachments/assets/338f9ed4-4c9b-43dc-929a-d927f5bb636f" />

