### PR TITLE
update upload widget in asset editor with download link

### DIFF
--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -2,7 +2,7 @@
   <div class="input-group">
     <label
       :for="id"
-      class="block text-xs font-medium text-neutral-700 uppercase mb-1"
+      class="block text-xs font-medium uppercase mb-1"
       :class="[{ 'sr-only': labelHidden }, labelClass]">
       {{ label }}
       <span v-if="required" class="text-red-600">*</span>
@@ -76,6 +76,10 @@ const model = defineModel<TModelValue>({
 });
 </script>
 <style scoped>
+.input-group label {
+  color: var(--app-input-label-textColor, var(--color-neutral-900));
+}
+
 /* hack to show placeholder text for safari date inputs.
 safari will show the current date if no value is set, even if a placeholder is set. */
 @supports (font: -apple-system-body) and (-webkit-appearance: none) {

--- a/src/components/Tuple/Tuple.vue
+++ b/src/components/Tuple/Tuple.vue
@@ -12,7 +12,7 @@
             cn(
               'text-xs block uppercase leading-none mb-1 tracking-wide',
               {
-                'font-bold': variant === 'stacked',
+                'font-medium': variant === 'stacked',
                 'sr-only': variant === 'value-only',
               },
               labelClass

--- a/src/css/themes/default.css
+++ b/src/css/themes/default.css
@@ -158,6 +158,9 @@
   --app-button-tertiary-disabled-backgroundColor: tranparent;
   --app-button-tertiary-disabled-textColor: var(--color-neutral-400);
 
+  /* Input */
+  --app-input-label-textColor: var(--color-neutral-900);
+
   /* Tuple */
   --app-tuple-label-textColor: var(--color-neutral-900);
   --app-tuple-value-textColor: var(--color-neutral-700);

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -379,4 +379,8 @@ onBeforeRouteUpdate(async (to, _from, next) => {
   next();
 });
 </script>
-<style scoped></style>
+<style scoped>
+label {
+  color: var(--app-input-label-textColor, var(--color-neutral-900));
+}
+</style>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -40,10 +40,10 @@
         <Tuple
           label="Source File"
           class="flex items-center justify-between flex-wrap text-sm gap-2 -mt-2">
-          {{ fileMetadata?.sourcefile }}
+          {{ fileMetaData?.sourcefile }}
           <Button
-            v-if="fileMetadata?.sourcefile"
-            :href="fileMetadata?.sourcefile"
+            v-if="fileMetaData?.sourcefile"
+            :href="fileMetaData?.sourcefile"
             variant="tertiary"
             class="flex items-center gap-1 !no-underline text-xs uppercase font-medium"
             download>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -73,7 +73,7 @@
         <Tuple label="Location">
           <pre>{{ item.loc || "-" }}</pre>
         </Tuple>
-        <Tuple label="Search Data" class="text-sm text-neutral-600 mb-2">
+        <Tuple label="Search Data">
           <pre>{{ item.searchData || "-" }}</pre>
         </Tuple>
         <div class="flex justify-between gap-4 flex-wrap">

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="edit-upload-widget-item">
-    <div class="grid grid-cols-3 gap-4 mb-2">
+    <div class="grid grid-cols-3 gap-x-4 gap-y-3 mb-2">
       <div class="w-full aspect-square rounded-md overflow-hidden relative">
         <img
           v-if="item.fileId && previewImageUrl"
@@ -20,7 +20,7 @@
       <div class="col-span-2 flex flex-col gap-1">
         <label
           :for="`${item.id}-description`"
-          class="block text-xs font-medium text-neutral-700 uppercase">
+          class="block text-xs font-medium uppercase">
           Description / Alt Text
           <Tooltip
             tip="Used by screen readers to describe the content of the file.">
@@ -36,32 +36,47 @@
           class="bg-black/5 border-none rounded-md w-full text-sm font-mono flex-1 placeholder:text-neutral-400"
           @input="handleDescriptionUpdate" />
       </div>
+      <div class="col-span-3">
+        <Tuple
+          label="Source File"
+          class="flex items-center justify-between flex-wrap text-sm gap-2 -mt-2">
+          {{ fileMetadata?.sourcefile }}
+          <Button
+            v-if="fileMetadata?.sourcefile"
+            :href="fileMetadata?.sourcefile"
+            variant="tertiary"
+            class="flex items-center gap-1 !no-underline text-xs uppercase font-medium"
+            download>
+            <DownloadIcon class="!size-4" />
+            Download
+          </Button>
+        </Tuple>
+      </div>
       <EditUploadWidgetItemSidecars
         class="col-span-3"
         :item="item"
         :widgetDef="widgetDef"
+        :fileMetaData="fileMetaData"
         @update:item="$emit('update:item', $event)" />
 
       <section
         v-if="isShowingDetails"
-        class="col-span-3 p-4 border border-black/15 rounded-md">
-        <h2 class="text-sm font-semibold text-neutral-800 mb-2">
-          File Details
-        </h2>
-        <Tuple label="File ID" class="text-sm text-neutral-600 mb-2">
+        class="col-span-3 py-3 border-y border-black/15 text-sm flex flex-col gap-2">
+        <h2 class="sr-only">File Details</h2>
+        <Tuple label="File ID">
           {{ item.fileId }}
         </Tuple>
-        <Tuple label="File Type" class="text-sm text-neutral-600 mb-2">
+        <Tuple label="File Type">
           {{ item.fileType }}
         </Tuple>
 
-        <Tuple label="Location" class="text-sm text-neutral-600 mb-2">
+        <Tuple label="Location">
           <pre>{{ item.loc || "-" }}</pre>
         </Tuple>
         <Tuple label="Search Data" class="text-sm text-neutral-600 mb-2">
           <pre>{{ item.searchData || "-" }}</pre>
         </Tuple>
-        <div class="flex flex-col gap-4 mt-2">
+        <div class="flex justify-between gap-4 flex-wrap">
           <label
             class="flex items-center gap-2 text-sm text-neutral-600 hover:text-neutral-900 transition-colors">
             <input
@@ -73,9 +88,11 @@
           </label>
           <Button
             :href="`${config.instance.base.url}/assetManager/processingLogsForAsset/${item.fileId}`"
+            variant="tertiary"
             target="_blank"
             class="text-sm !px-3 !py-2">
-            View Processing Logs
+            <FileCogIcon class="!size-4" />
+            View Logs
           </Button>
         </div>
       </section>
@@ -96,12 +113,17 @@
 import * as Type from "@/types";
 import config from "@/config";
 import Tooltip from "@/components/Tooltip/Tooltip.vue";
-import { ChevronDownIcon, FileIcon } from "lucide-vue-next";
+import {
+  ChevronDownIcon,
+  FileCogIcon,
+  FileIcon,
+  DownloadIcon,
+} from "lucide-vue-next";
 import Tuple from "@/components/Tuple/Tuple.vue";
 import Button from "@/components/Button/Button.vue";
-import { SpinnerIcon } from "@/icons";
 import EditUploadWidgetItemSidecars from "./EditUploadWidgetItemSidecars.vue";
 import { usePreviewImage } from "@/helpers/usePreviewImage";
+import { useFileMetadataQuery } from "@/queries/useFileMetadataQuery";
 
 const props = defineProps<{
   item: Type.WithId<Type.UploadWidgetContent>;
@@ -116,6 +138,8 @@ const emit = defineEmits<{
 
 // Use the new preview image composable
 const { previewImageUrl } = usePreviewImage(() => props.item.fileId);
+
+const { data: fileMetaData } = useFileMetadataQuery(() => props.item.fileId);
 
 function handleDescriptionUpdate(event: Event) {
   const target = event.target as HTMLTextAreaElement;

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -43,7 +43,7 @@
           {{ fileMetaData?.sourcefile }}
           <Button
             v-if="fileMetaData?.sourcefile"
-            :href="fileMetaData?.sourcefile"
+            :href="`${config.instance.base.url}/fileManager/getOriginal/${item.fileId}`"
             variant="tertiary"
             class="flex items-center gap-1 !no-underline text-xs uppercase font-medium"
             download>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItemSidecars.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItemSidecars.vue
@@ -1,21 +1,16 @@
 <template>
   <div class="upload-widget-item-sidecars">
-    <!-- <h3 class="text-sm font-semibold text-neutral-800 mb-2">Sidecars</h3>
-    <p class="text-sm text-neutral-600 mb-2">
-      Sidecars are additional metadata or files associated with the main file.
-    </p> -->
     <component
       :is="sidecarComponent"
       v-if="sidecarComponent"
       :sidecars="item.sidecars"
       :widgetDef="widgetDef"
-      :fileMetaData="fileMetadata"
+      :fileMetaData="fileMetaData"
       @update:sidecars="$emit('update:item', { ...item, sidecars: $event })" />
   </div>
 </template>
 <script setup lang="ts">
 import * as Type from "@/types";
-import { useFileMetadataQuery } from "@/queries/useFileMetadataQuery";
 import { PartialRecord } from "ramda";
 import { type Component, computed } from "vue";
 import ImageHandlerSidecar from "./Sidecars/ImageHandlerSidecar.vue";
@@ -24,29 +19,21 @@ import MovieHandlerSidecar from "./Sidecars/MovieHandlerSidecar.vue";
 import ObjHandlerSidecar from "./Sidecars/ObjHandlerSidecar.vue";
 import PlyHandlerSidecar from "./Sidecars/PlyHandlerSidecar.vue";
 import ZipObjHandlerSidecar from "./Sidecars/ZipObjHandlerSidecar.vue";
+import { FileMetaData } from "@/types/FileMetaDataTypes";
 
 const props = defineProps<{
   item: Type.WithId<Type.UploadWidgetContent>;
   widgetDef: Type.UploadWidgetDef;
+  fileMetaData?: FileMetaData;
 }>();
 
 defineEmits<{
   (e: "update:item", item: Type.WithId<Type.UploadWidgetContent>): void;
 }>();
 
-const { data: fileMetadata } = useFileMetadataQuery(() => props.item.fileId);
-
 const fileHandlerName = computed(
-  () => fileMetadata?.value?.handlerType?.toLowerCase() ?? null
+  () => props.fileMetaData?.handlerType?.toLowerCase() ?? null
 );
-
-type IsEnabledFn = ({
-  item,
-  widgetDef,
-}: {
-  item: Type.WithId<Type.UploadWidgetContent>;
-  widgetDef: Type.UploadWidgetDef;
-}) => boolean;
 
 type FileHandlerType =
   | "audiohandler"
@@ -77,38 +64,5 @@ const sidecarComponent = computed(() => {
   }
   return component;
 });
-
-// const sidecarRegistry: PartialRecord<FileHandlerType, Sidecar[]> = {
-//   imagehandler: [
-//     {
-//       name: "ppm",
-//       label: "Pixels per Millimeter",
-//       component: "input",
-//       placeholder: "Optional value",
-//       isEnabled: () => true,
-//     },
-//     {
-//       name: "iframe",
-//       label: "iframe url",
-//       component: "input",
-//       placeholder: "HTTPS highly recommended",
-//       isEnabled: ({ widgetDef }) => widgetDef.fieldData.enableIframe ?? false,
-//     },
-//     {
-//       name: "dendro",
-//       label: "Dendro Data",
-//       component: "input",
-//       placeholder: "",
-//       isEnabled: ({ widgetDef }) => widgetDef.fieldData.enableDendro ?? false,
-//     },
-//     {
-//       name: "svs",
-//       label: "SVS Data",
-//       component: "input",
-//       placeholder: "",
-//       isEnabled: ({ item, widgetDef }) => !!item.sidecars?.svs,
-//     },
-//   ],
-// };
 </script>
 <style scoped></style>


### PR DESCRIPTION
- add source file name and download button to upload widget in asset editor
- fixes inconsistencies between tuple label weights and input label weights

<img width="500"  alt="ScreenShot 2025-09-18 at 18 59 51@2x" src="https://github.com/user-attachments/assets/0eab441c-0b73-4614-9a14-55960baea46a" />


Also tweak styles in the expandable file details section to align. The "View Logs" button in file details now is similar to the new "Download" button.
<img width="500" alt="ScreenShot 2025-09-19 at 09 37 13@2x" src="https://github.com/user-attachments/assets/c92bd3f2-8bf1-41f0-aa83-a39924ec843a" />


On dev

Closes #371 
