### PR TITLE
fix: safari date input placeholder shows current date instead of mm/dd/yyyy

### DIFF
--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -25,6 +25,7 @@
             {
               'pl-10': $slots.prepend,
               'pr-10': $slots.append,
+              'input--is-blank': !model,
             },
             inputClass,
           ])
@@ -80,13 +81,13 @@ safari will show the current date if no value is set, even if a placeholder is s
 @supports (font: -apple-system-body) and (-webkit-appearance: none) {
   /* target date inputs without values that are not focused and make the text
   safari shows transparent */
-  input[type="date"]:not([value]):not(:focus) {
+  input[type="date"].input--is-blank:not(:focus) {
     color: transparent;
   }
   /* then use a pseudo element to show the placeholder text */
-  input[type="date"]:not([value]):not(:focus)::before {
+  input[type="date"].input--is-blank:not(:focus)::before {
     content: attr(placeholder);
-    color: #999;
+    color: var(--app-placeholderColor, #a3a3a3);
   }
 }
 </style>

--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -74,4 +74,19 @@ const model = defineModel<TModelValue>({
   required: true,
 });
 </script>
-<style scoped></style>
+<style scoped>
+/* hack to show placeholder text for safari date inputs.
+safari will show the current date if no value is set, even if a placeholder is set. */
+@supports (font: -apple-system-body) and (-webkit-appearance: none) {
+  /* target date inputs without values that are not focused and make the text
+  safari shows transparent */
+  input[type="date"]:not([value]):not(:focus) {
+    color: transparent;
+  }
+  /* then use a pseudo element to show the placeholder text */
+  input[type="date"]:not([value]):not(:focus)::before {
+    content: attr(placeholder);
+    color: #999;
+  }
+}
+</style>

--- a/src/css/themes/default.css
+++ b/src/css/themes/default.css
@@ -8,6 +8,7 @@
   --app-textColor: var(--color-neutral-900);
   --app-headingColor: var(--color-neutral-900);
   --app-backgroundColor: var(--color-neutral-100);
+  --app-placeholderColor: var(--color-neutral-400);
   --app-borderColor: var(--color-neutral-900);
   --app-borderWidth: 2px;
 

--- a/src/css/themes/folwell.css
+++ b/src/css/themes/folwell.css
@@ -20,6 +20,7 @@
 
   --app-fontFamily: "Open Sans", "Work Sans", "Helvetica Neue", sans-serif;
   --app-textColor: var(--color-zinc-900);
+  --app-placeholderColor: var(--color-zinc-400);
   --app-backgroundColor: var(--color-zinc-100);
   --app-borderColor: var(--color-zinc-300);
   --app-borderWidth: 2px;

--- a/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetFormSidebar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetFormSidebar.vue
@@ -85,6 +85,7 @@
         v-model="localAvailableAfterDate"
         label="Available After"
         type="date"
+        placeholder="mm / dd / yyyy"
         inputClass="text-sm pl-3"
         @update:modelValue="handleUpdateAvailableAfter" />
       <SelectGroup


### PR DESCRIPTION
Safari's date input placeholder is confusing. It looks like the current date is set, when it's the placeholder.

Chrome and Firefox show `mm / dd / yyyy` so this is a CSS hack to mimic that behavior. Which, I guess, could be confusing to those expecting `dd / mm / yyyy`... so lmk if a different placeholder makes better sense.

On dev.

Fixes #374

Behavior in safari 26. No promises for older versions:
https://github.com/user-attachments/assets/c286dc34-0cba-4fa1-9b49-6fb9c5041260

