### PR TITLE
fix: usePageAssetId warning when not on asset page

### DIFF
--- a/src/composables/usePageAssetId.ts
+++ b/src/composables/usePageAssetId.ts
@@ -11,5 +11,5 @@ export const usePageAssetIdProvider = (
 };
 
 export const usePageAssetId = () => {
-  return inject(PAGE_ASSET_ID);
+  return inject(PAGE_ASSET_ID, null);
 };


### PR DESCRIPTION
The app menu will try to get the page assetId with `usePageAssetId`. This won't exist if we're not on an asset view/edit page, so a warning will be printed to the console.

This silences the error by returning a default `null` if there's not pageAssetId provider.