### PR TITLE
fix: related asset view permission issue b/c of missing parent id

### DIFF
--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -19,7 +19,7 @@ import instanceRoutes from "./routes/instance";
 import s3Routes from "./routes/s3";
 import config from "./config";
 
-const app = new Hono<MockServerContext>();
+const app = new Hono<MockServerContext>({ strict: false });
 
 // Middleware
 app.use(

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -80,9 +80,10 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
   return Promise.reject(apiError);
 });
 
-export async function fetchAsset(assetId: string): Promise<Asset | null> {
+// parentAssetId is needed to properly resolve permissions for related assets
+export async function fetchAsset(assetId: string, parentAssetId = ''): Promise<Asset | null> {
   const res = await axios.get<Asset>(
-    `${BASE_URL}/asset/viewAsset/${assetId}/true`
+    `${BASE_URL}/asset/viewAsset/${assetId}/true/${parentAssetId}`
   );
   if (!res.data) {
     return null;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -56,19 +56,21 @@ export function clearCache() {
   cache = createCache();
 }
 
-async function getAsset(assetId: string): Promise<Asset | null> {
+// parentAssetId is needed to properly resolve permissions for related assets
+async function getAsset(assetId: string, parentAssetId = ''): Promise<Asset | null> {
   if (!assetId) return null;
 
   // load asset and cache it in the store
   const asset =
-    cache.assets.get(assetId) || (await fetchers.fetchAsset(assetId));
+    cache.assets.get(assetId) || (await fetchers.fetchAsset(assetId, parentAssetId));
   cache.assets.set(assetId, asset);
 
   return asset;
 }
 
 async function getAssetWithTemplate(
-  assetId: string | null
+  assetId: string | null,
+  parentAssetId = ''
 ): Promise<{ asset: Asset | null; template: Template | null }> {
   if (!assetId) {
     return { asset: null, template: null };
@@ -76,7 +78,7 @@ async function getAssetWithTemplate(
 
   // load asset and cache it in the store
   const asset =
-    cache.assets.get(assetId) || (await fetchers.fetchAsset(assetId));
+    cache.assets.get(assetId) || (await fetchers.fetchAsset(assetId, parentAssetId));
   cache.assets.set(assetId, asset);
 
   if (!asset) return { asset: null, template: null };

--- a/src/components/AssetDetailsPanel/AssetDetailsPanel.vue
+++ b/src/components/AssetDetailsPanel/AssetDetailsPanel.vue
@@ -71,10 +71,12 @@ const props = withDefaults(
     assetId: string | null;
     isOpen?: boolean;
     showToggle?: boolean;
+    parentAssetId?: string | null;
   }>(),
   {
     isOpen: true,
     showToggle: true,
+    parentAssetId: null,
   }
 );
 
@@ -83,7 +85,8 @@ defineEmits<{
 }>();
 
 const assetIdRef = computed(() => props.assetId);
-const { asset, template } = useAsset(assetIdRef);
+const parentAssetIdRef = computed(() => props.parentAssetId);
+const { asset, template } = useAsset(assetIdRef, parentAssetIdRef);
 const instanceStore = useInstanceStore();
 const moreLikeThisItems = ref<SearchResultMatch[]>([]);
 const showCollectionBottom = computed(

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -3,7 +3,7 @@
     <Transition name="fade">
       <div
         v-if="error"
-        class="fixed inset-0 z-40 bg-transparent-black-700 flex items-center justify-center">
+        class="bg-transparent-black-700 flex items-center justify-center">
         <SignInRequiredNotice v-if="isCurrentUserUnauthorized" />
 
         <Notification

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -3,7 +3,7 @@
     <Transition name="fade">
       <div
         v-if="error"
-        class="bg-transparent-black-700 flex items-center justify-center">
+        class="fixed inset-0 z-40 bg-transparent-black-700 flex items-center justify-center">
         <SignInRequiredNotice v-if="isCurrentUserUnauthorized" />
 
         <Notification

--- a/src/components/ObjectViewer/ObjectViewer.vue
+++ b/src/components/ObjectViewer/ObjectViewer.vue
@@ -4,7 +4,9 @@
     <iframe
       v-if="fileHandlerId"
       class="object-viewer__iframe w-full flex-1"
-      :src="`${config.instance.base.url}/asset/getEmbed/${fileHandlerId}`"
+      :src="`${config.instance.base.url}/asset/getEmbed/${fileHandlerId}/${
+        parentAssetId ?? ''
+      }`"
       frameBorder="0"
       allowfullscreen="true"></iframe>
     <div
@@ -21,6 +23,7 @@ import config from "@/config";
 
 defineProps<{
   fileHandlerId: string | null;
+  parentAssetId: string | null;
 }>();
 </script>
 <style scoped>

--- a/src/components/ObjectViewer/ObjectViewer.vue
+++ b/src/components/ObjectViewer/ObjectViewer.vue
@@ -21,10 +21,15 @@
 <script setup lang="ts">
 import config from "@/config";
 
-defineProps<{
-  fileHandlerId: string | null;
-  parentAssetId: string | null;
-}>();
+withDefaults(
+  defineProps<{
+    fileHandlerId: string | null;
+    parentAssetId?: string | null;
+  }>(),
+  {
+    parentAssetId: null,
+  }
+);
 </script>
 <style scoped>
 .object-viewer {

--- a/src/components/WidgetList/WidgetList.vue
+++ b/src/components/WidgetList/WidgetList.vue
@@ -27,7 +27,7 @@ const props = defineProps<{
 
 const assetStore = useAssetStore();
 const assetIdRef = computed(() => props.assetId);
-const parentAssetIdRef = computed(() => assetStore.activeAssetId);
+const parentAssetIdRef = computed((): string => assetStore.activeAssetId ?? "");
 const { asset, template } = useAsset(assetIdRef, parentAssetIdRef);
 const widgets = computed(() =>
   getWidgetsForDisplay({ asset: asset.value, template: template.value })

--- a/src/components/WidgetList/WidgetList.vue
+++ b/src/components/WidgetList/WidgetList.vue
@@ -19,13 +19,16 @@ import { getWidgetsForDisplay } from "@/helpers/displayUtils";
 
 import Widget from "@/components/Widget/Widget.vue";
 import { useAsset } from "@/helpers/useAsset";
+import { useAssetStore } from "@/stores/assetStore";
 
 const props = defineProps<{
   assetId: string;
 }>();
 
+const assetStore = useAssetStore();
 const assetIdRef = computed(() => props.assetId);
-const { asset, template } = useAsset(assetIdRef);
+const parentAssetIdRef = computed(() => assetStore.activeAssetId);
+const { asset, template } = useAsset(assetIdRef, parentAssetIdRef);
 const widgets = computed(() =>
   getWidgetsForDisplay({ asset: asset.value, template: template.value })
 );

--- a/src/helpers/useAsset.ts
+++ b/src/helpers/useAsset.ts
@@ -1,9 +1,12 @@
 import { Asset, Template } from "@/types";
-import { Ref, ref, watch, computed } from "vue";
+import { Ref, ref, watch, computed, MaybeRefOrGetter, toValue } from "vue";
 import api from "../api";
 import { getAssetTitle } from "./displayUtils";
 
-export function useAsset(assetIdRef: Ref<string | null>) {
+export function useAsset(
+  assetIdRef: Ref<string | null>,
+  parentAssetIdRef?: MaybeRefOrGetter<string | null>
+) {
   const assetRef = ref<Asset | null>(null);
   const templateRef = ref<Template | null>(null);
   const title = computed((): string =>
@@ -12,7 +15,8 @@ export function useAsset(assetIdRef: Ref<string | null>) {
 
   async function onAssetIdChange() {
     const { asset, template } = await api.getAssetWithTemplate(
-      assetIdRef.value
+      assetIdRef.value,
+      toValue(parentAssetIdRef) ?? ""
     );
     assetRef.value = asset;
     templateRef.value = template;

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -27,6 +27,7 @@
       }"
       :showToggle="permitPanelToggle"
       :assetId="assetStore.activeAssetId"
+      :parentAssetId="assetStore.activeAssetId"
       :isOpen="permitPanelToggle ? isAssetDetailsOpen : true"
       @toggle="isAssetDetailsOpen = !isAssetDetailsOpen" />
     <ObjectDetailsPanel

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -13,7 +13,8 @@
         'md:top-0 md:bottom-16 md:left-0 md:right-0':
           !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
       }"
-      :fileHandlerId="assetStore.activeFileObjectId" />
+      :fileHandlerId="assetStore.activeFileObjectId"
+      :parentAssetId="assetStore.activeAssetId" />
     <AssetDetailsPanel
       class="asset-view__asset-panel md:absolute"
       :class="{

--- a/src/stores/assetStore.ts
+++ b/src/stores/assetStore.ts
@@ -26,7 +26,8 @@ export const useAssetStore = defineStore("asset2", {
       assetId: string | null,
       objectId?: string | null
     ): Promise<Asset | null> {
-      const { asset } = await api.getAssetWithTemplate(assetId);
+      const parentAssetId = this.activeAssetId || "";
+      const { asset } = await api.getAssetWithTemplate(assetId, parentAssetId);
 
       if (!asset || !assetId) {
         this.activeAssetId = null;
@@ -59,7 +60,8 @@ export const useAssetStore = defineStore("asset2", {
      * @returns the active object
      */
     async setActiveObject(objectId: string | null): Promise<Asset | null> {
-      const { asset } = await api.getAssetWithTemplate(objectId);
+      const parentAssetId = this.activeAssetId || "";
+      const { asset } = await api.getAssetWithTemplate(objectId, parentAssetId);
 
       // if asset exists, set the objectId to active, otherwise null
       this.activeObjectId = asset ? objectId : null;
@@ -68,8 +70,10 @@ export const useAssetStore = defineStore("asset2", {
       return asset;
     },
 
+    // parentAssetId is needed to properly resolve permissions for related assets
     async getAsset(assetId: string): Promise<Asset | null> {
-      const { asset } = await api.getAssetWithTemplate(assetId);
+      const parentAssetId = this.activeAssetId || "";
+      const { asset } = await api.getAssetWithTemplate(assetId, parentAssetId);
 
       return asset;
     },


### PR DESCRIPTION
This resolves an issue where users may not be able to view some related assets because server-side cannot determine permissions correctly with the parent asset id. Without this, we won't be able to load the related asset embedded in the object viewer, or get data about the asset from `viewAsset`.

Changes:
- adds an optional `parentAssetId` parameter to api functions that get asset.
- passes `parentAssetId` prop to `<ObjectViewer>` and `<AssetDetails>` components.
- updates assetStore to pass the active assetId to api functions as `parentAssetId`.
- updates `<WidgetList>` to get parentAssetId from the asset store. (I'm pretty sure this is okay, but we could run into issues if WidgetList is ever used without

This PR complements a forthcoming PR for elevator.

On dev for testing.

