### PR TITLE
add link for collapsed inline related asset

### DIFF
--- a/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     v-if="asset"
-    class="collapsed-inline-related-asset-widget-item flex flex-col">
+    class="collapsed-inline-related-asset-widget-item flex flex-col w-full">
     <div class="flex justify-between items-baseline">
       <h3>{{ title }}</h3>
       <Button :to="`/asset/viewAsset/${assetId}`" variant="tertiary">

--- a/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
@@ -7,7 +7,6 @@
       <Button :to="`/asset/viewAsset/${assetId}`" variant="tertiary">
         View
         <ArrowRightIcon class="size-4" />
-        <span class="sr-only">Read more about {{ title }}</span>
       </Button>
     </div>
     <WidgetList :assetId="assetId" />

--- a/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/CollapsedInlineRelatedAssetWidgetItem.vue
@@ -2,7 +2,14 @@
   <section
     v-if="asset"
     class="collapsed-inline-related-asset-widget-item flex flex-col">
-    <h3>{{ title }}</h3>
+    <div class="flex justify-between items-baseline">
+      <h3>{{ title }}</h3>
+      <Button :to="`/asset/viewAsset/${assetId}`" variant="tertiary">
+        View
+        <ArrowRightIcon class="size-4" />
+        <span class="sr-only">Read more about {{ title }}</span>
+      </Button>
+    </div>
     <WidgetList :assetId="assetId" />
   </section>
 </template>
@@ -10,6 +17,8 @@
 import WidgetList from "@/components/WidgetList/WidgetList.vue";
 import { computed } from "vue";
 import { useAsset } from "@/helpers/useAsset";
+import { ArrowRightIcon } from "lucide-vue-next";
+import Button from "@/components/Button/Button.vue";
 
 const props = defineProps<{
   assetId: string;


### PR DESCRIPTION
Previously, there would be no way to view the collapsed inline related asset entry in the new interface. This adds a view button akin to the "open" button in the legacy interface. The black circle arrow button remains unchanged, pointing to targetAssetId.

Resolves #389 

<img width="400" alt="ScreenShot 2025-11-17 at 15 16 23@2x" src="https://github.com/user-attachments/assets/fb97fe7d-ebe4-4385-b077-8fb1dca47773" />
