### PR TITLE
check if user is authed and can access add/edit asset page

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -12,8 +12,9 @@
 
       <!-- Not Authorized -->
       <div v-else-if="!canAccess" class="p-8">
-        <h1 class="text-4xl font-bold mb-4">Access Denied</h1>
-        <p class="mb-4">You do not have permission to view this page.</p>
+        <h1 class="text-8xl font-bold text-neutral-300">403</h1>
+        <h2 class="text-4xl mb-8">Forbidden</h2>
+        <p class="my-4">You do not have permission to view this page.</p>
         <Button :to="{ name: 'home' }" icon="home" iconPosition="start">
           Go Home
         </Button>

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,6 +15,14 @@ import { useErrorStore } from "./stores/errorStore";
 import LogoutPage from "./pages/LogoutPage/LogoutPage.vue";
 import ExcerptViewPage from "./pages/ExcerptViewPage/ExcerptViewPage.vue";
 import SearchResultsEmbedPage from "./pages/SearchResultsEmbedPage/SearchResultsEmbedPage.vue";
+import { User } from "./types";
+
+declare module "vue-router" {
+  interface RouteMeta {
+    requiresAuth?: boolean;
+    canAccess?: (user: User) => boolean;
+  }
+}
 
 interface RouterHistoryState {
   preserveScroll?: boolean;
@@ -128,6 +136,10 @@ const router = createRouter({
       path: "/assetManager/userAssets",
       component: () =>
         import("@/pages/AllUserAssetsPage/AllUserAssetsPage.vue"),
+      meta: {
+        requiresAuth: true,
+        canAccess: (user: User) => user.canManageAssets,
+      },
     },
     {
       name: "addInlineRelatedAsset",
@@ -139,6 +151,10 @@ const router = createRouter({
         // could be null
         collectionId: parseIntFromParam(route.params.collectionId),
       }),
+      meta: {
+        requiresAuth: true,
+        canAccess: (user: User) => user.canManageAssets,
+      },
     },
     {
       name: "editInlineRelatedAsset",
@@ -148,6 +164,10 @@ const router = createRouter({
       props: (route) => ({
         assetId: route.params.assetId,
       }),
+      meta: {
+        requiresAuth: true,
+        canAccess: (user: User) => user.canManageAssets,
+      },
     },
     {
       name: "editAsset",
@@ -159,6 +179,10 @@ const router = createRouter({
         assetId: route.params.assetId,
         title: route.params.assetId ? "Edit Asset" : "Add Asset",
       }),
+      meta: {
+        requiresAuth: true,
+        canAccess: (user: User) => user.canManageAssets,
+      },
     },
     {
       name: "listCollections",


### PR DESCRIPTION
This resolves an issue where an unauthenticated user could land on the Add Asset Page, and not be prompted to login.

Adds `requiresAuth` and `canAccess` to `route.meta` information. When these are properties are set, the `<DefaultLayout />` will check that the user is:

1. Authenticated. If not, they'll see a notification to Login; 
2. Authorized, by evaluating `canAccess(currentUser)`. If not, the user will see a 403 message.

<p><img width="600" alt="ScreenShot 2025-08-26 at 05 29 37@2x" src="https://github.com/user-attachments/assets/afe958ac-6b67-493b-9f42-856ec5413ee3" /></p>


<p><img width="600"  alt="ScreenShot 2025-08-26 at 05 29 14@2x" src="https://github.com/user-attachments/assets/b23e57c9-79f5-43e9-9082-2cde0893da78" /></p>
