### PR TITLE
emit events on static page content load and images load for custom scripts

### DIFF
--- a/mock-server/db/index.ts
+++ b/mock-server/db/index.ts
@@ -13,16 +13,17 @@ import { createUploadsTable } from "./uploads";
 const makeDb = () => {
   const collections = createCollectionsTable();
   const templates = createTemplatesTable();
+  const pages = createPagesTable();
   const assets = createAssetsTable({ collections, templates });
   const tables = {
     collections,
     templates,
     assets,
+    pages,
     searches: createSearchesTable({ assets, collections, templates }),
     users: createUsersTable(),
     sessions: createSessionsTable(),
-    instances: createInstancesTable(),
-    pages: createPagesTable(),
+    instances: createInstancesTable({ pages }),
     files: createFilesTable(),
     drawers: createDrawersTable(),
     uploads: createUploadsTable(),

--- a/mock-server/db/instances.ts
+++ b/mock-server/db/instances.ts
@@ -41,7 +41,13 @@ export function createInstancesTable({ pages }: { pages: PagesTable }) {
       if (baseTable.size() === 0) {
         throw new Error("No instances available");
       }
-      return instanceSeeds[0]; // Return the first/default instance
+      // Get the instance from the store (which may have been updated)
+      // rather than returning the seed data directly
+      const instance = baseTable.get(instanceSeeds[0].id);
+      if (!instance) {
+        throw new Error("Default instance not found");
+      }
+      return instance;
     },
   };
 }

--- a/mock-server/db/instances.ts
+++ b/mock-server/db/instances.ts
@@ -1,6 +1,7 @@
 import { ShowCustomHeaderMode } from "../../src/types";
-import { MockInstance } from "../types";
+import { MockInstance, MockPage } from "../types";
 import { createBaseTable } from "./baseTable";
+import { PagesTable } from "./pages";
 
 const instanceSeeds: MockInstance[] = [
   {
@@ -19,12 +20,13 @@ const instanceSeeds: MockInstance[] = [
     customFooter: null,
     useVoyagerViewer: true,
     useCustomCSS: false,
-    featuredAssetId: "",
-    featuredAssetText: "",
+    featuredAssetId: "687969fd9c90c709c1021d01",
+    featuredAssetText: "This is a featured asset",
+    pages: [],
   },
 ];
 
-export function createInstancesTable() {
+export function createInstancesTable({ pages }: { pages: PagesTable }) {
   const baseTable = createBaseTable(
     (instance: MockInstance) => instance.id,
     instanceSeeds
@@ -32,6 +34,9 @@ export function createInstancesTable() {
 
   return {
     ...baseTable,
+    get pages() {
+      return pages.getAll();
+    },
     getDefault: (): MockInstance => {
       if (baseTable.size() === 0) {
         throw new Error("No instances available");

--- a/mock-server/db/instances.ts
+++ b/mock-server/db/instances.ts
@@ -1,5 +1,5 @@
 import { ShowCustomHeaderMode } from "../../src/types";
-import { MockInstance, MockPage } from "../types";
+import { MockInstance } from "../types";
 import { createBaseTable } from "./baseTable";
 import { PagesTable } from "./pages";
 

--- a/mock-server/db/pages.ts
+++ b/mock-server/db/pages.ts
@@ -23,6 +23,17 @@ const pageSeeds: MockPage[] = [
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Goldy_Gopher_Volleyball.jpg/500px-Goldy_Gopher_Volleyball.jpg" alt="Goldy Gopher snowboarding down a staircase at a women's volleyball game" width="300" />
     `,
   },
+  {
+    id: 3,
+    title: "Test Page with Broken Images",
+    content: `
+    <h1>Page with Image Load Errors</h1>
+    <p>This page has a mix of valid and broken images to test error handling</p>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/Goldy_the_Gopher.jpg" alt="Valid image" width="300" />
+    <img src="https://invalid-domain-that-does-not-exist.com/broken-image.jpg" alt="Broken image 1" width="300" />
+    <img src="https://example.com/this-image-does-not-exist-404.png" alt="Broken image 2" width="300" />
+    `,
+  },
 ];
 
 function toPageWithoutContent(page: MockPage): Page {

--- a/mock-server/db/pages.ts
+++ b/mock-server/db/pages.ts
@@ -6,15 +6,30 @@ const pageSeeds: MockPage[] = [
   {
     id: 1,
     title: "Home Page",
-    content: "<h1>Elevator Home Page</h1>",
+    content: `<h1>Elevator Home Page</h1>
+      <p>Welcome to the Elevator mock server!</p>
+      <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/Goldy_the_Gopher.jpg" alt="Goldy the Gopher" width="300" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Goldy_Gopher_Volleyball.jpg/500px-Goldy_Gopher_Volleyball.jpg" alt="Goldy Gopher snowboarding down a staircase at a women's volleyball game" width="300" />
+    `,
   },
-  { id: 2, title: "About", content: "<p>Learn more about us</p>" },
+  {
+    id: 2,
+    title: "About",
+    includeInNav: true,
+    content: `
+    <h1>About Elevator</h1>
+    <p>Learn more about us</p>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/Goldy_the_Gopher.jpg" alt="Goldy the Gopher" width="300" />
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Goldy_Gopher_Volleyball.jpg/500px-Goldy_Gopher_Volleyball.jpg" alt="Goldy Gopher snowboarding down a staircase at a women's volleyball game" width="300" />
+    `,
+  },
 ];
 
 function toPageWithoutContent(page: MockPage): Page {
   return {
     id: page.id,
     title: page.title,
+    includeInNav: page.includeInNav,
     children: page.children?.map(toPageWithoutContent) ?? ([] as Page[]),
   };
 }

--- a/mock-server/db/pages.ts
+++ b/mock-server/db/pages.ts
@@ -34,6 +34,16 @@ const pageSeeds: MockPage[] = [
     <img src="https://example.com/this-image-does-not-exist-404.png" alt="Broken image 2" width="300" />
     `,
   },
+  {
+    id: 4,
+    title: "Test Page with Slow Loading Image",
+    content: `
+    <h1>Page with Timeout Test</h1>
+    <p>This page has an image that takes longer than the timeout to load</p>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/Goldy_the_Gopher.jpg" alt="Fast loading image" width="300" />
+    <img src="http://localhost:3001/_tests/slow-image.jpg" alt="Slow loading image" width="300" />
+    `,
+  },
 ];
 
 function toPageWithoutContent(page: MockPage): Page {

--- a/mock-server/db/pages.ts
+++ b/mock-server/db/pages.ts
@@ -14,10 +14,9 @@ const pageSeeds: MockPage[] = [
   },
   {
     id: 2,
-    title: "About",
+    title: "About Elevator",
     includeInNav: true,
     content: `
-    <h1>About Elevator</h1>
     <p>Learn more about us</p>
     <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/Goldy_the_Gopher.jpg" alt="Goldy the Gopher" width="300" />
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Goldy_Gopher_Volleyball.jpg/500px-Goldy_Gopher_Volleyball.jpg" alt="Goldy Gopher snowboarding down a staircase at a women's volleyball game" width="300" />
@@ -26,8 +25,8 @@ const pageSeeds: MockPage[] = [
   {
     id: 3,
     title: "Test Page with Broken Images",
+    includeInNav: true,
     content: `
-    <h1>Page with Image Load Errors</h1>
     <p>This page has a mix of valid and broken images to test error handling</p>
     <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/Goldy_the_Gopher.jpg" alt="Valid image" width="300" />
     <img src="https://invalid-domain-that-does-not-exist.com/broken-image.jpg" alt="Broken image 1" width="300" />

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -128,6 +128,22 @@ app.post("/_tests/auth/login", async (c) => {
   return c.json({ sessionId: session.id, user });
 });
 
+app.patch("/_tests/instance/update", async (c) => {
+  const db = c.get("db");
+  const updates = await c.req.json();
+
+  const instance = db.instances.getDefault();
+  if (!instance) {
+    return c.json({ error: "Instance not found" }, 404);
+  }
+
+  // Merge updates into existing instance
+  const updatedInstance = { ...instance, ...updates };
+  db.instances.set(instance.id, updatedInstance);
+
+  return c.json({ success: true, instance: updatedInstance });
+});
+
 // Health check
 app.get("/health", (c) =>
   c.json({ status: "ok", timestamp: new Date().toISOString() })

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import { createServer } from "node:https";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { cors } from "hono/cors";

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -144,6 +144,21 @@ app.patch("/_tests/instance/update", async (c) => {
   return c.json({ success: true, instance: updatedInstance });
 });
 
+// Endpoint that delays response to test timeout behavior
+app.get("/_tests/slow-image.jpg", async (c) => {
+  // Delay for 15 seconds (longer than the 10-second timeout in onAllImagesLoaded)
+  await new Promise((resolve) => setTimeout(resolve, 15000));
+
+  // Return a 1x1 transparent GIF
+  const gif = Buffer.from(
+    "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+    "base64"
+  );
+
+  c.header("Content-Type", "image/gif");
+  return c.body(gif);
+});
+
 // Health check
 app.get("/health", (c) =>
   c.json({ status: "ok", timestamp: new Date().toISOString() })

--- a/mock-server/types.ts
+++ b/mock-server/types.ts
@@ -37,6 +37,7 @@ export interface MockInstance {
   useCustomCSS: boolean;
   featuredAssetId: string | null;
   featuredAssetText: string | null;
+  pages: MockPage[];
 }
 
 export interface AssetFormData {
@@ -73,6 +74,7 @@ export interface MockPage {
   id: number;
   title: string;
   content: string;
+  includeInNav?: boolean;
   children?: MockPage[];
 }
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -210,9 +210,12 @@ export async function fetchSearchIdForClickToSearch(
 }
 
 export async function fetchStaticPage(
-  pageId: number
+  pageId: number,
+  options?: { signal?: AbortSignal }
 ): Promise<ApiStaticPageResponse> {
-  const res = await axios.get(`${BASE_URL}/page/view/${pageId}/true`);
+  const res = await axios.get(`${BASE_URL}/page/view/${pageId}/true`, {
+    signal: options?.signal,
+  });
   return res.data;
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -217,10 +217,14 @@ async function getSearchResultsById(
   return searchResults;
 }
 
-async function getStaticPage(pageId: number): Promise<ApiStaticPageResponse> {
+async function getStaticPage(
+  pageId: number,
+  options?: { signal?: AbortSignal }
+): Promise<ApiStaticPageResponse> {
   // check the cache first
   const page =
-    cache.staticPages.get(pageId) || (await fetchers.fetchStaticPage(pageId));
+    cache.staticPages.get(pageId) ||
+    (await fetchers.fetchStaticPage(pageId, options));
 
   // cache the page
   cache.staticPages.set(pageId, page);

--- a/src/components/AppFooter/AppFooter.vue
+++ b/src/components/AppFooter/AppFooter.vue
@@ -2,7 +2,9 @@
   <footer
     v-if="instanceStore.customFooter"
     class="app-footer bg-transparent-black-100">
-    <SanitizedHTML :html="instanceStore.customFooter" :addTags="['style', 'link', 'script']" />
+    <SanitizedHTML
+      :html="instanceStore.customFooter"
+      :addTags="['style', 'link']" />
   </footer>
 </template>
 <script setup lang="ts">

--- a/src/components/CustomAppHeader/CustomAppHeader.vue
+++ b/src/components/CustomAppHeader/CustomAppHeader.vue
@@ -2,7 +2,7 @@
   <div class="custom-app-header bg-transparent-black-100">
     <SanitizedHTML
       :html="instanceStore?.customHeader ?? ''"
-      :addTags="['style', 'link', 'script']" />
+      :addTags="['style', 'link']" />
   </div>
 </template>
 <script setup lang="ts">

--- a/src/components/SanitizedHTML/SanitizedHTML.vue
+++ b/src/components/SanitizedHTML/SanitizedHTML.vue
@@ -1,10 +1,10 @@
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div ref="containerRef" v-html="htmlWithoutScripts" />
+  <div ref="containerRef" v-html="sanitizedHtml" />
 </template>
 <script setup lang="ts">
 import DOMPurify from "dompurify";
-import { computed, onMounted, ref, watch, onUnmounted, type Ref } from "vue";
+import { computed, ref } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -19,86 +19,17 @@ const props = withDefaults(
 );
 
 const containerRef = ref<HTMLElement>();
-const addedScripts: Ref<HTMLScriptElement[]> = ref([]);
 
-const sanitizeConfig = {
+const sanitizeConfig = computed(() => ({
   FORBID_ATTR: props.removeInlineStyles ? ["style"] : [],
-  ADD_TAGS: ["iframe", "script", ...props.addTags],
+  // Allow iframe and any additional tags specified, but NOT script
+  ADD_TAGS: ["iframe", ...props.addTags],
   // needed for <style> tags
   // https://github.com/cure53/DOMPurify/issues/257#issuecomment-346384997
   FORCE_BODY: props.addTags?.includes("style"),
-};
+}));
 
 const sanitizedHtml = computed(() => {
-  return DOMPurify.sanitize(props.html, sanitizeConfig);
-});
-
-const htmlWithoutScripts = computed(() => {
-  // Create a temporary DOM element to parse the sanitized HTML
-  const tempDiv = document.createElement("div");
-  tempDiv.innerHTML = sanitizedHtml.value;
-
-  // Remove all script tags from the HTML
-  const scripts = tempDiv.querySelectorAll("script");
-  scripts.forEach((script) => script.remove());
-
-  return tempDiv.innerHTML;
-});
-
-const extractAndExecuteScripts = () => {
-  // Clean up previously added scripts
-  cleanupScripts();
-
-  // Create a temporary DOM element to parse the sanitized HTML
-  const tempDiv = document.createElement("div");
-  tempDiv.innerHTML = sanitizedHtml.value;
-
-  // Find all script tags
-  const scripts = tempDiv.querySelectorAll("script");
-
-  scripts.forEach((originalScript) => {
-    const script = document.createElement("script");
-
-    // Copy attributes
-    Array.from(originalScript.attributes).forEach((attr) => {
-      script.setAttribute(attr.name, attr.value);
-    });
-
-    // Copy content if it's an inline script
-    if (originalScript.textContent) {
-      script.textContent = originalScript.textContent;
-    }
-
-    // Append to body to execute
-    document.body.appendChild(script);
-    addedScripts.value.push(script);
-  });
-};
-
-const cleanupScripts = () => {
-  // Remove previously added scripts from the document
-  addedScripts.value.forEach((script) => {
-    if (script.parentNode) {
-      script.parentNode.removeChild(script);
-    }
-  });
-  addedScripts.value = [];
-};
-
-// Watch for changes in the HTML prop and re-extract scripts
-watch(
-  () => props.html,
-  () => {
-    extractAndExecuteScripts();
-  },
-  { immediate: false }
-);
-
-onMounted(() => {
-  extractAndExecuteScripts();
-});
-
-onUnmounted(() => {
-  cleanupScripts();
+  return DOMPurify.sanitize(props.html, sanitizeConfig.value);
 });
 </script>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -35,6 +35,10 @@ export const ELEVATOR_EVENTS = {
     CONTENT_LOADED: "elevator:static-content-page:content-loaded",
     IMAGES_LOADED: "elevator:static-content-page:images-loaded",
   },
+  HOME_PAGE: {
+    CONTENT_LOADED: "elevator:home-page:content-loaded",
+    IMAGES_LOADED: "elevator:home-page:images-loaded",
+  },
 } as const;
 
 // these are ids for searchable fields that don't actually exist

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -29,6 +29,14 @@ export const SORT_KEYS = {
   CUSTOM: "custom",
 } as const;
 
+// custom elevator events that custom header/footer scripts can listen for
+export const ELEVATOR_EVENTS = {
+  STATIC_CONTENT_PAGE: {
+    CONTENT_LOADED: "elevator:static-content-page:content-loaded",
+    IMAGES_LOADED: "elevator:static-content-page:images-loaded",
+  },
+} as const;
+
 // these are ids for searchable fields that don't actually exist
 // in the api, but we want to treat them like they do for the sake
 // of the UI

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -35,10 +35,6 @@ export const ELEVATOR_EVENTS = {
     CONTENT_LOADED: "elevator:static-content-page:content-loaded",
     IMAGES_LOADED: "elevator:static-content-page:images-loaded",
   },
-  HOME_PAGE: {
-    CONTENT_LOADED: "elevator:home-page:content-loaded",
-    IMAGES_LOADED: "elevator:home-page:images-loaded",
-  },
 } as const;
 
 // these are ids for searchable fields that don't actually exist

--- a/src/helpers/customScriptHelpers.ts
+++ b/src/helpers/customScriptHelpers.ts
@@ -17,9 +17,7 @@ export function getScriptsFromHTML(
 }
 
 export function executeScripts(scripts: HTMLScriptElement[]) {
-  console.log("Executing scripts:", scripts);
   scripts.forEach((script) => {
-    console.log("Executing custom script:", script);
     const scriptToAppend = document.createElement("script");
 
     // Copy attributes

--- a/src/helpers/customScriptHelpers.ts
+++ b/src/helpers/customScriptHelpers.ts
@@ -4,7 +4,6 @@
 export function getScriptsFromHTML(
   html: string | null | undefined
 ): HTMLScriptElement[] {
-  console.log("Extracting scripts from HTML");
   if (!html) return [];
 
   // Create a temporary DOM element to parse the sanitized HTML

--- a/src/helpers/customScriptHelpers.ts
+++ b/src/helpers/customScriptHelpers.ts
@@ -1,0 +1,60 @@
+/**
+ * Extracts script tags from HTML
+ */
+export function getScriptsFromHTML(
+  html: string | null | undefined
+): HTMLScriptElement[] {
+  console.log("Extracting scripts from HTML");
+  if (!html) return [];
+
+  // Create a temporary DOM element to parse the sanitized HTML
+  const tempDiv = document.createElement("div");
+  tempDiv.innerHTML = html;
+
+  // Find all script tags and return them as an array
+  const scripts = tempDiv.querySelectorAll("script");
+  return Array.from(scripts);
+}
+
+export function executeScripts(scripts: HTMLScriptElement[]) {
+  console.log("Executing scripts:", scripts);
+  scripts.forEach((script) => {
+    console.log("Executing custom script:", script);
+    const scriptToAppend = document.createElement("script");
+
+    // Copy attributes
+    Array.from(script.attributes).forEach((attr) => {
+      scriptToAppend.setAttribute(attr.name, attr.value);
+    });
+
+    // Copy content if it's an inline script
+    if (script.textContent) {
+      scriptToAppend.textContent = script.textContent;
+    }
+
+    // Append to body to execute
+    document.body.appendChild(scriptToAppend);
+  });
+}
+
+export function removeScripts(scripts: HTMLScriptElement[]) {
+  scripts.forEach((script) => {
+    if (script.parentNode) {
+      script.parentNode.removeChild(script);
+    }
+  });
+}
+
+export function removeScriptsFromHtml(
+  html: string | null | undefined
+): string | null {
+  if (!html) return null;
+  const tempDiv = document.createElement("div");
+  tempDiv.innerHTML = html;
+
+  // Remove all script tags from the HTML
+  const scripts = tempDiv.querySelectorAll("script");
+  scripts.forEach((script) => script.remove());
+
+  return tempDiv.innerHTML || null;
+}

--- a/src/helpers/onAllImagesLoaded.ts
+++ b/src/helpers/onAllImagesLoaded.ts
@@ -1,0 +1,54 @@
+// fire off a callback when all images inside a container are loaded
+// Returns a cleanup function to remove event listeners and cancel the operation
+export function onAllImagesLoaded(
+  selector: string,
+  onComplete: (images: HTMLImageElement[]) => void,
+  opts: { timeout?: number } = {}
+): () => void {
+  const { timeout = 10_000 } = opts;
+
+  const container = document.querySelector(selector);
+  if (!container) {
+    throw new Error(`Container not found: ${selector}`);
+  }
+
+  const images = Array.from(container.querySelectorAll("img"));
+  const abortController = new AbortController();
+  let completed = false;
+
+  const handleComplete = () => {
+    if (completed) return;
+    completed = true;
+    abortController.abort(); // Remove all listeners at once
+    onComplete(images);
+  };
+
+  // Create a promise for each image
+  Promise.all(
+    images.map((img) => {
+      if (img.complete) return Promise.resolve();
+
+      return new Promise<void>((resolve) => {
+        const load = () => resolve();
+        const error = () => resolve();
+
+        img.addEventListener("load", load, {
+          signal: abortController.signal,
+          once: true,
+        });
+        img.addEventListener("error", error, {
+          signal: abortController.signal,
+          once: true,
+        });
+      });
+    })
+  ).then(handleComplete);
+
+  // Timeout fallback
+  const timeoutId = setTimeout(handleComplete, timeout);
+
+  return () => {
+    clearTimeout(timeoutId);
+    abortController.abort();
+  };
+}

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -125,7 +125,7 @@ const bothQueriesComplete = computed(() => {
   return true;
 });
 
-const { CONTENT_LOADED, IMAGES_LOADED } = ELEVATOR_EVENTS.HOME_PAGE;
+const { CONTENT_LOADED, IMAGES_LOADED } = ELEVATOR_EVENTS.STATIC_CONTENT_PAGE;
 
 const dispatchEvent = (eventName: string, payload: Record<string, unknown>) => {
   window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -143,6 +143,7 @@ watch(
     cleanupFns.length = 0; // Clear the array
 
     await nextTick();
+
     dispatchEvent(CONTENT_LOADED, {
       homePageId: homePageId.value,
       featuredAssetId: featuredAssetId.value,

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -145,7 +145,7 @@ watch(
     await nextTick();
 
     dispatchEvent(CONTENT_LOADED, {
-      homePageId: homePageId.value,
+      pageId: homePageId.value,
       featuredAssetId: featuredAssetId.value,
     });
 
@@ -158,7 +158,7 @@ watch(
         selector,
         (images: HTMLImageElement[]) =>
           dispatchEvent(IMAGES_LOADED, {
-            homePageId: homePageId.value,
+            pageId: homePageId.value,
             featuredAssetId: featuredAssetId.value,
             images,
           }),

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -93,11 +93,10 @@ const homePageId = computed(() => {
 
 // Fetch home page content (only when ready, can browse, and home page exists)
 const { data: pageData } = useStaticPageQuery(
-  computed(() => homePageId.value ?? 0),
+  homePageId, // Pass the computed directly
   {
     enabled: computed(
-      () =>
-        isReady.value && canSearchAndBrowse.value && homePageId.value !== null
+      () => isReady.value && canSearchAndBrowse.value && !!homePageId.value
     ),
   }
 );
@@ -131,7 +130,7 @@ const dispatchEvent = (eventName: string, payload: Record<string, unknown>) => {
   window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
 };
 
-const cleanupFns = [] as Array<() => void>;
+const cleanupFns = new Set<() => void>();
 
 // Emit custom events when both page and featured asset (if any) are loaded
 watch(
@@ -140,7 +139,7 @@ watch(
     if (!isComplete) return;
 
     cleanupFns.forEach((fn) => fn());
-    cleanupFns.length = 0; // Clear the array
+    cleanupFns.clear();
 
     await nextTick();
 
@@ -164,7 +163,7 @@ watch(
           }),
         { timeout: 10000 }
       );
-      cleanupFns.push(cleanup);
+      cleanupFns.add(cleanup);
     });
   },
   { immediate: true }

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -58,27 +58,24 @@
 <script setup lang="ts">
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
-import { ref, watch, computed } from "vue";
-import { StaticContentPage, Asset, ShowCustomHeaderMode } from "@/types";
+import { computed, nextTick, onUnmounted, watch } from "vue";
+import { ShowCustomHeaderMode } from "@/types";
 import { useInstanceStore } from "@/stores/instanceStore";
-import api from "@/api";
 import FeaturedAssetCard from "@/components/FeaturedAssetCard/FeaturedAssetCard.vue";
 import SignInRequiredNotice from "./SignInRequiredNotice.vue";
 import Notification from "@/components/Notification/Notification.vue";
 import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
+import { useStaticPageQuery } from "@/queries/useStaticPageQuery";
+import { useAssetQuery } from "@/queries/useAssetQuery";
+import { ELEVATOR_EVENTS } from "@/constants/constants";
+import { onAllImagesLoaded } from "@/helpers/onAllImagesLoaded";
 
-const page = ref<StaticContentPage | null>(null);
 const instanceStore = useInstanceStore();
 const canSearchAndBrowse = computed(
   () => instanceStore.instance?.userCanSearchAndBrowse ?? false
 );
 const isReady = computed(() => instanceStore.isReady);
-
-const fallbackHomePage: StaticContentPage = {
-  title: "No Home Page",
-  content: `<p>Update your instance to set a Home Page</p>`,
-};
 
 const featuredAssetId = computed(
   (): string | null => instanceStore.instance?.featuredAssetId ?? null
@@ -86,37 +83,95 @@ const featuredAssetId = computed(
 const featuredAssetText = computed(
   () => instanceStore.instance?.featuredAssetText ?? ""
 );
-const featuredAsset = ref<Asset | null>(null);
 
-// the Home Page is just the first page with a title of "Home Page"
-function findHomePageId() {
-  return instanceStore.pages.find((page) => page.title === "Home Page")?.id;
-}
+// Find home page ID from instance pages
+const homePageId = computed(() => {
+  return (
+    instanceStore.pages.find((page) => page.title === "Home Page")?.id ?? null
+  );
+});
 
-async function fetchHomePage(homePageId: number | undefined) {
-  if (!homePageId) return fallbackHomePage;
-  return api.getStaticPage(homePageId);
-}
+// Fetch home page content (only when ready, can browse, and home page exists)
+const { data: pageData } = useStaticPageQuery(
+  computed(() => homePageId.value ?? 0),
+  {
+    enabled: computed(
+      () =>
+        isReady.value && canSearchAndBrowse.value && homePageId.value !== null
+    ),
+  }
+);
 
-async function fetchFeaturedAsset(assetId): Promise<Asset | null> {
-  if (!assetId) return null;
-  return api.getAsset(assetId);
-}
+// Fetch featured asset (only when ready, can browse, and featured asset exists)
+const { data: featuredAsset } = useAssetQuery(featuredAssetId, {
+  enabled: computed(
+    () => isReady.value && canSearchAndBrowse.value && !!featuredAssetId.value
+  ),
+});
 
+// Provide fallback if no home page is configured
+const page = computed(() => {
+  if (pageData.value) return pageData.value;
+  if (!isReady.value || !canSearchAndBrowse.value) return null;
+  if (homePageId.value === null) {
+    return {
+      title: "No Home Page",
+      content: `<p>Update your instance to set a Home Page</p>`,
+    };
+  }
+  return null;
+});
+
+// Determine when both queries are complete
+const bothQueriesComplete = computed(() => {
+  // Always wait for page
+  if (!page.value) return false;
+
+  // If there's a featured asset, wait for it too
+  if (featuredAssetId.value && !featuredAsset.value) return false;
+
+  return true;
+});
+
+const { CONTENT_LOADED, IMAGES_LOADED } = ELEVATOR_EVENTS.HOME_PAGE;
+
+const dispatchEvent = (eventName: string, payload: Record<string, unknown>) => {
+  window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+};
+
+let cleanupOnAllImagesLoaded: (() => void) | null = null;
+
+// Emit custom events when both page and featured asset (if any) are loaded
 watch(
-  () => instanceStore.fetchStatus,
-  async () => {
-    if (instanceStore.fetchStatus !== "success") return;
+  bothQueriesComplete,
+  async (isComplete) => {
+    if (!isComplete) return;
 
-    // if the can't search and browse, we're done
-    if (!canSearchAndBrowse.value) return;
+    cleanupOnAllImagesLoaded?.();
 
-    const homePageId = findHomePageId();
-    page.value = await fetchHomePage(homePageId);
-    featuredAsset.value = await fetchFeaturedAsset(featuredAssetId.value);
+    await nextTick();
+    dispatchEvent(CONTENT_LOADED, {
+      homePageId: homePageId.value,
+      featuredAssetId: featuredAssetId.value,
+    });
+
+    cleanupOnAllImagesLoaded = onAllImagesLoaded(
+      ".home-page-content",
+      (images: HTMLImageElement[]) =>
+        dispatchEvent(IMAGES_LOADED, {
+          homePageId: homePageId.value,
+          featuredAssetId: featuredAssetId.value,
+          images,
+        }),
+      { timeout: 10000 }
+    );
   },
   { immediate: true }
 );
+
+onUnmounted(() => {
+  cleanupOnAllImagesLoaded?.();
+});
 </script>
 <style scoped>
 .home-page-content {

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -111,15 +111,7 @@ const { data: featuredAsset } = useAssetQuery(featuredAssetId, {
 
 // Provide fallback if no home page is configured
 const page = computed(() => {
-  if (pageData.value) return pageData.value;
-  if (!isReady.value || !canSearchAndBrowse.value) return null;
-  if (homePageId.value === null) {
-    return {
-      title: "No Home Page",
-      content: `<p>Update your instance to set a Home Page</p>`,
-    };
-  }
-  return null;
+  return pageData.value ?? null;
 });
 
 // Determine when both queries are complete

--- a/src/pages/HomePage/HomePage.vue
+++ b/src/pages/HomePage/HomePage.vue
@@ -148,23 +148,17 @@ watch(
       featuredAssetId: featuredAssetId.value,
     });
 
-    [".home-page-content", ".featured-asset-block"].forEach((selector) => {
-      // test if selector exists
-      const element = document.querySelector(selector);
-      if (!element) return;
-
-      const cleanup = onAllImagesLoaded(
-        selector,
-        (images: HTMLImageElement[]) =>
-          dispatchEvent(IMAGES_LOADED, {
-            pageId: homePageId.value,
-            featuredAssetId: featuredAssetId.value,
-            images,
-          }),
-        { timeout: 10000 }
-      );
-      cleanupFns.add(cleanup);
-    });
+    const cleanup = onAllImagesLoaded(
+      ".home-page-content, .featured-asset-block",
+      (images: HTMLImageElement[]) =>
+        dispatchEvent(IMAGES_LOADED, {
+          pageId: homePageId.value,
+          featuredAssetId: featuredAssetId.value,
+          images,
+        }),
+      { timeout: 10000 }
+    );
+    cleanupFns.add(cleanup);
   },
   { immediate: true }
 );

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -32,12 +32,13 @@ import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import AppFooter from "@/components/AppFooter/AppFooter.vue";
-import { computed, ref, watch } from "vue";
-import { ApiStaticPageResponse } from "@/types";
+import { computed, nextTick, onUnmounted, toRef, watch } from "vue";
 import { useInstanceStore } from "@/stores/instanceStore";
-import api from "@/api";
 import config from "@/config";
 import { ShowCustomHeaderMode } from "@/types";
+import { ELEVATOR_EVENTS } from "@/constants/constants";
+import { onAllImagesLoaded } from "@/helpers/onAllImagesLoaded";
+import { useStaticPageQuery } from "@/queries/useStaticPageQuery";
 
 const instanceStore = useInstanceStore();
 
@@ -46,7 +47,7 @@ const props = defineProps<{
 }>();
 
 const BASE_URL = config.instance.base.path;
-const page = ref<ApiStaticPageResponse | null>(null);
+const pageIdRef = toRef(props, "pageId");
 
 const canCurrentUserEdit = computed(() => {
   return (
@@ -55,13 +56,40 @@ const canCurrentUserEdit = computed(() => {
   );
 });
 
+const { CONTENT_LOADED: DOM_READY, IMAGES_LOADED } =
+  ELEVATOR_EVENTS.STATIC_CONTENT_PAGE;
+const { data: page } = useStaticPageQuery(pageIdRef);
+
+const dispatchEvent = (eventName: string, payload: Record<string, unknown>) => {
+  window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+};
+
+let cleanupOnAllImagesLoaded: (() => void) | null = null;
+
+// Emit custom events for external scripts (e.g. header/footer)
 watch(
-  () => props.pageId,
-  async () => {
-    page.value = await api.getStaticPage(props.pageId);
+  page,
+  async (newPage) => {
+    if (!newPage) return;
+
+    cleanupOnAllImagesLoaded?.();
+
+    await nextTick();
+    dispatchEvent(DOM_READY, { pageId: pageIdRef.value });
+
+    cleanupOnAllImagesLoaded = onAllImagesLoaded(
+      ".static-content-page__content",
+      (images: HTMLImageElement[]) =>
+        dispatchEvent(IMAGES_LOADED, { pageId: pageIdRef.value, images }),
+      { timeout: 10000 }
+    );
   },
   { immediate: true }
 );
+
+onUnmounted(() => {
+  cleanupOnAllImagesLoaded?.();
+});
 </script>
 <style scoped>
 .static-content-page__content {

--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -56,8 +56,7 @@ const canCurrentUserEdit = computed(() => {
   );
 });
 
-const { CONTENT_LOADED: DOM_READY, IMAGES_LOADED } =
-  ELEVATOR_EVENTS.STATIC_CONTENT_PAGE;
+const { CONTENT_LOADED, IMAGES_LOADED } = ELEVATOR_EVENTS.STATIC_CONTENT_PAGE;
 const { data: page } = useStaticPageQuery(pageIdRef);
 
 const dispatchEvent = (eventName: string, payload: Record<string, unknown>) => {
@@ -75,7 +74,7 @@ watch(
     cleanupOnAllImagesLoaded?.();
 
     await nextTick();
-    dispatchEvent(DOM_READY, { pageId: pageIdRef.value });
+    dispatchEvent(CONTENT_LOADED, { pageId: pageIdRef.value });
 
     cleanupOnAllImagesLoaded = onAllImagesLoaded(
       ".static-content-page__content",

--- a/src/queries/useStaticPageQuery.ts
+++ b/src/queries/useStaticPageQuery.ts
@@ -2,9 +2,13 @@ import { useQuery } from "@tanstack/vue-query";
 import { MaybeRefOrGetter, toValue } from "vue";
 import api from "@/api";
 
-export function useStaticPageQuery(pageIdRef: MaybeRefOrGetter<number>) {
+export function useStaticPageQuery(
+  pageIdRef: MaybeRefOrGetter<number>,
+  options = {}
+) {
   return useQuery({
     queryKey: ["staticPage", pageIdRef],
     queryFn: ({ signal }) => api.getStaticPage(toValue(pageIdRef), { signal }),
+    ...options,
   });
 }

--- a/src/queries/useStaticPageQuery.ts
+++ b/src/queries/useStaticPageQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/vue-query";
+import { MaybeRefOrGetter, toValue } from "vue";
+import api from "@/api";
+
+export function useStaticPageQuery(pageIdRef: MaybeRefOrGetter<number>) {
+  return useQuery({
+    queryKey: ["staticPage", pageIdRef],
+    queryFn: ({ signal }) => api.getStaticPage(toValue(pageIdRef), { signal }),
+  });
+}

--- a/src/queries/useStaticPageQuery.ts
+++ b/src/queries/useStaticPageQuery.ts
@@ -3,12 +3,15 @@ import { MaybeRefOrGetter, toValue } from "vue";
 import api from "@/api";
 
 export function useStaticPageQuery(
-  pageIdRef: MaybeRefOrGetter<number>,
+  pageIdRef: MaybeRefOrGetter<number | null>,
   options = {}
 ) {
   return useQuery({
     queryKey: ["staticPage", pageIdRef],
-    queryFn: ({ signal }) => api.getStaticPage(toValue(pageIdRef), { signal }),
+    queryFn: ({ signal }) => {
+      const pageId = toValue(pageIdRef);
+      return pageId ? api.getStaticPage(pageId, { signal }) : null;
+    },
     ...options,
   });
 }

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -125,9 +125,6 @@ const actions = (state: ReturnType<typeof createState>) => ({
         apiResponse.customFooter
       );
 
-      console.log("original custom header:", apiResponse.customHeader);
-      console.log("sanitized custom header:", state.customHeader.value);
-
       // Extract scripts from custom header and footer
       const headerScripts = getScriptsFromHTML(apiResponse.customHeader);
       const footerScripts = getScriptsFromHTML(apiResponse.customFooter);

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -49,7 +49,7 @@ const createState = () => ({
   customHeader: ref<string | null>(null),
   customFooter: ref<string | null>(null),
   customScripts: ref<HTMLScriptElement[]>([]),
-  hasExecutedCustomSripts: ref<boolean>(false),
+  hasExecutedCustomScripts: ref<boolean>(false),
 });
 
 const getters = (state: ReturnType<typeof createState>) => ({

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -2,6 +2,11 @@ import { defineStore } from "pinia";
 import api from "@/api";
 import { selectCurrentUserFromResponse } from "@/helpers/selectCurrentUserFromResponse";
 import { selectInstanceFromResponse } from "@/helpers/selectInstanceFromResponse";
+import {
+  getScriptsFromHTML,
+  executeScripts,
+  removeScriptsFromHtml,
+} from "@/helpers/customScriptHelpers";
 import { ref, computed } from "vue";
 import {
   FetchStatus,
@@ -43,6 +48,8 @@ const createState = () => ({
   customHeaderMode: ref<ShowCustomHeaderMode>(ShowCustomHeaderMode.NEVER),
   customHeader: ref<string | null>(null),
   customFooter: ref<string | null>(null),
+  customScripts: ref<HTMLScriptElement[]>([]),
+  hasExecutedCustomSripts: ref<boolean>(false),
 });
 
 const getters = (state: ReturnType<typeof createState>) => ({
@@ -109,8 +116,24 @@ const actions = (state: ReturnType<typeof createState>) => ({
         apiResponse.collections
       );
       state.customHeaderMode.value = apiResponse.customHeaderMode;
-      state.customHeader.value = apiResponse.customHeader ?? null;
-      state.customFooter.value = apiResponse.customFooter ?? null;
+
+      // Store script-free HTML
+      state.customHeader.value = removeScriptsFromHtml(
+        apiResponse.customHeader
+      );
+      state.customFooter.value = removeScriptsFromHtml(
+        apiResponse.customFooter
+      );
+
+      console.log("original custom header:", apiResponse.customHeader);
+      console.log("sanitized custom header:", state.customHeader.value);
+
+      // Extract scripts from custom header and footer
+      const headerScripts = getScriptsFromHTML(apiResponse.customHeader);
+      const footerScripts = getScriptsFromHTML(apiResponse.customFooter);
+
+      // store header and footer scripts
+      state.customScripts.value = [...headerScripts, ...footerScripts];
 
       // add id to searchable field object from api response
       state.searchableFields.value = Object.entries(
@@ -131,7 +154,12 @@ const actions = (state: ReturnType<typeof createState>) => ({
     if (["fetching", "success", "error"].includes(state.fetchStatus.value)) {
       return;
     }
-    return actions(state).refresh();
+    await actions(state).refresh();
+
+    // Execute custom scripts only on init,
+    // not on refresh
+    executeScripts(state.customScripts.value as HTMLScriptElement[]);
+    state.hasExecutedCustomSripts.value = true;
   },
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -668,6 +668,7 @@ export interface AssetCollection {
 export interface Page {
   title: string;
   id: number;
+  includeInNav?: boolean;
   children?: Page[];
 }
 

--- a/tests/e2e/duplicate-event-listeners.spec.ts
+++ b/tests/e2e/duplicate-event-listeners.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import {
+  setupWorkerHTTPHeader,
+  loginUser,
+  refreshDatabase,
+  updateInstance,
+} from "../setup";
+
+// Extend Window type to include our test tracking object
+declare global {
+  interface Window {
+    eventListenerCallCounts: {
+      contentLoaded: number;
+      imagesLoaded: number;
+    };
+  }
+}
+
+test.describe("Event Listener Duplication Bug", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({
+      page,
+      workerId,
+    });
+
+    await refreshDatabase({ request, workerId });
+
+    // Update instance to include a custom header script that tracks listener call counts
+    // This script simulates what admins might write - a simple event listener
+    await updateInstance({
+      request,
+      workerId,
+      updates: {
+        customHeaderMode: 1, // ShowCustomHeaderMode.ALWAYS
+        customHeader: `
+          <script>
+            console.log('Custom header script loaded');
+
+            // Track how many times each listener is called
+            window.eventListenerCallCounts = window.eventListenerCallCounts || {
+              contentLoaded: 0,
+              imagesLoaded: 0
+            };
+
+            // Simple event listener (what an admin might write)
+            window.addEventListener('elevator:static-content-page:content-loaded', (event) => {
+              window.eventListenerCallCounts.contentLoaded++;
+              console.log('CONTENT_LOADED listener called, count:', window.eventListenerCallCounts.contentLoaded);
+            });
+
+            window.addEventListener('elevator:static-content-page:images-loaded', (event) => {
+              window.eventListenerCallCounts.imagesLoaded++;
+              console.log('IMAGES_LOADED listener called, count:', window.eventListenerCallCounts.imagesLoaded);
+            });
+          </script>
+        `,
+      },
+    });
+
+    await loginUser({ request, page, workerId });
+  });
+
+  test("should NOT duplicate event listeners when navigating between different page types", async ({
+    page,
+  }) => {
+    const getCallCounts = async () => {
+      return page.evaluate(() => window.eventListenerCallCounts);
+    };
+
+    // Enable console logging for debugging
+    page.on("console", (msg) => console.log("BROWSER:", msg.text()));
+
+    // navigate to HomePage
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Elevator Home Page" })
+    ).toBeVisible();
+
+    // Wait for both events to fire on HomePage
+    await page.waitForTimeout(2000);
+
+    // Each listener should have been called once
+    expect(await getCallCounts()).toEqual({
+      contentLoaded: 1,
+      imagesLoaded: 1,
+    });
+
+    // Find menu toggle button or clickable menu element
+    const menuToggle = page.getByRole("button", { name: "Toggle main menu" });
+
+    // Ensure the menu toggle is visible
+    await expect(menuToggle).toBeVisible();
+    await menuToggle.click();
+
+    const menu = page.locator("#app-menu-navigation");
+    await expect(menu).toContainText("About");
+
+    // Navigate to About static page
+    const aboutLink = menu.getByText("About");
+    await expect(aboutLink).toBeVisible();
+    await aboutLink.click();
+
+    // Wait for both events
+    await page.waitForTimeout(2000);
+
+    // each listener should be called once more (not duplicated)
+    expect(await getCallCounts()).toEqual({
+      contentLoaded: 2,
+      imagesLoaded: 2,
+    });
+
+    // now navigate to another static page with images
+    // i.e. the page component doesn't change, but we should
+    // still see exactly one additional call per listener
+    // Find menu toggle button or clickable menu element
+    await menuToggle.click();
+    const pageWithImagesLink = menu.getByText("Test Page with Broken Images");
+    await expect(pageWithImagesLink).toBeVisible();
+    await pageWithImagesLink.click();
+
+    // Wait for both events to fire
+    await page.waitForTimeout(2000);
+
+    // Check call counts
+
+    // each listener should be called once more (not duplicated)
+    expect(await getCallCounts()).toEqual({
+      contentLoaded: 3,
+      imagesLoaded: 3,
+    });
+
+    // now back to homepage
+    await page.getByRole("link", { name: "defaultinstance" }).click();
+
+    await page.waitForTimeout(2000);
+
+    // each listener should be called once more (not duplicated)
+    expect(await getCallCounts()).toEqual({
+      contentLoaded: 4,
+      imagesLoaded: 4,
+    });
+  });
+});

--- a/tests/e2e/homepage-events.spec.ts
+++ b/tests/e2e/homepage-events.spec.ts
@@ -25,7 +25,7 @@ test.describe("HomePage - CONTENT_LOADED Event", () => {
         customHeader: `
           <script>
             // Listen for the home page content loaded event
-            window.addEventListener('elevator:home-page:content-loaded', (event) => {
+            window.addEventListener('elevator:static-content-page:content-loaded', (event) => {
               const { homePageId, featuredAssetId } = event.detail;
 
               // Add test element to verify event fired
@@ -120,7 +120,7 @@ test.describe("HomePage - IMAGES_LOADED Event", () => {
             let totalImagesFromEvents = 0;
             let totalLoadedFromEvents = 0;
 
-            window.addEventListener('elevator:home-page:images-loaded', (event) => {
+            window.addEventListener('elevator:static-content-page:images-loaded', (event) => {
               eventCount++;
               const { homePageId, featuredAssetId, images } = event.detail;
 
@@ -166,7 +166,9 @@ test.describe("HomePage - IMAGES_LOADED Event", () => {
     await loginUser({ request, page, workerId });
   });
 
-  test("emits IMAGES_LOADED events for both content areas", async ({ page }) => {
+  test("emits IMAGES_LOADED events for both content areas", async ({
+    page,
+  }) => {
     await page.goto("/");
 
     await expect(

--- a/tests/e2e/homepage-events.spec.ts
+++ b/tests/e2e/homepage-events.spec.ts
@@ -115,7 +115,7 @@ test.describe("HomePage - IMAGES_LOADED Event", () => {
         customHeaderMode: 2, // ShowCustomHeaderMode.HOME_PAGE_ONLY
         customHeader: `
           <script>
-            // Track all IMAGES_LOADED events (HomePage fires one per area)
+            // Track IMAGES_LOADED event (HomePage fires once for all content areas)
             let eventCount = 0;
             let totalImagesFromEvents = 0;
             let totalLoadedFromEvents = 0;

--- a/tests/e2e/homepage-events.spec.ts
+++ b/tests/e2e/homepage-events.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect } from "@playwright/test";
+import {
+  setupWorkerHTTPHeader,
+  loginUser,
+  refreshDatabase,
+  updateInstance,
+} from "../setup";
+
+test.describe("HomePage - CONTENT_LOADED Event", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({
+      page,
+      workerId,
+    });
+
+    await refreshDatabase({ request, workerId });
+
+    // Update instance with a script that listens for HOME_PAGE events
+    await updateInstance({
+      request,
+      workerId,
+      updates: {
+        customHeaderMode: 2, // ShowCustomHeaderMode.HOME_PAGE_ONLY
+        customHeader: `
+          <script>
+            // Listen for the home page content loaded event
+            window.addEventListener('elevator:home-page:content-loaded', (event) => {
+              const { homePageId, featuredAssetId } = event.detail;
+
+              // Add test element to verify event fired
+              const testEl = document.createElement('div');
+              testEl.id = 'test-content-loaded';
+              testEl.setAttribute('data-home-page-id', homePageId?.toString() || 'null');
+              testEl.setAttribute('data-featured-asset-id', featuredAssetId || 'null');
+              testEl.textContent = \`home page loaded: homePageId=\${homePageId}, featuredAssetId=\${featuredAssetId}\`;
+              document.body.appendChild(testEl);
+            });
+          </script>
+        `,
+      },
+    });
+
+    await loginUser({ request, page, workerId });
+  });
+
+  test("emits CONTENT_LOADED event after page and featured asset load", async ({
+    page,
+  }) => {
+    // Navigate to the homepage
+    await page.goto("/");
+
+    // Wait for the home page heading to be visible
+    await expect(
+      page.getByRole("heading", { name: "Elevator Home Page" })
+    ).toBeVisible();
+
+    // Wait for the featured asset section to be visible
+    const featuredSection = page.locator(".featured-asset-block");
+    await expect(featuredSection).toBeVisible();
+
+    // Wait for the test element (proves CONTENT_LOADED event fired)
+    const testElement = page.locator("#test-content-loaded");
+    await expect(testElement).toBeVisible();
+
+    // Verify the event includes both homePageId and featuredAssetId
+    await expect(testElement).toHaveAttribute("data-home-page-id", "1");
+    await expect(testElement).toHaveAttribute(
+      "data-featured-asset-id",
+      "687969fd9c90c709c1021d01"
+    );
+
+    // Verify the text content
+    await expect(testElement).toContainText("homePageId=1");
+    await expect(testElement).toContainText(
+      "featuredAssetId=687969fd9c90c709c1021d01"
+    );
+  });
+
+  test("CONTENT_LOADED waits for featured asset to load", async ({ page }) => {
+    // Navigate to homepage
+    await page.goto("/");
+
+    // The event should NOT fire until both page content AND featured asset are ready
+    // We can verify this by checking that the featured asset card is rendered
+    await expect(page.locator(".featured-asset-block")).toBeVisible();
+
+    // Now the event should have fired
+    const testElement = page.locator("#test-content-loaded");
+    await expect(testElement).toBeVisible();
+
+    // Verify featured asset ID is in the payload
+    await expect(testElement).toHaveAttribute(
+      "data-featured-asset-id",
+      "687969fd9c90c709c1021d01"
+    );
+  });
+});
+
+test.describe("HomePage - IMAGES_LOADED Event", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({
+      page,
+      workerId,
+    });
+
+    await refreshDatabase({ request, workerId });
+
+    // Update instance with a script that listens for IMAGES_LOADED
+    await updateInstance({
+      request,
+      workerId,
+      updates: {
+        customHeaderMode: 2, // ShowCustomHeaderMode.HOME_PAGE_ONLY
+        customHeader: `
+          <script>
+            // Track all IMAGES_LOADED events (HomePage fires one per area)
+            let eventCount = 0;
+            let totalImagesFromEvents = 0;
+            let totalLoadedFromEvents = 0;
+
+            window.addEventListener('elevator:home-page:images-loaded', (event) => {
+              eventCount++;
+              const { homePageId, featuredAssetId, images } = event.detail;
+
+              console.log(\`IMAGES_LOADED event #\${eventCount}: \${images.length} images\`);
+
+              // Check if all images are actually loaded
+              const allLoaded = images.every(img => img.complete && img.naturalWidth > 0);
+              const loadedCount = images.filter(img => img.complete && img.naturalWidth > 0).length;
+
+              // Accumulate totals from all events
+              totalImagesFromEvents += images.length;
+              totalLoadedFromEvents += loadedCount;
+
+              // Count images currently in DOM
+              const homePageContentImages = document.querySelectorAll('.home-page-content img').length;
+              const featuredAssetImages = document.querySelectorAll('.featured-asset-block img').length;
+
+              // Update/create test element (replace on each event)
+              let testEl = document.getElementById('test-images-loaded');
+              if (!testEl) {
+                testEl = document.createElement('div');
+                testEl.id = 'test-images-loaded';
+                document.body.appendChild(testEl);
+              }
+
+              // Store cumulative data
+              testEl.setAttribute('data-event-count', eventCount.toString());
+              testEl.setAttribute('data-event-total-images', totalImagesFromEvents.toString());
+              testEl.setAttribute('data-event-loaded-images', totalLoadedFromEvents.toString());
+              testEl.setAttribute('data-last-event-count', images.length.toString());
+              testEl.setAttribute('data-last-event-loaded', loadedCount.toString());
+              testEl.setAttribute('data-home-page-id', homePageId?.toString() || 'null');
+              testEl.setAttribute('data-featured-asset-id', featuredAssetId || 'null');
+              testEl.setAttribute('data-home-content-images', homePageContentImages.toString());
+              testEl.setAttribute('data-featured-asset-images', featuredAssetImages.toString());
+              testEl.textContent = \`Events: \${eventCount}, Total from events: \${totalLoadedFromEvents}/\${totalImagesFromEvents}\`;
+            });
+          </script>
+        `,
+      },
+    });
+
+    await loginUser({ request, page, workerId });
+  });
+
+  test("emits IMAGES_LOADED events for both content areas", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: "Elevator Home Page" })
+    ).toBeVisible();
+
+    const testElement = page.locator("#test-images-loaded");
+    await expect(testElement).toBeVisible({ timeout: 15000 });
+
+    // Wait a bit longer to see if a second event fires
+    await page.waitForTimeout(2000);
+
+    // Get all the attributes
+    const eventCount = await testElement.getAttribute("data-event-count");
+    const eventTotalImages = await testElement.getAttribute(
+      "data-event-total-images"
+    );
+    const eventLoadedImages = await testElement.getAttribute(
+      "data-event-loaded-images"
+    );
+
+    const actualEventCount = parseInt(eventCount || "0");
+    const totalFromEvents = parseInt(eventTotalImages || "0");
+    const loadedFromEvents = parseInt(eventLoadedImages || "0");
+
+    // Verify 2 events fired (one for .home-page-content, one for .featured-asset-block)
+    expect(actualEventCount).toBe(2);
+
+    // Verify we got at least the 2 images from the page content
+    // Note: The featured asset uses LazyLoadImage which may not be loaded yet when events fire,
+    // so we might get 2-3 images total depending on timing
+    expect(totalFromEvents).toBeGreaterThanOrEqual(2);
+    expect(loadedFromEvents).toBeGreaterThanOrEqual(2);
+
+    // Verify the event includes the correct IDs
+    await expect(testElement).toHaveAttribute("data-home-page-id", "1");
+    await expect(testElement).toHaveAttribute(
+      "data-featured-asset-id",
+      "687969fd9c90c709c1021d01"
+    );
+  });
+});

--- a/tests/e2e/homepage-events.spec.ts
+++ b/tests/e2e/homepage-events.spec.ts
@@ -26,14 +26,14 @@ test.describe("HomePage - CONTENT_LOADED Event", () => {
           <script>
             // Listen for the home page content loaded event
             window.addEventListener('elevator:static-content-page:content-loaded', (event) => {
-              const { homePageId, featuredAssetId } = event.detail;
+              const { pageId, featuredAssetId } = event.detail;
 
               // Add test element to verify event fired
               const testEl = document.createElement('div');
               testEl.id = 'test-content-loaded';
-              testEl.setAttribute('data-home-page-id', homePageId?.toString() || 'null');
+              testEl.setAttribute('data-page-id', pageId?.toString() || 'null');
               testEl.setAttribute('data-featured-asset-id', featuredAssetId || 'null');
-              testEl.textContent = \`home page loaded: homePageId=\${homePageId}, featuredAssetId=\${featuredAssetId}\`;
+              testEl.textContent = \`home page loaded: pageId=\${pageId}, featuredAssetId=\${featuredAssetId}\`;
               document.body.appendChild(testEl);
             });
           </script>
@@ -64,14 +64,14 @@ test.describe("HomePage - CONTENT_LOADED Event", () => {
     await expect(testElement).toBeVisible();
 
     // Verify the event includes both homePageId and featuredAssetId
-    await expect(testElement).toHaveAttribute("data-home-page-id", "1");
+    await expect(testElement).toHaveAttribute("data-page-id", "1");
     await expect(testElement).toHaveAttribute(
       "data-featured-asset-id",
       "687969fd9c90c709c1021d01"
     );
 
     // Verify the text content
-    await expect(testElement).toContainText("homePageId=1");
+    await expect(testElement).toContainText("pageId=1");
     await expect(testElement).toContainText(
       "featuredAssetId=687969fd9c90c709c1021d01"
     );
@@ -122,7 +122,7 @@ test.describe("HomePage - IMAGES_LOADED Event", () => {
 
             window.addEventListener('elevator:static-content-page:images-loaded', (event) => {
               eventCount++;
-              const { homePageId, featuredAssetId, images } = event.detail;
+              const { pageId, featuredAssetId, images } = event.detail;
 
               console.log(\`IMAGES_LOADED event #\${eventCount}: \${images.length} images\`);
 
@@ -152,7 +152,7 @@ test.describe("HomePage - IMAGES_LOADED Event", () => {
               testEl.setAttribute('data-event-loaded-images', totalLoadedFromEvents.toString());
               testEl.setAttribute('data-last-event-count', images.length.toString());
               testEl.setAttribute('data-last-event-loaded', loadedCount.toString());
-              testEl.setAttribute('data-home-page-id', homePageId?.toString() || 'null');
+              testEl.setAttribute('data-page-id', pageId?.toString() || 'null');
               testEl.setAttribute('data-featured-asset-id', featuredAssetId || 'null');
               testEl.setAttribute('data-home-content-images', homePageContentImages.toString());
               testEl.setAttribute('data-featured-asset-images', featuredAssetImages.toString());
@@ -194,17 +194,17 @@ test.describe("HomePage - IMAGES_LOADED Event", () => {
     const totalFromEvents = parseInt(eventTotalImages || "0");
     const loadedFromEvents = parseInt(eventLoadedImages || "0");
 
-    // Verify 2 events fired (one for .home-page-content, one for .featured-asset-block)
-    expect(actualEventCount).toBe(2);
+    // Verify only 1 event fired - main content and featured assets
+    // must both be loaded before a single event fires
+    expect(actualEventCount).toBe(1);
 
     // Verify we got at least the 2 images from the page content
-    // Note: The featured asset uses LazyLoadImage which may not be loaded yet when events fire,
     // so we might get 2-3 images total depending on timing
-    expect(totalFromEvents).toBeGreaterThanOrEqual(2);
-    expect(loadedFromEvents).toBeGreaterThanOrEqual(2);
+    expect(totalFromEvents).toBe(2);
+    expect(loadedFromEvents).toBe(2);
 
     // Verify the event includes the correct IDs
-    await expect(testElement).toHaveAttribute("data-home-page-id", "1");
+    await expect(testElement).toHaveAttribute("data-page-id", "1");
     await expect(testElement).toHaveAttribute(
       "data-featured-asset-id",
       "687969fd9c90c709c1021d01"

--- a/tests/e2e/static-content-events.spec.ts
+++ b/tests/e2e/static-content-events.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import {
+  setupWorkerHTTPHeader,
+  loginUser,
+  refreshDatabase,
+  updateInstance,
+} from "../setup";
+
+test.describe("Static Content Page - Custom Events", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({
+      page,
+      workerId,
+    });
+
+    // Refresh the database for this worker
+    await refreshDatabase({ request, workerId });
+
+    // Update instance to include a custom header script that listens for events
+    // IMPORTANT: Do this BEFORE loginUser so the instance data is updated
+    // before the Vue app initializes
+    await updateInstance({
+      request,
+      workerId,
+      updates: {
+        customHeaderMode: 1, // ShowCustomHeaderMode.ALWAYS
+        customHeader: `
+          <script>
+            console.log('Custom header script loaded');
+            // Listen for the static content page loaded event
+            window.addEventListener('elevator:static-content-page:content-loaded', (event) => {
+              const { pageId } = event.detail;
+              console.log('Static content page loaded:', pageId);
+
+              // Count images in the static content
+              const container = document.querySelector('.static-content-page__content');
+              const images = container ? container.querySelectorAll('img') : [];
+
+              // Add a test element we can assert against
+              const testEl = document.createElement('div');
+              testEl.id = 'test-event-received';
+              testEl.textContent = \`images in static content = \${images.length}\`;
+              document.querySelector('#app h1').before(testEl);
+            });
+          </script>
+        `,
+      },
+    });
+
+    // Login user AFTER updating instance
+    await loginUser({ request, page, workerId });
+  });
+
+  test("emits CONTENT_LOADED event when page renders", async ({ page }) => {
+    // Navigate to the "About" page (pageId = 2, which has 2 images)
+    await page.goto("/page/view/2");
+
+    // Wait for the heading to ensure page is loaded
+    await expect(
+      page.getByRole("heading", { name: "About Elevator" })
+    ).toBeVisible();
+
+    // Wait for the test element to appear (proves the event was fired)
+    const testElement = page.locator("#test-event-received");
+    await expect(testElement).toBeVisible();
+
+    // Verify the correct image count
+    await expect(testElement).toHaveText("images in static content = 2");
+  });
+
+  test("emits event for different pages with different image counts", async ({
+    page,
+  }) => {
+    // Navigate to the "Home Page" (pageId = 1, which also has 2 images)
+    await page.goto("/page/view/1");
+
+    // Wait for the heading
+    await expect(
+      page.getByRole("heading", { name: "Elevator Home Page" })
+    ).toBeVisible();
+
+    // Verify event was fired with correct count
+    const testElement = page.locator("#test-event-received");
+    await expect(testElement).toBeVisible();
+    await expect(testElement).toHaveText("images in static content = 2");
+  });
+});

--- a/tests/e2e/static-content-events.spec.ts
+++ b/tests/e2e/static-content-events.spec.ts
@@ -174,4 +174,33 @@ test.describe("Static Content Page - IMAGES_LOADED Event", () => {
       "images loaded: 2/2, all complete: true"
     );
   });
+
+  test("emits IMAGES_LOADED event even when some images fail to load", async ({
+    page,
+  }) => {
+    // Navigate to page 3 which has 1 valid image and 2 broken images
+    await page.goto("/page/view/3");
+
+    await expect(
+      page.getByRole("heading", { name: "Page with Image Load Errors" })
+    ).toBeVisible();
+
+    // Wait for IMAGES_LOADED event (should still fire despite broken images)
+    const testElement = page.locator("#test-images-loaded");
+    await expect(testElement).toBeVisible({ timeout: 15000 });
+
+    // Verify the event fired with all 3 images in the payload
+    await expect(testElement).toHaveAttribute("data-total-count", "3");
+
+    // Verify only 1 image actually loaded successfully
+    await expect(testElement).toHaveAttribute("data-loaded-count", "1");
+
+    // Verify not all images loaded (allLoaded should be false)
+    await expect(testElement).toHaveAttribute("data-all-loaded", "false");
+
+    // Verify the text reflects the mixed state
+    await expect(testElement).toContainText(
+      "images loaded: 1/3, all complete: false"
+    );
+  });
 });

--- a/tests/e2e/static-content-events.spec.ts
+++ b/tests/e2e/static-content-events.spec.ts
@@ -72,7 +72,9 @@ test.describe("Static Content Page - Custom Events", () => {
 
     // Verify the correct image count and page ID
     await expect(testElement).toHaveAttribute("data-page-id", "2");
-    await expect(testElement).toHaveText("page 2: images in static content = 2");
+    await expect(testElement).toHaveText(
+      "page 2: images in static content = 2"
+    );
   });
 
   test("emits event for different pages with different image counts", async ({
@@ -89,7 +91,9 @@ test.describe("Static Content Page - Custom Events", () => {
     // Verify event was fired with correct count
     const testElement = page.locator("#test-event-received");
     await expect(testElement).toBeVisible();
-    await expect(testElement).toHaveText("page 1: images in static content = 2");
+    await expect(testElement).toHaveText(
+      "page 1: images in static content = 2"
+    );
   });
 
   test("emits CONTENT_LOADED event on each page navigation", async ({
@@ -106,7 +110,9 @@ test.describe("Static Content Page - Custom Events", () => {
     const testElement = page.locator("#test-event-received");
     await expect(testElement).toBeVisible();
     await expect(testElement).toHaveAttribute("data-page-id", "1");
-    await expect(testElement).toHaveText("page 1: images in static content = 2");
+    await expect(testElement).toHaveText(
+      "page 1: images in static content = 2"
+    );
 
     // Navigate to page 2 (About - 2 images)
     await page.goto("/page/view/2");
@@ -117,18 +123,22 @@ test.describe("Static Content Page - Custom Events", () => {
 
     // Verify event fired again with pageId = 2
     await expect(testElement).toHaveAttribute("data-page-id", "2");
-    await expect(testElement).toHaveText("page 2: images in static content = 2");
+    await expect(testElement).toHaveText(
+      "page 2: images in static content = 2"
+    );
 
     // Navigate to page 3 (Broken Images - 3 images)
     await page.goto("/page/view/3");
 
     await expect(
-      page.getByRole("heading", { name: "Page with Image Load Errors" })
+      page.getByRole("heading", { name: "Test Page with Broken Images" })
     ).toBeVisible();
 
     // Verify event fired again with pageId = 3
     await expect(testElement).toHaveAttribute("data-page-id", "3");
-    await expect(testElement).toHaveText("page 3: images in static content = 3");
+    await expect(testElement).toHaveText(
+      "page 3: images in static content = 3"
+    );
 
     // Navigate back to page 1 to verify it works in reverse
     await page.goto("/page/view/1");
@@ -139,7 +149,9 @@ test.describe("Static Content Page - Custom Events", () => {
 
     // Verify event fired again with pageId = 1
     await expect(testElement).toHaveAttribute("data-page-id", "1");
-    await expect(testElement).toHaveText("page 1: images in static content = 2");
+    await expect(testElement).toHaveText(
+      "page 1: images in static content = 2"
+    );
   });
 });
 
@@ -238,7 +250,7 @@ test.describe("Static Content Page - IMAGES_LOADED Event", () => {
     await page.goto("/page/view/3");
 
     await expect(
-      page.getByRole("heading", { name: "Page with Image Load Errors" })
+      page.getByRole("heading", { name: "Test Page with Broken Images" })
     ).toBeVisible();
 
     // Wait for IMAGES_LOADED event (should still fire despite broken images)

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -77,3 +77,29 @@ export async function loginUser({
     }
   }
 }
+
+export async function updateInstance({
+  request,
+  workerId,
+  updates,
+}: {
+  request: APIRequestContext;
+  workerId: string;
+  updates: Record<string, unknown>;
+}) {
+  const response = await request.patch(
+    `${MOCK_SERVER_BASE}/_tests/instance/update`,
+    {
+      data: updates,
+      headers: { "x-worker-id": workerId },
+    }
+  );
+
+  if (!response.ok()) {
+    throw new Error(
+      `Instance update failed: ${response.status()} ${await response.text()}`
+    );
+  }
+
+  return await response.json();
+}


### PR DESCRIPTION
This adds functionality for Elevator admins to add custom scripts which  can respond to page content loads or image loads.

A large chunk of the PR is adding tests to convince myself that we're correctly handling edge cases.

## Problem: Legacy App vs SPA Script Execution

As an example, suppose an admin wishes to add a custom script which turns  images on a particular static page into a carousel.

In the legacy UI, admins could add the script directly in the custom app header which adds an event  listener on load. Each new page navigation would trigger a full page  reload, rerunning all scripts and attaching event handlers as needed. This simple model worked because:
- Every navigation was a fresh start with a clean DOM
- Scripts could safely assume they ran once per page view
- Standard browser events (DOMContentLoaded, load) fired reliably

But the new UI is a single page app (SPA), which breaks this approach:

1. **Standard browser events don't fire on navigation.** Events like  `DOMContentLoaded` and `window.load` only fire once when the SPA initially loads, so scripts listening for these events will never respond to route changes.

2. **We cannot naively rerun custom scripts on each route change.** Each page nav isn't a fresh start with a clean dom in SPA navigation,  so re-execution of scripts may attach new event listeners or initialize components,  creating multiple handlers for the same elements. This leads to:
   - Memory leaks from accumulated listeners
   - Multiple responses to a single event (e.g., carousel initializing 3x)
   - Unpredictable behavior as state accumulates across navigations

3. **Custom scripts lack visibility into SPA routing.** Admin-provided scripts have no easy way to detect when the SPA has navigated to a new page. Monitoring route changes is not enough since the SPA will need to fetch page content from the api before it can update the DOM.

## Solution: Parse-Once Execution + Custom Lifecycle Events

This PR updates script handling to address these problems:

### 1. Parse and run custom scripts at app initialization (not when CustomAppHeader renders)

Previously, scripts were parsed in the `<SaniitizeHTML>` component as part of `<CustomAppHeader>`. This had two issues:
   - not every page has the custom app header, so navigation may cause a rerender and thus re-execution of these scripts
   - the default behavior of the sanitize component was to execute any embedded scripts, which isn't great

Instead, 
- we moved script parsing and execution to the `instanceStore` which is responsible for fetching and parsing the customAppHeader and footer already. 
- `instanceStore` now has a new property,`customScripts`, to hold any script elements from the `customHeader` and `customFooter`
- `instanceStore.customHeader`, `instanceStore.customFooter` properties will only hold scriptless HTML
- `<SanitizeHTML>` updated to remove scripts from html
- `instanceStore` will execute any `customScripts` once at app initialization

### 2. Emit custom lifecycle events on navigation:
   - `elevator:static-page:content-loaded` - Fired when new page content has been inserted into the DOM
   - `elevator:static-page:images-loaded` - Fired when all images on the new page have finished loading

Scripts can listen for these events to respond to navigation:
   
   ```javascript
   // Example: Initialize carousel on every page navigation
   document.addEventListener('elevator:static-page:images-loaded', () => {
     const carousel = document.querySelector('.carousel');
     if (carousel) {
       initCarousel(carousel);
     }
   });
```

### 3. Homepage feature assets

If the homepage has a feature asset, we wait for BOTH the page content and featured asset info to load before emitting events.

## Other Details
- we emit `images-loaded` if an image loads OR errors (e.g. 404)
- if a page has no images, we still emit `images-loaded`. 
- we set a timeout of 10s for image loads. If some image hasn't loaded within 10s, we consider it an error and fire the `images-loaded` event. We may want to change this behavior.
- for `content-loaded', the`event.detail` payload includes `{ pageId: 2 }` in case there's page specific JS.
- similarly, for `images-loaded`, the `event.detail` payload includes `{ pageId: 3, images: [...image elements] }`

## Testing

You can test the behavior on dev, by adding a custom script to the Custom Header admin setting:

```html
<script>
window.addEventListener('elevator:static-content-page:content-loaded', (event) => {
  console.log('Static content page loaded:', {...event.detail});
});

window.addEventListener('elevator:static-content-page:images-loaded', (event) => {
  console.log('Images loaded', { ...event.detail })
});
</script>
```

It should behave something like this:

https://github.com/user-attachments/assets/29be2ca5-e18c-4e5c-a1c8-6c40ead2ec49
