### PR TITLE
Add Admin Instance Settings page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
       <ToastRoot />
     </Teleport>
     <ErrorBoundary>
-      <RouterView v-if="instanceStore.isReady && drawerStore.isReady" />
+      <RouterView v-if="instanceStore.hasData && drawerStore.isReady" />
     </ErrorBoundary>
   </div>
 </template>

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -854,9 +854,15 @@ export async function fetchInstanceSettings(
   return res.data;
 }
 
+export type UpdateInstanceSettingsParams = Partial<InstanceSettings> & {
+  instanceId: number;
+  customHeaderImage?: File | null;
+};
+
 export async function updateInstanceSettings(
-  settings: Partial<InstanceSettings> & { instanceId: number }
+  params: UpdateInstanceSettingsParams
 ): Promise<{ success: boolean; message: string }> {
+  const { customHeaderImage, ...settings } = params;
   const formData = new FormData();
 
   // Append each setting to the form data
@@ -873,6 +879,11 @@ export async function updateInstanceSettings(
       formData.append(key, String(value));
     }
   });
+
+  // Append header logo image if provided
+  if (customHeaderImage) {
+    formData.append("customHeaderImage", customHeaderImage);
+  }
 
   // Use /true to get JSON response instead of redirect
   const res = await axios.post<{ success: boolean; message: string }>(

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -37,6 +37,7 @@ import {
   type GetFileContainerApiResponse,
   CollectionDescription,
   ApiAssetSubmissionResponse,
+  InstanceSettings
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -840,6 +841,44 @@ export async function checkPreviewImages(fileIds: string[]) {
       status: "icon" | "true";
     }>
   >(`${BASE_URL}/fileManager/previewImageAvailable`, formData);
+
+  return res.data;
+}
+
+export async function fetchInstanceSettings(
+  instanceId: number
+): Promise<InstanceSettings> {
+  const res = await axios.get<InstanceSettings>(
+    `${BASE_URL}/instances/getInstance/${instanceId}`
+  );
+  return res.data;
+}
+
+export async function updateInstanceSettings(
+  settings: Partial<InstanceSettings> & { instanceId: number }
+): Promise<{ success: boolean; message: string }> {
+  const formData = new FormData();
+
+  // Append each setting to the form data
+  Object.entries(settings).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => formData.append(`${key}[]`, String(item)));
+    } else if (typeof value === "boolean") {
+      formData.append(key, value ? "1" : "0");
+    } else {
+      formData.append(key, String(value));
+    }
+  });
+
+  // Use /true to get JSON response instead of redirect
+  const res = await axios.post<{ success: boolean; message: string }>(
+    `${BASE_URL}/instances/save/true`,
+    formData
+  );
 
   return res.data;
 }

--- a/src/components/AppMenu/AdminNavSection.vue
+++ b/src/components/AppMenu/AdminNavSection.vue
@@ -1,6 +1,6 @@
 <template>
   <AppMenuGroup label="Admin">
-    <AppMenuItem :href="`${BASE_URL}/instances/edit/${instance.id}`">
+    <AppMenuItem :to="`/instances/edit/${instance.id}`">
       Instance Settings
     </AppMenuItem>
     <AppMenuItem :href="`${BASE_URL}/permissions/edit/instance/${instance.id}`">

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -4,7 +4,7 @@
       <div
         v-if="error"
         class="fixed inset-0 z-40 bg-transparent-black-700 flex items-center justify-center">
-        <SignInRequiredNotice v-if="isCurrentUserUnauthorized" />
+        <SignInRequiredNotice v-if="isCurrentUserUnauthenticated" />
 
         <Notification
           v-else
@@ -31,13 +31,9 @@ import Button from "../Button/Button.vue";
 import { useErrorStore } from "@/stores/errorStore";
 import Notification from "../Notification/Notification.vue";
 import { ApiError } from "@/api/ApiError";
-import { useInstanceStore } from "@/stores/instanceStore";
 import SignInRequiredNotice from "@/pages/HomePage/SignInRequiredNotice.vue";
-import config from "@/config";
 
-const BASE_URL = config.instance.base.url;
 const errorStore = useErrorStore();
-const instanceStore = useInstanceStore();
 
 const error = computed(() => errorStore.error);
 const errorTitle = computed(() => {
@@ -51,12 +47,8 @@ const errorTitle = computed(() => {
 
   return `Error: ${error.value.statusCode}`;
 });
-const isCurrentUserUnauthorized = computed(() => {
-  return (
-    !instanceStore.isLoggedIn &&
-    error.value instanceof ApiError &&
-    error.value.statusCode === 401
-  );
+const isCurrentUserUnauthenticated = computed(() => {
+  return error.value instanceof ApiError && error.value.statusCode === 401;
 });
 
 const messages: Record<number | string, string> = {

--- a/src/components/Form/FormSection.vue
+++ b/src/components/Form/FormSection.vue
@@ -1,0 +1,17 @@
+<template>
+  <section
+    :id="id"
+    class="border-t border-neutral-300 py-6 grid sm:grid-cols-[15rem,1fr] gap-4 items-start">
+    <h2 class="text-lg font-semibold">{{ title }}</h2>
+    <div class="space-y-4">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  id: string;
+  title: string;
+}>();
+</script>

--- a/src/components/Form/FormToc.vue
+++ b/src/components/Form/FormToc.vue
@@ -1,0 +1,43 @@
+<template>
+  <nav>
+    <h2 class="text-xs tracking-wide font-medium uppercase mb-2 opacity-70">
+      {{ title }}
+    </h2>
+    <ol class="text-sm space-y-1">
+      <li v-for="section in sections" :key="section.id">
+        <a
+          :href="`#${section.id}`"
+          class="block py-1 text-current opacity-70 hover:opacity-100 transition-opacity no-underline hover:no-underline"
+          @click.prevent="scrollToSection(section.id)">
+          {{ section.label }}
+        </a>
+      </li>
+    </ol>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import type { TocItem } from "@/types";
+
+const props = withDefaults(
+  defineProps<{
+    sections: TocItem[];
+    title?: string;
+    offset?: number;
+  }>(),
+  {
+    title: "Contents",
+    offset: 80,
+  }
+);
+
+function scrollToSection(id: string) {
+  const element = document.getElementById(id);
+  if (element) {
+    window.scrollTo({
+      top: element.offsetTop - props.offset,
+      behavior: "smooth",
+    });
+  }
+}
+</script>

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,0 +1,2 @@
+export { default as FormSection } from "./FormSection.vue";
+export { default as FormToc } from "./FormToc.vue";

--- a/src/components/TextAreaGroup/TextAreaGroup.vue
+++ b/src/components/TextAreaGroup/TextAreaGroup.vue
@@ -23,7 +23,7 @@
         :name="`textarea-${id}`"
         :class="
           cn(
-            'text-area-input block w-full rounded-md border-none focus:border-blue-500 focus:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-2  sm:text-sm p-2 font-mono text-neutral-700 focus:text-neutral-900 h-24 bg-black/5 placeholder:text-black/30',
+            'text-area-input block w-full rounded-md border-none focus:border-blue-500 focus:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-2 sm:text-sm px-4  py-2 text-neutral-700 focus:text-neutral-900 h-24 bg-black/5 placeholder:text-black/25',
             inputClass
           )
         "

--- a/src/components/TextAreaGroup/TextAreaGroup.vue
+++ b/src/components/TextAreaGroup/TextAreaGroup.vue
@@ -23,7 +23,7 @@
         :name="`textarea-${id}`"
         :class="
           cn(
-            'text-area-input block w-full rounded border-neutral-300 focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2 font-mono text-neutral-700 focus:text-neutral-900 h-24',
+            'text-area-input block w-full rounded-md border-none focus:border-blue-500 focus:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-2  sm:text-sm p-2 font-mono text-neutral-700 focus:text-neutral-900 h-24 bg-black/5 placeholder:text-black/30',
             inputClass
           )
         "

--- a/src/components/ToggleGroup/ToggleGroup.vue
+++ b/src/components/ToggleGroup/ToggleGroup.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="flex items-center justify-between gap-4 flex-wrap">
+    <label
+      :id="labelId"
+      class="text-sm text-neutral-700 cursor-pointer"
+      @click="$emit('update:modelValue', !modelValue)">
+      {{ label }}
+    </label>
+    <Toggle
+      :modelValue="modelValue"
+      :settingLabel="label"
+      @update:modelValue="$emit('update:modelValue', $event)" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useId } from "vue";
+import Toggle from "@/components/Toggle/Toggle.vue";
+
+defineProps<{
+  modelValue: boolean;
+  label: string;
+}>();
+
+defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+}>();
+
+const labelId = useId();
+</script>

--- a/src/layouts/FormPageLayout.vue
+++ b/src/layouts/FormPageLayout.vue
@@ -1,0 +1,26 @@
+<template>
+  <div
+    class="md:grid lg:grid-cols-[minmax(0,1fr),minmax(auto,20rem)] relative min-h-screen">
+    <div class="p-4 md:p-8 max-w-4xl mx-auto w-full mb-20 lg:mb-0">
+      <header v-if="$slots.header || title" class="mb-8">
+        <slot name="header">
+          <h1 class="text-2xl md:text-4xl font-bold">{{ title }}</h1>
+        </slot>
+      </header>
+      <slot />
+    </div>
+    <aside
+      class="sidebar-container bg-[--app-sidebar-backgroundColor] text-[--app-sidebar-textColor] [border-left:var(--app-borderWidth)_solid_var(--app-borderColor)] p-6 fixed bottom-0 left-0 w-full lg:static">
+      <div class="sticky top-20 flex flex-col gap-6">
+        <slot name="sidebar-actions" />
+        <slot name="sidebar-nav" />
+      </div>
+    </aside>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title?: string;
+}>();
+</script>

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -82,16 +82,26 @@
             <ToggleGroup v-model="form.useHeaderLogo" label="Use Header Logo" />
 
             <template #details>
-              <label id="headerImageInput" class="sr-only">
-                Upload Header Image (PNG)
-              </label>
-              <input
-                id="headerImageInput"
-                ref="headerImageInput"
-                type="file"
-                accept="image/png"
-                class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border file:border-blue-500 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                @change="handleHeaderImageChange" />
+              <div class="flex gap-4 items-center">
+                <img
+                  v-if="headerImagePreview"
+                  :src="headerImagePreview"
+                  alt="Header Image Preview"
+                  class="size-16 mb-2 block object-cover" />
+                <ElevatorIcon v-else class="h-16 mb-2 text-neutral-400" />
+                <div>
+                  <label id="headerImageInput" class="sr-only">
+                    Upload Header Image (PNG)
+                  </label>
+                  <input
+                    id="headerImageInput"
+                    ref="headerImageInput"
+                    type="file"
+                    accept="image/png"
+                    class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border file:border-blue-500 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                    @change="handleHeaderImageChange" />
+                </div>
+              </div>
             </template>
           </FormSubSection>
         </FormSection>
@@ -288,12 +298,17 @@ import {
 import type { InstanceSettings, SelectOption, TocItem } from "@/types";
 import { FormSection, FormToc } from "@/components/Form";
 import ToggleGroup from "@/components/ToggleGroup/ToggleGroup.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
+import ElevatorIcon from "@/icons/ElevatorIcon.vue";
 
 const props = defineProps<{
   instanceId: number;
 }>();
 
 const toastStore = useToastStore();
+
+// for easier access to logo url
+const instanceStore = useInstanceStore();
 
 const {
   data: settingsData,
@@ -336,7 +351,7 @@ const headerImagePreview = computed(() => {
   }
   // Show existing image if useHeaderLogo is enabled
   if (form.value.useHeaderLogo) {
-    return `${config.instance.base.origin}/assets/instanceAssets/${props.instanceId}.png`;
+    return instanceStore.instance.logoImg?.src || null;
   }
   return null;
 });
@@ -438,7 +453,10 @@ async function handleSave() {
       customHeaderImage: selectedHeaderImage.value,
     });
 
+    await instanceStore.refreshLogoImage();
+
     // Clear the selected file after successful save
+    // do this after refresh to avoid broken image flicker
     selectedHeaderImage.value = null;
 
     toastStore.addToast({

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -1,6 +1,15 @@
 <template>
   <DefaultLayout>
-    <div class="p-8 px-4">Instance Settings page</div>
+    <div class="p-8 px-4">
+      <header>
+        <p class="text-2xl md:text-4xl font-bold text-neutral-400">Admin</p>
+        <h1 class="text-2xl md:text-4xl font-bold">Instance Settings</h1>
+      </header>
+
+      <section>
+        <h2>General</h2>
+      </section>
+    </div>
   </DefaultLayout>
 </template>
 <script setup lang="ts">

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -34,9 +34,6 @@
             placeholder="Internal notes about this instance"
             inputClass="h-24"
             @update:modelValue="form.notes = $event || null" />
-        </FormSection>
-
-        <FormSection id="authentication" title="Authentication">
           <ToggleGroup
             v-model="form.useCentralAuth"
             label="Use Central Authentication" />
@@ -80,30 +77,21 @@
                 @update:modelValue="form.customHeaderCSS = $event || null" />
             </template>
           </FormSubSection>
-          <FormSubSection :isOpen="form.useHeaderLogo">
+
+          <FormSubSection :isOpen="!!form.useHeaderLogo">
             <ToggleGroup v-model="form.useHeaderLogo" label="Use Header Logo" />
+
             <template #details>
-              <div v-if="form.useHeaderLogo" class="space-y-3">
-                <label class="block text-xs font-medium uppercase">
-                  Logo Image (PNG)
-                </label>
-                <div
-                  v-if="headerImagePreview && !headerImageError"
-                  class="border border-neutral-200 rounded-md p-2 bg-neutral-50">
-                  <img
-                    :src="headerImagePreview"
-                    alt="Current header image"
-                    class="max-h-24 object-contain"
-                    @error="headerImageError = true"
-                    @load="headerImageError = false" />
-                </div>
-                <input
-                  ref="headerImageInput"
-                  type="file"
-                  accept="image/png"
-                  class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                  @change="handleHeaderImageChange" />
-              </div>
+              <label id="headerImageInput" class="sr-only">
+                Upload Header Image (PNG)
+              </label>
+              <input
+                id="headerImageInput"
+                ref="headerImageInput"
+                type="file"
+                accept="image/png"
+                class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border file:border-blue-500 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                @change="handleHeaderImageChange" />
             </template>
           </FormSubSection>
         </FormSection>
@@ -417,7 +405,6 @@ const allThemes = computed(() => config.instance.theming.availableThemes);
 // Table of contents sections
 const tocSections: TocItem[] = [
   { id: "general", label: "General" },
-  { id: "authentication", label: "Authentication" },
   { id: "customization", label: "Customization" },
   { id: "storage", label: "Storage" },
   { id: "featured-asset", label: "Featured Asset" },

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -2,10 +2,17 @@
   <DefaultLayout>
     <div class="p-4 md:p-8 max-w-4xl mx-auto w-full">
       <header class="mb-8">
-        <p class="text-sm md:text-base font-medium text-neutral-500 uppercase">
+        <p
+          class="text-sm md:text-base font-medium text-neutral-500 uppercase flex items-center gap-1">
           Admin
+          <template v-if="form.name">
+            <ChevronRightIcon class="!w-4 !h-4" />
+            Instance Settings
+          </template>
         </p>
-        <h1 class="text-2xl md:text-4xl font-bold">Instance Settings</h1>
+        <h1 class="text-2xl md:text-4xl font-bold">
+          {{ form.name || "Instance Settings" }}
+        </h1>
       </header>
 
       <div v-if="isLoading" class="flex justify-center items-center py-12">
@@ -245,6 +252,7 @@ import {
   getDefaultInstanceSettings,
 } from "@/queries/useInstanceSettingsQuery";
 import type { InstanceSettings, SelectOption } from "@/types";
+import { ChevronRightIcon } from "@/icons";
 
 const props = defineProps<{
   instanceId: number;

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -1,287 +1,275 @@
 <template>
   <DefaultLayout>
-    <div
-      class="md:grid lg:grid-cols-[minmax(0,1fr),minmax(auto,20rem)] relative min-h-screen">
-      <div class="p-4 md:p-8 max-w-4xl mx-auto w-full mb-20 lg:mb-0">
-        <header class="mb-8">
-          <h1 class="text-2xl md:text-4xl font-bold">Instance Settings</h1>
-        </header>
-
-        <div v-if="isLoading" class="flex justify-center items-center py-12">
-          <SpinnerIcon class="w-8 h-8 animate-spin" />
-          <span class="ml-2">Loading settings...</span>
-        </div>
-
-        <div
-          v-else-if="isError"
-          class="text-red-600 p-4 bg-red-50 rounded-md border border-red-200">
-          Failed to load instance settings.
-        </div>
-
-        <form v-else id="instance-settings-form" @submit.prevent="handleSave">
-          <!-- General Settings -->
-          <FormSection id="general" title="General">
-            <InputGroup
-              v-model="form.name"
-              label="Instance Name"
-              required
-              placeholder="My Elevator Instance" />
-            <InputGroup
-              v-model="form.domain"
-              label="Domain"
-              required
-              placeholder="example.edu" />
-            <InputGroup
-              v-model="form.ownerHomepage"
-              label="Owner Contact"
-              placeholder="https:// or mailto:" />
-            <TextAreaGroup
-              :modelValue="form.notes ?? ''"
-              label="Instance Notes"
-              placeholder="Internal notes about this instance"
-              inputClass="h-24"
-              @update:modelValue="form.notes = $event || null" />
-          </FormSection>
-
-          <FormSection id="authentication" title="Authentication">
-            <ToggleField
-              v-model="form.useCentralAuth"
-              label="Use Central Authentication" />
-          </FormSection>
-
-          <FormSection id="customization" title="Customization">
-            <InputGroup
-              v-model="form.customHomeRedirect"
-              label="Custom Home Redirect"
-              placeholder="e.g. /collections or custom URL" />
-            <InputGroup
-              v-model="form.googleAnalyticsKey"
-              label="Google Analytics Key"
-              placeholder="UA-XXXXX-Y or G-XXXXXXX" />
-            <SelectGroup
-              v-model="form.useCustomHeader"
-              :options="customHeaderOptions"
-              label="Display Custom Header/Footer" />
-            <TextAreaGroup
-              v-if="!!form.useCustomHeader"
-              :modelValue="form.customHeaderText ?? ''"
-              label="Custom Header Content"
-              placeholder="HTML content for custom header"
-              inputClass="h-24 font-mono text-sm"
-              @update:modelValue="form.customHeaderText = $event || null" />
-            <TextAreaGroup
-              v-if="!!form.useCustomHeader"
-              :modelValue="form.customFooterText ?? ''"
-              label="Custom Footer Content"
-              placeholder="HTML content for custom footer"
-              inputClass="h-24 font-mono text-sm"
-              @update:modelValue="form.customFooterText = $event || null" />
-
-            <FormSubSection :isOpen="!!form.useCustomCSS">
-              <ToggleField v-model="form.useCustomCSS" label="Use Custom CSS" />
-              <template #details>
-                <TextAreaGroup
-                  v-if="!!form.useCustomCSS"
-                  :modelValue="form.customHeaderCSS ?? ''"
-                  label="Custom CSS"
-                  placeholder="Custom CSS styles"
-                  inputClass="h-32 font-mono text-sm"
-                  @update:modelValue="form.customHeaderCSS = $event || null" />
-              </template>
-            </FormSubSection>
-            <FormSubSection :isOpen="form.useHeaderLogo">
-              <ToggleField
-                v-model="form.useHeaderLogo"
-                label="Use Header Logo" />
-              <template #details>
-                <div v-if="form.useHeaderLogo" class="space-y-3">
-                  <label class="block text-xs font-medium uppercase">
-                    Logo Image (PNG)
-                  </label>
-                  <div
-                    v-if="headerImagePreview && !headerImageError"
-                    class="border border-neutral-200 rounded-md p-2 bg-neutral-50">
-                    <img
-                      :src="headerImagePreview"
-                      alt="Current header image"
-                      class="max-h-24 object-contain"
-                      @error="headerImageError = true"
-                      @load="headerImageError = false" />
-                  </div>
-                  <input
-                    ref="headerImageInput"
-                    type="file"
-                    accept="image/png"
-                    class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                    @change="handleHeaderImageChange" />
-                </div>
-              </template>
-            </FormSubSection>
-          </FormSection>
-
-          <FormSection id="storage" title="Storage">
-            <InputGroup
-              v-model="form.amazonS3Key"
-              label="Amazon S3 Key"
-              placeholder="AWS access key ID" />
-            <InputGroup
-              v-model="form.amazonS3Secret"
-              label="Amazon S3 Secret"
-              :type="showS3Secret ? 'text' : 'password'"
-              placeholder="AWS secret access key">
-              <template #append>
-                <button
-                  type="button"
-                  class="p-1.5 text-neutral-500 hover:text-neutral-700 focus:outline-none"
-                  @click="showS3Secret = !showS3Secret">
-                  <EyeIcon v-if="showS3Secret" class="w-5 h-5" />
-                  <EyeOffIcon v-else class="w-5 h-5" />
-                </button>
-              </template>
-            </InputGroup>
-            <InputGroup
-              v-model="form.defaultBucket"
-              label="Default Bucket"
-              placeholder="S3 bucket name" />
-            <InputGroup
-              v-model="form.bucketRegion"
-              label="Bucket Region"
-              placeholder="e.g., us-east-1" />
-          </FormSection>
-
-          <FormSection id="featured-asset" title="Featured Asset">
-            <InputGroup
-              v-model="form.featuredAsset"
-              label="Featured Asset ID"
-              placeholder="Asset ID for homepage feature" />
-            <TextAreaGroup
-              :modelValue="form.featuredAssetText ?? ''"
-              label="Featured Asset Text"
-              placeholder="Text to display above the featured asset"
-              @update:modelValue="form.featuredAssetText = $event || null" />
-          </FormSection>
-
-          <FormSection id="search-settings" title="Search">
-            <ToggleField
-              v-model="form.showCollectionInSearchResults"
-              label="Show Collection in Search Results" />
-            <ToggleField
-              v-model="form.showTemplateInSearchResults"
-              label="Show Template in Search Results" />
-            <ToggleField
-              v-model="form.allowIndexing"
-              label="Allow Search Engine Indexing" />
-            <ToggleField
-              v-model="form.autoloadMaxSearchResults"
-              label="Autoload Search Results (under 1000)" />
-          </FormSection>
-
-          <FormSection id="assets" title="Assets">
-            <ToggleField
-              v-model="form.enableInterstitial"
-              label="Show Interstitial When Embedding via API" />
-            <TextAreaGroup
-              v-if="form.enableInterstitial"
-              :modelValue="form.interstitialText ?? ''"
-              label="Interstitial Text"
-              placeholder="Text shown in embed interstitial"
-              inputClass="h-24"
-              @update:modelValue="form.interstitialText = $event || null" />
-            <ToggleField
-              v-model="form.showPreviousNextSearchResults"
-              label="Show Previous/Next in Asset View" />
-            <ToggleField
-              v-model="form.hideVideoAudio"
-              label="Hide Video/Audio Download Links" />
-            <ToggleField
-              v-model="form.automaticAltText"
-              label="Auto-generate Alt Text and Captions" />
-            <ToggleField
-              v-model="form.useVoyagerViewer"
-              label="Use Smithsonian Voyager for 3D" />
-            <ToggleField
-              v-model="form.enableHLSStreaming"
-              label="Enable HLS Streaming" />
-            <InputGroup
-              v-model="form.maximumMoreLikeThis"
-              label="More Like This Results"
-              type="number" />
-            <InputGroup
-              v-model="form.defaultTextTruncationHeight"
-              label="Text Area Collapsed Height (px)"
-              type="number" />
-          </FormSection>
-
-          <FormSection id="user-interface" title="User Interface">
-            <SelectGroup
-              v-model="form.interfaceVersion"
-              :options="interfaceVersionOptions"
-              label="Interface Version" />
-            <FormSubSection
-              v-if="!!form.interfaceVersion"
-              :isOpen="form.enableTheming">
-              <ToggleField
-                v-model="form.enableTheming"
-                label="Enable Theme Selection" />
-              <template #details>
-                <SelectGroup
-                  v-if="form.enableTheming"
-                  v-model="form.defaultTheme"
-                  :options="themeOptions"
-                  label="Default Theme" />
-                <div v-if="form.enableTheming" class="space-y-2">
-                  <label class="block text-xs font-medium uppercase">
-                    Available Themes
-                  </label>
-                  <div class="flex flex-wrap gap-4">
-                    <label
-                      v-for="theme in allThemes"
-                      :key="theme"
-                      class="flex items-center gap-2 text-sm">
-                      <input
-                        type="checkbox"
-                        :value="theme"
-                        :checked="form.availableThemes?.includes(theme)"
-                        class="rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
-                        @change="toggleTheme(theme)" />
-                      {{ theme }}
-                    </label>
-                  </div>
-                </div>
-              </template>
-            </FormSubSection>
-          </FormSection>
-        </form>
+    <FormPageLayout title="Instance Settings">
+      <div v-if="isLoading" class="flex justify-center items-center py-12">
+        <SpinnerIcon class="w-8 h-8 animate-spin" />
+        <span class="ml-2">Loading settings...</span>
       </div>
-      <!-- sidebar -->
-      <aside
-        class="sidebar-container bg-[--app-sidebar-backgroundColor] text-[--app-sidebar-textColor] [border-left:var(--app-borderWidth)_solid_var(--app-borderColor)] p-6 fixed bottom-0 left-0 w-full lg:static">
-        <div class="sticky top-20 flex flex-col gap-6">
-          <div v-if="!isLoading && !isError" class="grid grid-cols-2 gap-2">
-            <Button
-              variant="secondary"
-              :disabled="!hasUnsavedChanges"
-              @click="handleCancel">
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              form="instance-settings-form"
-              variant="primary"
-              :disabled="isSaving">
-              <SpinnerIcon v-if="isSaving" class="w-4 h-4 animate-spin" />
-              {{ isSaving ? "Saving..." : "Save" }}
-            </Button>
-            <p
-              v-if="hasUnsavedChanges"
-              class="col-span-2 text-xs text-amber-600 text-center">
-              You have unsaved changes
-            </p>
-          </div>
-          <SettingsTableOfContents class="hidden lg:block" />
+
+      <div
+        v-else-if="isError"
+        class="text-red-600 p-4 bg-red-50 rounded-md border border-red-200">
+        Failed to load instance settings.
+      </div>
+
+      <form v-else id="instance-settings-form" @submit.prevent="handleSave">
+        <FormSection id="general" title="General">
+          <InputGroup
+            v-model="form.name"
+            label="Instance Name"
+            required
+            placeholder="My Elevator Instance" />
+          <InputGroup
+            v-model="form.domain"
+            label="Domain"
+            required
+            placeholder="example.edu" />
+          <InputGroup
+            v-model="form.ownerHomepage"
+            label="Owner Contact"
+            placeholder="https:// or mailto:" />
+          <TextAreaGroup
+            :modelValue="form.notes ?? ''"
+            label="Instance Notes"
+            placeholder="Internal notes about this instance"
+            inputClass="h-24"
+            @update:modelValue="form.notes = $event || null" />
+        </FormSection>
+
+        <FormSection id="authentication" title="Authentication">
+          <ToggleGroup
+            v-model="form.useCentralAuth"
+            label="Use Central Authentication" />
+        </FormSection>
+
+        <FormSection id="customization" title="Customization">
+          <InputGroup
+            v-model="form.customHomeRedirect"
+            label="Custom Home Redirect"
+            placeholder="e.g. /collections or custom URL" />
+          <InputGroup
+            v-model="form.googleAnalyticsKey"
+            label="Google Analytics Key"
+            placeholder="UA-XXXXX-Y or G-XXXXXXX" />
+          <SelectGroup
+            v-model="form.useCustomHeader"
+            :options="customHeaderOptions"
+            label="Display Custom Header/Footer" />
+          <TextAreaGroup
+            :modelValue="form.customHeaderText ?? ''"
+            label="Custom Header Content"
+            placeholder="HTML content for custom header"
+            inputClass="h-24 font-mono text-sm"
+            @update:modelValue="form.customHeaderText = $event || null" />
+          <TextAreaGroup
+            :modelValue="form.customFooterText ?? ''"
+            label="Custom Footer Content"
+            placeholder="HTML content for custom footer"
+            inputClass="h-24 font-mono text-sm"
+            @update:modelValue="form.customFooterText = $event || null" />
+
+          <FormSubSection :isOpen="!!form.useCustomCSS">
+            <ToggleGroup v-model="form.useCustomCSS" label="Use Custom CSS" />
+            <template #details>
+              <TextAreaGroup
+                v-if="!!form.useCustomCSS"
+                :modelValue="form.customHeaderCSS ?? ''"
+                label="Custom CSS"
+                placeholder="Custom CSS styles"
+                inputClass="h-32 font-mono text-sm"
+                @update:modelValue="form.customHeaderCSS = $event || null" />
+            </template>
+          </FormSubSection>
+          <FormSubSection :isOpen="form.useHeaderLogo">
+            <ToggleGroup v-model="form.useHeaderLogo" label="Use Header Logo" />
+            <template #details>
+              <div v-if="form.useHeaderLogo" class="space-y-3">
+                <label class="block text-xs font-medium uppercase">
+                  Logo Image (PNG)
+                </label>
+                <div
+                  v-if="headerImagePreview && !headerImageError"
+                  class="border border-neutral-200 rounded-md p-2 bg-neutral-50">
+                  <img
+                    :src="headerImagePreview"
+                    alt="Current header image"
+                    class="max-h-24 object-contain"
+                    @error="headerImageError = true"
+                    @load="headerImageError = false" />
+                </div>
+                <input
+                  ref="headerImageInput"
+                  type="file"
+                  accept="image/png"
+                  class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                  @change="handleHeaderImageChange" />
+              </div>
+            </template>
+          </FormSubSection>
+        </FormSection>
+
+        <FormSection id="storage" title="Storage">
+          <InputGroup
+            v-model="form.amazonS3Key"
+            label="Amazon S3 Key"
+            placeholder="AWS access key ID" />
+          <InputGroup
+            v-model="form.amazonS3Secret"
+            label="Amazon S3 Secret"
+            :type="showS3Secret ? 'text' : 'password'"
+            placeholder="AWS secret access key">
+            <template #append>
+              <button
+                type="button"
+                class="p-1.5 text-neutral-500 hover:text-neutral-700 focus:outline-none"
+                @click="showS3Secret = !showS3Secret">
+                <EyeIcon v-if="showS3Secret" class="w-5 h-5" />
+                <EyeOffIcon v-else class="w-5 h-5" />
+              </button>
+            </template>
+          </InputGroup>
+          <InputGroup
+            v-model="form.defaultBucket"
+            label="Default Bucket"
+            placeholder="S3 bucket name" />
+          <InputGroup
+            v-model="form.bucketRegion"
+            label="Bucket Region"
+            placeholder="e.g., us-east-1" />
+        </FormSection>
+
+        <FormSection id="featured-asset" title="Featured Asset">
+          <InputGroup
+            v-model="form.featuredAsset"
+            label="Featured Asset ID"
+            placeholder="Asset ID for homepage feature" />
+          <TextAreaGroup
+            :modelValue="form.featuredAssetText ?? ''"
+            label="Featured Asset Text"
+            placeholder="Text to display above the featured asset"
+            @update:modelValue="form.featuredAssetText = $event || null" />
+        </FormSection>
+
+        <FormSection id="search-settings" title="Search">
+          <ToggleGroup
+            v-model="form.showCollectionInSearchResults"
+            label="Show Collection in Search Results" />
+          <ToggleGroup
+            v-model="form.showTemplateInSearchResults"
+            label="Show Template in Search Results" />
+          <ToggleGroup
+            v-model="form.allowIndexing"
+            label="Allow Search Engine Indexing" />
+          <ToggleGroup
+            v-model="form.autoloadMaxSearchResults"
+            label="Autoload Search Results (under 1000)" />
+        </FormSection>
+
+        <FormSection id="assets" title="Assets">
+          <ToggleGroup
+            v-model="form.enableInterstitial"
+            label="Show Interstitial When Embedding via API" />
+          <TextAreaGroup
+            v-if="form.enableInterstitial"
+            :modelValue="form.interstitialText ?? ''"
+            label="Interstitial Text"
+            placeholder="Text shown in embed interstitial"
+            inputClass="h-24"
+            @update:modelValue="form.interstitialText = $event || null" />
+          <ToggleGroup
+            v-model="form.showPreviousNextSearchResults"
+            label="Show Previous/Next in Asset View" />
+          <ToggleGroup
+            v-model="form.hideVideoAudio"
+            label="Hide Video/Audio Download Links" />
+          <ToggleGroup
+            v-model="form.automaticAltText"
+            label="Auto-generate Alt Text and Captions" />
+          <ToggleGroup
+            v-model="form.useVoyagerViewer"
+            label="Use Smithsonian Voyager for 3D" />
+          <ToggleGroup
+            v-model="form.enableHLSStreaming"
+            label="Enable HLS Streaming" />
+          <InputGroup
+            v-model="form.maximumMoreLikeThis"
+            label="More Like This Results"
+            type="number" />
+          <InputGroup
+            v-model="form.defaultTextTruncationHeight"
+            label="Text Area Collapsed Height (px)"
+            type="number" />
+        </FormSection>
+
+        <FormSection id="user-interface" title="User Interface">
+          <SelectGroup
+            v-model="form.interfaceVersion"
+            :options="interfaceVersionOptions"
+            label="Interface Version" />
+          <FormSubSection
+            v-if="!!form.interfaceVersion"
+            :isOpen="form.enableTheming">
+            <ToggleGroup
+              v-model="form.enableTheming"
+              label="Enable Theme Selection" />
+            <template #details>
+              <SelectGroup
+                v-if="form.enableTheming"
+                v-model="form.defaultTheme"
+                :options="themeOptions"
+                label="Default Theme" />
+              <div v-if="form.enableTheming" class="space-y-2">
+                <label class="block text-xs font-medium uppercase">
+                  Available Themes
+                </label>
+                <div class="flex flex-wrap gap-4">
+                  <label
+                    v-for="theme in allThemes"
+                    :key="theme"
+                    class="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      :value="theme"
+                      :checked="form.availableThemes?.includes(theme)"
+                      class="rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
+                      @change="toggleTheme(theme)" />
+                    {{ theme }}
+                  </label>
+                </div>
+              </div>
+            </template>
+          </FormSubSection>
+        </FormSection>
+      </form>
+
+      <template #sidebar-actions>
+        <div v-if="!isLoading && !isError" class="grid grid-cols-2 gap-2">
+          <Button
+            variant="secondary"
+            :disabled="!hasUnsavedChanges"
+            @click="handleCancel">
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="instance-settings-form"
+            variant="primary"
+            :disabled="isSaving">
+            <SpinnerIcon v-if="isSaving" class="w-4 h-4 animate-spin" />
+            {{ isSaving ? "Saving..." : "Save" }}
+          </Button>
+          <p
+            v-if="hasUnsavedChanges"
+            class="col-span-2 text-xs text-amber-600 text-center">
+            You have unsaved changes
+          </p>
         </div>
-      </aside>
-    </div>
+      </template>
+
+      <template #sidebar-nav>
+        <FormToc :sections="tocSections" class="hidden lg:block" />
+      </template>
+    </FormPageLayout>
   </DefaultLayout>
 </template>
 
@@ -294,6 +282,7 @@ import {
   type FunctionalComponent,
 } from "vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import FormPageLayout from "@/layouts/FormPageLayout.vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import TextAreaGroup from "@/components/TextAreaGroup/TextAreaGroup.vue";
 import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
@@ -301,7 +290,6 @@ import Button from "@/components/Button/Button.vue";
 import SpinnerIcon from "@/icons/SpinnerIcon.vue";
 import EyeIcon from "@/icons/EyeIcon.vue";
 import EyeOffIcon from "@/icons/EyeOffIcon.vue";
-import Toggle from "@/components/Toggle/Toggle.vue";
 import { useToastStore } from "@/stores/toastStore";
 import config from "@/config";
 import {
@@ -309,7 +297,9 @@ import {
   useUpdateInstanceSettingsMutation,
   getDefaultInstanceSettings,
 } from "@/queries/useInstanceSettingsQuery";
-import type { InstanceSettings, SelectOption } from "@/types";
+import type { InstanceSettings, SelectOption, TocItem } from "@/types";
+import { FormSection, FormToc } from "@/components/Form";
+import ToggleGroup from "@/components/ToggleGroup/ToggleGroup.vue";
 
 const props = defineProps<{
   instanceId: number;
@@ -425,7 +415,7 @@ const interfaceVersionOptions = computed((): SelectOption<0 | 1>[] => [
 const allThemes = computed(() => config.instance.theming.availableThemes);
 
 // Table of contents sections
-const tocSections = [
+const tocSections: TocItem[] = [
   { id: "general", label: "General" },
   { id: "authentication", label: "Authentication" },
   { id: "customization", label: "Customization" },
@@ -434,7 +424,7 @@ const tocSections = [
   { id: "search-settings", label: "Search" },
   { id: "assets", label: "Assets" },
   { id: "user-interface", label: "User Interface" },
-] as const;
+];
 
 function toggleTheme(theme: string) {
   const current = form.value.availableThemes ?? [];
@@ -458,7 +448,11 @@ async function handleSave() {
     await updateMutation.mutateAsync({
       ...form.value,
       instanceId: props.instanceId,
+      customHeaderImage: selectedHeaderImage.value,
     });
+
+    // Clear the selected file after successful save
+    selectedHeaderImage.value = null;
 
     toastStore.addToast({
       title: "Saved",
@@ -477,35 +471,7 @@ async function handleSave() {
   }
 }
 
-// ToggleField component for consistent toggle styling
-const ToggleField: FunctionalComponent<{
-  modelValue: boolean;
-  label: string;
-  "onUpdate:modelValue"?: (value: boolean) => void;
-}> = (props) => (
-  <div class="flex items-center justify-between gap-4 flex-wrap">
-    <span class="text-sm text-neutral-700">{props.label}</span>
-    <Toggle
-      modelValue={props.modelValue}
-      settingLabel={props.label}
-      onUpdate:modelValue={props["onUpdate:modelValue"]}
-    />
-  </div>
-);
-
-// FormSection component for grouping fields
-const FormSection: FunctionalComponent<{ title: string; id?: string }> = (
-  props,
-  { slots, attrs }
-) => (
-  <section
-    id={attrs.id as string}
-    class="border-t border-neutral-300 py-6 grid sm:grid-cols-[15rem,1fr] gap-4 items-start">
-    <h2 class="text-lg font-semibold">{props.title}</h2>
-    <div class="space-y-4">{slots.default?.()}</div>
-  </section>
-);
-
+// FormSubSection component - kept inline as it's only used here
 const FormSubSection: FunctionalComponent<{
   isOpen: boolean;
 }> = ({ isOpen = false }, { slots }) => (
@@ -516,36 +482,6 @@ const FormSubSection: FunctionalComponent<{
     {slots.default?.()}
     {isOpen && slots.details?.()}
   </section>
-);
-
-// SettingsTableOfContents component for sidebar navigation
-const SettingsTableOfContents: FunctionalComponent = () => (
-  <nav>
-    <h2 class="text-xs tracking-wide font-medium uppercase mb-2 opacity-70">
-      Contents
-    </h2>
-    <ol class="text-sm space-y-1">
-      {tocSections.map((section) => (
-        <li key={section.id}>
-          <a
-            href={`#${section.id}`}
-            class="block py-1 text-current opacity-70 hover:opacity-100 transition-opacity no-underline hover:no-underline"
-            onClick={(e: MouseEvent) => {
-              e.preventDefault();
-              const element = document.getElementById(section.id);
-              if (element) {
-                window.scrollTo({
-                  top: element.offsetTop - 80,
-                  behavior: "smooth",
-                });
-              }
-            }}>
-            {section.label}
-          </a>
-        </li>
-      ))}
-    </ol>
-  </nav>
 );
 </script>
 

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -1,18 +1,256 @@
 <template>
   <DefaultLayout>
-    <div class="p-8 px-4">
-      <header>
-        <p class="text-2xl md:text-4xl font-bold text-neutral-400">Admin</p>
+    <div class="p-4 md:p-8 max-w-4xl mx-auto w-full">
+      <header class="mb-8">
+        <p class="text-sm md:text-base font-medium text-neutral-500 uppercase">
+          Admin
+        </p>
         <h1 class="text-2xl md:text-4xl font-bold">Instance Settings</h1>
       </header>
 
-      <section>
-        <h2>General</h2>
-      </section>
+      <div v-if="isLoading" class="flex justify-center items-center py-12">
+        <SpinnerIcon class="w-8 h-8 animate-spin" />
+        <span class="ml-2">Loading settings...</span>
+      </div>
+
+      <div v-else-if="isError" class="text-red-600 p-4 bg-red-50 rounded-md">
+        Failed to load instance settings. Please try again.
+      </div>
+
+      <form v-else class="space-y-4" @submit.prevent="handleSave">
+        <!-- General Settings -->
+        <FormSection title="General">
+          <InputGroup
+            v-model="form.name"
+            label="Instance Name"
+            required
+            placeholder="My Elevator Instance" />
+          <InputGroup
+            v-model="form.domain"
+            label="Domain"
+            required
+            placeholder="example.edu" />
+          <InputGroup
+            v-model="form.ownerHomepage"
+            label="Owner Contact"
+            placeholder="https:// or mailto:" />
+          <InputGroup
+            v-model="form.googleAnalyticsKey"
+            label="Google Analytics Key"
+            placeholder="UA-XXXXX-Y or G-XXXXXXX" />
+        </FormSection>
+
+        <!-- Featured Asset -->
+        <FormSection title="Featured Asset">
+          <InputGroup
+            v-model="form.featuredAsset"
+            label="Featured Asset ID"
+            placeholder="Asset ID for homepage feature" />
+          <TextAreaGroup
+            :modelValue="form.featuredAssetText ?? ''"
+            label="Featured Asset Text"
+            placeholder="Text to display above the featured asset"
+            @update:modelValue="form.featuredAssetText = $event || null" />
+        </FormSection>
+
+        <!-- Display Options -->
+        <FormSection title="Display Options">
+          <ToggleField
+            v-model="form.showCollectionInSearchResults"
+            label="Show Collection in Search Results" />
+          <ToggleField
+            v-model="form.showTemplateInSearchResults"
+            label="Show Template in Search Results" />
+          <ToggleField
+            v-model="form.showPreviousNextSearchResults"
+            label="Show Previous/Next in Asset View" />
+          <ToggleField
+            v-model="form.hideVideoAudio"
+            label="Hide Video/Audio Download Links" />
+          <ToggleField
+            v-model="form.allowIndexing"
+            label="Allow Search Engine Indexing" />
+          <ToggleField
+            v-model="form.autoloadMaxSearchResults"
+            label="Autoload Search Results (under 1000)" />
+        </FormSection>
+
+        <!-- Advanced Features -->
+        <FormSection title="Advanced Features">
+          <ToggleField
+            v-model="form.useVoyagerViewer"
+            label="Use Smithsonian Voyager for 3D" />
+          <ToggleField
+            v-model="form.automaticAltText"
+            label="Auto-generate Alt Text and Captions" />
+          <ToggleField
+            v-model="form.enableHLSStreaming"
+            label="Enable HLS Streaming" />
+          <ToggleField
+            v-model="form.useCentralAuth"
+            label="Use Central Authentication" />
+        </FormSection>
+
+        <!-- Vue Interface Options -->
+        <FormSection title="Vue Interface Options">
+          <ToggleField
+            v-model="form.enableThemes"
+            label="Enable Theme Selection" />
+          <SelectGroup
+            v-if="form.enableThemes"
+            v-model="form.defaultTheme"
+            :options="themeOptions"
+            label="Default Theme" />
+          <InputGroup
+            v-model="form.customHomeRedirect"
+            label="Custom Home Redirect"
+            placeholder="/collections or custom URL" />
+          <InputGroup
+            v-model="form.maximumMoreLikeThis"
+            label="More Like This Display Count"
+            type="number" />
+          <InputGroup
+            v-model="form.defaultTextTruncationHeight"
+            label="Text Area Collapsed Height (px)"
+            type="number" />
+        </FormSection>
+
+        <!-- Notes -->
+        <FormSection title="Notes">
+          <TextAreaGroup
+            :modelValue="form.notes ?? ''"
+            label="Instance Notes"
+            placeholder="Internal notes about this instance"
+            inputClass="h-32"
+            @update:modelValue="form.notes = $event || null" />
+        </FormSection>
+
+        <!-- Form Actions -->
+        <div class="flex justify-end gap-4 pt-4 border-t border-neutral-200">
+          <Button type="submit" variant="primary" :disabled="isSaving">
+            <SpinnerIcon v-if="isSaving" class="w-4 h-4 animate-spin" />
+            {{ isSaving ? "Saving..." : "Save Settings" }}
+          </Button>
+        </div>
+      </form>
     </div>
   </DefaultLayout>
 </template>
-<script setup lang="ts">
+
+<script setup lang="tsx">
+import { ref, watch, computed, type FunctionalComponent } from "vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import InputGroup from "@/components/InputGroup/InputGroup.vue";
+import TextAreaGroup from "@/components/TextAreaGroup/TextAreaGroup.vue";
+import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
+import Button from "@/components/Button/Button.vue";
+import SpinnerIcon from "@/icons/SpinnerIcon.vue";
+import Toggle from "@/components/Toggle/Toggle.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  useInstanceSettingsQuery,
+  useUpdateInstanceSettingsMutation,
+  getDefaultInstanceSettings,
+} from "@/queries/useInstanceSettingsQuery";
+import type { InstanceSettings, SelectOption } from "@/types";
+
+const props = defineProps<{
+  instanceId: number;
+}>();
+
+const toastStore = useToastStore();
+
+const {
+  data: settingsData,
+  isLoading,
+  isError,
+} = useInstanceSettingsQuery(() => props.instanceId);
+
+const updateMutation = useUpdateInstanceSettingsMutation();
+const isSaving = computed(() => updateMutation.isPending.value);
+
+// Form state - initialized from query data
+const form = ref<InstanceSettings>(
+  getDefaultInstanceSettings(props.instanceId)
+);
+
+// Sync form with fetched data
+watch(
+  settingsData,
+  (newData) => {
+    if (newData) {
+      form.value = { ...newData };
+    }
+  },
+  { immediate: true }
+);
+
+// Theme options for the select
+const themeOptions = computed((): SelectOption<string>[] => [
+  { id: "default", label: "Default" },
+  { id: "dark", label: "Dark" },
+]);
+
+async function handleSave() {
+  if (!props.instanceId) {
+    toastStore.addToast({
+      title: "Error",
+      message: "Instance ID not available",
+      variant: "error",
+    });
+    return;
+  }
+
+  try {
+    await updateMutation.mutateAsync({
+      ...form.value,
+      instanceId: props.instanceId,
+    });
+
+    toastStore.addToast({
+      title: "Saved",
+      message: "Instance settings saved successfully.",
+      variant: "success",
+      duration: 3000,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error occurred";
+    toastStore.addToast({
+      title: "Error",
+      message: `Failed to save settings: ${message}`,
+      variant: "error",
+    });
+  }
+}
+
+// ToggleField component for consistent toggle styling
+const ToggleField: FunctionalComponent<{
+  modelValue: boolean;
+  label: string;
+  "onUpdate:modelValue"?: (value: boolean) => void;
+}> = (props) => (
+  <div class="flex items-center justify-between py-2">
+    <span class="text-sm text-neutral-700">{props.label}</span>
+    <Toggle
+      modelValue={props.modelValue}
+      settingLabel={props.label}
+      onUpdate:modelValue={props["onUpdate:modelValue"]}
+    />
+  </div>
+);
+
+// FormSection component for grouping fields
+const FormSection: FunctionalComponent<{ title: string }> = (
+  props,
+  { slots }
+) => (
+  <section class="bg-white rounded-lg border border-neutral-200 p-6 grid md:grid-cols-[15rem,1fr] gap-4 items-start">
+    <h2 class="text-lg font-semibold">{props.title}</h2>
+    <div class="space-y-4">{slots.default?.()}</div>
+  </section>
+);
 </script>
+
 <style scoped></style>

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -1,234 +1,272 @@
 <template>
   <DefaultLayout>
-    <div class="p-4 md:p-8 max-w-4xl mx-auto w-full">
-      <header class="mb-8">
-        <p
-          class="text-sm md:text-base font-medium text-neutral-500 uppercase flex items-center gap-1">
-          Admin
-          <template v-if="form.name">
-            <ChevronRightIcon class="!w-4 !h-4" />
-            Instance Settings
-          </template>
-        </p>
-        <h1 class="text-2xl md:text-4xl font-bold">
-          {{ form.name || "Instance Settings" }}
-        </h1>
-      </header>
+    <div
+      class="md:grid lg:grid-cols-[minmax(0,1fr),minmax(auto,20rem)] relative min-h-screen">
+      <div class="p-4 md:p-8 max-w-4xl mx-auto w-full mb-20 lg:mb-0">
+        <header class="mb-8">
+          <h1 class="text-2xl md:text-4xl font-bold">Instance Settings</h1>
+        </header>
 
-      <div v-if="isLoading" class="flex justify-center items-center py-12">
-        <SpinnerIcon class="w-8 h-8 animate-spin" />
-        <span class="ml-2">Loading settings...</span>
-      </div>
-
-      <div v-else-if="isError" class="text-red-600 p-4 bg-red-50 rounded-md">
-        Failed to load instance settings. Please try again.
-      </div>
-
-      <form v-else class="space-y-4" @submit.prevent="handleSave">
-        <!-- General Settings -->
-        <FormSection title="General">
-          <InputGroup
-            v-model="form.name"
-            label="Instance Name"
-            required
-            placeholder="My Elevator Instance" />
-          <InputGroup
-            v-model="form.domain"
-            label="Domain"
-            required
-            placeholder="example.edu" />
-          <InputGroup
-            v-model="form.ownerHomepage"
-            label="Owner Contact"
-            placeholder="https:// or mailto:" />
-          <InputGroup
-            v-model="form.googleAnalyticsKey"
-            label="Google Analytics Key"
-            placeholder="UA-XXXXX-Y or G-XXXXXXX" />
-          <TextAreaGroup
-            :modelValue="form.notes ?? ''"
-            label="Instance Notes"
-            placeholder="Internal notes about this instance"
-            inputClass="h-24"
-            @update:modelValue="form.notes = $event || null" />
-        </FormSection>
-
-        <!-- Featured Asset -->
-        <FormSection title="Featured Asset">
-          <InputGroup
-            v-model="form.featuredAsset"
-            label="Featured Asset ID"
-            placeholder="Asset ID for homepage feature" />
-          <TextAreaGroup
-            :modelValue="form.featuredAssetText ?? ''"
-            label="Featured Asset Text"
-            placeholder="Text to display above the featured asset"
-            @update:modelValue="form.featuredAssetText = $event || null" />
-        </FormSection>
-
-        <!-- Storage Settings -->
-        <FormSection title="Storage Settings">
-          <InputGroup
-            v-model="form.amazonS3Key"
-            label="Amazon S3 Key"
-            placeholder="AWS access key ID" />
-          <InputGroup
-            v-model="form.amazonS3Secret"
-            label="Amazon S3 Secret"
-            :type="showS3Secret ? 'text' : 'password'"
-            placeholder="AWS secret access key">
-            <template #append>
-              <button
-                type="button"
-                class="p-1.5 text-neutral-500 hover:text-neutral-700 focus:outline-none"
-                @click="showS3Secret = !showS3Secret">
-                <EyeIcon v-if="showS3Secret" class="w-5 h-5" />
-                <EyeOffIcon v-else class="w-5 h-5" />
-              </button>
-            </template>
-          </InputGroup>
-          <InputGroup
-            v-model="form.defaultBucket"
-            label="Default Bucket"
-            placeholder="S3 bucket name" />
-          <InputGroup
-            v-model="form.bucketRegion"
-            label="Bucket Region"
-            placeholder="e.g., us-east-1" />
-        </FormSection>
-
-        <!-- Custom Styling and Display -->
-        <FormSection title="Custom Styling and Display">
-          <SelectGroup
-            v-model="form.useCustomHeader"
-            :options="customHeaderOptions"
-            label="Display Custom Header/Footer" />
-          <TextAreaGroup
-            v-if="form.useCustomHeader !== 0"
-            :modelValue="form.customHeaderText ?? ''"
-            label="Custom Header Content"
-            placeholder="HTML content for custom header"
-            inputClass="h-24 font-mono text-sm"
-            @update:modelValue="form.customHeaderText = $event || null" />
-          <TextAreaGroup
-            v-if="form.useCustomHeader !== 0"
-            :modelValue="form.customFooterText ?? ''"
-            label="Custom Footer Content"
-            placeholder="HTML content for custom footer"
-            inputClass="h-24 font-mono text-sm"
-            @update:modelValue="form.customFooterText = $event || null" />
-          <ToggleField v-model="form.useCustomCSS" label="Use Custom CSS" />
-          <TextAreaGroup
-            v-if="form.useCustomCSS"
-            :modelValue="form.customHeaderCSS ?? ''"
-            label="Custom CSS"
-            placeholder="Custom CSS styles"
-            inputClass="h-32 font-mono text-sm"
-            @update:modelValue="form.customHeaderCSS = $event || null" />
-          <ToggleField
-            v-model="form.enableInterstitial"
-            label="Show Interstitial When Embedding via API" />
-          <TextAreaGroup
-            v-if="form.enableInterstitial"
-            :modelValue="form.interstitialText ?? ''"
-            label="Interstitial Text"
-            placeholder="Text shown in embed interstitial"
-            inputClass="h-24"
-            @update:modelValue="form.interstitialText = $event || null" />
-          <ToggleField v-model="form.useHeaderLogo" label="Use Header Logo" />
-          <div v-if="form.useHeaderLogo" class="space-y-3">
-            <label class="block text-xs font-medium uppercase">
-              Header Image (PNG)
-            </label>
-            <div
-              v-if="headerImagePreview && !headerImageError"
-              class="border border-neutral-200 rounded-md p-2 bg-neutral-50">
-              <img
-                :src="headerImagePreview"
-                alt="Current header image"
-                class="max-h-24 object-contain"
-                @error="headerImageError = true"
-                @load="headerImageError = false" />
-            </div>
-            <input
-              ref="headerImageInput"
-              type="file"
-              accept="image/png"
-              class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-              @change="handleHeaderImageChange" />
-          </div>
-        </FormSection>
-
-        <!-- Display Options -->
-        <FormSection title="Display Options">
-          <ToggleField
-            v-model="form.showCollectionInSearchResults"
-            label="Show Collection in Search Results" />
-          <ToggleField
-            v-model="form.showTemplateInSearchResults"
-            label="Show Template in Search Results" />
-          <ToggleField
-            v-model="form.showPreviousNextSearchResults"
-            label="Show Previous/Next in Asset View" />
-          <ToggleField
-            v-model="form.hideVideoAudio"
-            label="Hide Video/Audio Download Links" />
-          <ToggleField
-            v-model="form.allowIndexing"
-            label="Allow Search Engine Indexing" />
-          <ToggleField
-            v-model="form.autoloadMaxSearchResults"
-            label="Autoload Search Results (under 1000)" />
-        </FormSection>
-
-        <!-- Advanced Features -->
-        <FormSection title="Advanced Features">
-          <ToggleField
-            v-model="form.useVoyagerViewer"
-            label="Use Smithsonian Voyager for 3D" />
-          <ToggleField
-            v-model="form.automaticAltText"
-            label="Auto-generate Alt Text and Captions" />
-          <ToggleField
-            v-model="form.enableHLSStreaming"
-            label="Enable HLS Streaming" />
-          <ToggleField
-            v-model="form.useCentralAuth"
-            label="Use Central Authentication" />
-        </FormSection>
-
-        <!-- Vue Interface Options -->
-        <FormSection title="Vue Interface Options">
-          <ToggleField
-            v-model="form.enableThemes"
-            label="Enable Theme Selection" />
-          <SelectGroup
-            v-if="form.enableThemes"
-            v-model="form.defaultTheme"
-            :options="themeOptions"
-            label="Default Theme" />
-          <InputGroup
-            v-model="form.customHomeRedirect"
-            label="Custom Home Redirect"
-            placeholder="/collections or custom URL" />
-          <InputGroup
-            v-model="form.maximumMoreLikeThis"
-            label="More Like This Display Count"
-            type="number" />
-          <InputGroup
-            v-model="form.defaultTextTruncationHeight"
-            label="Text Area Collapsed Height (px)"
-            type="number" />
-        </FormSection>
-
-        <!-- Form Actions -->
-        <div class="flex justify-end gap-4 pt-4 border-t border-neutral-200">
-          <Button type="submit" variant="primary" :disabled="isSaving">
-            <SpinnerIcon v-if="isSaving" class="w-4 h-4 animate-spin" />
-            {{ isSaving ? "Saving..." : "Save Settings" }}
-          </Button>
+        <div v-if="isLoading" class="flex justify-center items-center py-12">
+          <SpinnerIcon class="w-8 h-8 animate-spin" />
+          <span class="ml-2">Loading settings...</span>
         </div>
-      </form>
+
+        <div
+          v-else-if="isError"
+          class="text-red-600 p-4 bg-red-50 rounded-md border border-red-200">
+          Failed to load instance settings.
+        </div>
+
+        <form v-else @submit.prevent="handleSave">
+          <!-- General Settings -->
+          <FormSection id="general" title="General">
+            <InputGroup
+              v-model="form.name"
+              label="Instance Name"
+              required
+              placeholder="My Elevator Instance" />
+            <InputGroup
+              v-model="form.domain"
+              label="Domain"
+              required
+              placeholder="example.edu" />
+            <InputGroup
+              v-model="form.ownerHomepage"
+              label="Owner Contact"
+              placeholder="https:// or mailto:" />
+            <TextAreaGroup
+              :modelValue="form.notes ?? ''"
+              label="Instance Notes"
+              placeholder="Internal notes about this instance"
+              inputClass="h-24"
+              @update:modelValue="form.notes = $event || null" />
+          </FormSection>
+
+          <FormSection id="authentication" title="Authentication">
+            <ToggleField
+              v-model="form.useCentralAuth"
+              label="Use Central Authentication" />
+          </FormSection>
+
+          <FormSection id="customization" title="Customization">
+            <InputGroup
+              v-model="form.customHomeRedirect"
+              label="Custom Home Redirect"
+              placeholder="e.g. /collections or custom URL" />
+            <InputGroup
+              v-model="form.googleAnalyticsKey"
+              label="Google Analytics Key"
+              placeholder="UA-XXXXX-Y or G-XXXXXXX" />
+            <SelectGroup
+              v-model="form.useCustomHeader"
+              :options="customHeaderOptions"
+              label="Display Custom Header/Footer" />
+            <TextAreaGroup
+              v-if="!!form.useCustomHeader"
+              :modelValue="form.customHeaderText ?? ''"
+              label="Custom Header Content"
+              placeholder="HTML content for custom header"
+              inputClass="h-24 font-mono text-sm"
+              @update:modelValue="form.customHeaderText = $event || null" />
+            <TextAreaGroup
+              v-if="!!form.useCustomHeader"
+              :modelValue="form.customFooterText ?? ''"
+              label="Custom Footer Content"
+              placeholder="HTML content for custom footer"
+              inputClass="h-24 font-mono text-sm"
+              @update:modelValue="form.customFooterText = $event || null" />
+
+            <FormSubSection :isOpen="!!form.useCustomCSS">
+              <ToggleField v-model="form.useCustomCSS" label="Use Custom CSS" />
+              <template #details>
+                <TextAreaGroup
+                  v-if="!!form.useCustomCSS"
+                  :modelValue="form.customHeaderCSS ?? ''"
+                  label="Custom CSS"
+                  placeholder="Custom CSS styles"
+                  inputClass="h-32 font-mono text-sm"
+                  @update:modelValue="form.customHeaderCSS = $event || null" />
+              </template>
+            </FormSubSection>
+            <FormSubSection :isOpen="form.useHeaderLogo">
+              <ToggleField
+                v-model="form.useHeaderLogo"
+                label="Use Header Logo" />
+              <template #details>
+                <div v-if="form.useHeaderLogo" class="space-y-3">
+                  <label class="block text-xs font-medium uppercase">
+                    Logo Image (PNG)
+                  </label>
+                  <div
+                    v-if="headerImagePreview && !headerImageError"
+                    class="border border-neutral-200 rounded-md p-2 bg-neutral-50">
+                    <img
+                      :src="headerImagePreview"
+                      alt="Current header image"
+                      class="max-h-24 object-contain"
+                      @error="headerImageError = true"
+                      @load="headerImageError = false" />
+                  </div>
+                  <input
+                    ref="headerImageInput"
+                    type="file"
+                    accept="image/png"
+                    class="block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                    @change="handleHeaderImageChange" />
+                </div>
+              </template>
+            </FormSubSection>
+          </FormSection>
+
+          <FormSection id="storage" title="Storage">
+            <InputGroup
+              v-model="form.amazonS3Key"
+              label="Amazon S3 Key"
+              placeholder="AWS access key ID" />
+            <InputGroup
+              v-model="form.amazonS3Secret"
+              label="Amazon S3 Secret"
+              :type="showS3Secret ? 'text' : 'password'"
+              placeholder="AWS secret access key">
+              <template #append>
+                <button
+                  type="button"
+                  class="p-1.5 text-neutral-500 hover:text-neutral-700 focus:outline-none"
+                  @click="showS3Secret = !showS3Secret">
+                  <EyeIcon v-if="showS3Secret" class="w-5 h-5" />
+                  <EyeOffIcon v-else class="w-5 h-5" />
+                </button>
+              </template>
+            </InputGroup>
+            <InputGroup
+              v-model="form.defaultBucket"
+              label="Default Bucket"
+              placeholder="S3 bucket name" />
+            <InputGroup
+              v-model="form.bucketRegion"
+              label="Bucket Region"
+              placeholder="e.g., us-east-1" />
+          </FormSection>
+
+          <FormSection id="featured-asset" title="Featured Asset">
+            <InputGroup
+              v-model="form.featuredAsset"
+              label="Featured Asset ID"
+              placeholder="Asset ID for homepage feature" />
+            <TextAreaGroup
+              :modelValue="form.featuredAssetText ?? ''"
+              label="Featured Asset Text"
+              placeholder="Text to display above the featured asset"
+              @update:modelValue="form.featuredAssetText = $event || null" />
+          </FormSection>
+
+          <FormSection id="search-settings" title="Search">
+            <ToggleField
+              v-model="form.showCollectionInSearchResults"
+              label="Show Collection in Search Results" />
+            <ToggleField
+              v-model="form.showTemplateInSearchResults"
+              label="Show Template in Search Results" />
+            <ToggleField
+              v-model="form.allowIndexing"
+              label="Allow Search Engine Indexing" />
+            <ToggleField
+              v-model="form.autoloadMaxSearchResults"
+              label="Autoload Search Results (under 1000)" />
+          </FormSection>
+
+          <FormSection id="assets" title="Assets">
+            <ToggleField
+              v-model="form.enableInterstitial"
+              label="Show Interstitial When Embedding via API" />
+            <TextAreaGroup
+              v-if="form.enableInterstitial"
+              :modelValue="form.interstitialText ?? ''"
+              label="Interstitial Text"
+              placeholder="Text shown in embed interstitial"
+              inputClass="h-24"
+              @update:modelValue="form.interstitialText = $event || null" />
+            <ToggleField
+              v-model="form.showPreviousNextSearchResults"
+              label="Show Previous/Next in Asset View" />
+            <ToggleField
+              v-model="form.hideVideoAudio"
+              label="Hide Video/Audio Download Links" />
+            <ToggleField
+              v-model="form.automaticAltText"
+              label="Auto-generate Alt Text and Captions" />
+            <ToggleField
+              v-model="form.useVoyagerViewer"
+              label="Use Smithsonian Voyager for 3D" />
+            <ToggleField
+              v-model="form.enableHLSStreaming"
+              label="Enable HLS Streaming" />
+            <InputGroup
+              v-model="form.maximumMoreLikeThis"
+              label="More Like This Results"
+              type="number" />
+            <InputGroup
+              v-model="form.defaultTextTruncationHeight"
+              label="Text Area Collapsed Height (px)"
+              type="number" />
+          </FormSection>
+
+          <FormSection id="user-interface" title="User Interface">
+            <SelectGroup
+              v-model="form.interfaceVersion"
+              :options="interfaceVersionOptions"
+              label="Interface Version" />
+            <FormSubSection
+              v-if="!!form.interfaceVersion"
+              :isOpen="form.enableTheming">
+              <ToggleField
+                v-model="form.enableTheming"
+                label="Enable Theme Selection" />
+              <template #details>
+                <SelectGroup
+                  v-if="form.enableTheming"
+                  v-model="form.defaultTheme"
+                  :options="themeOptions"
+                  label="Default Theme" />
+                <div v-if="form.enableTheming" class="space-y-2">
+                  <label class="block text-xs font-medium uppercase">
+                    Available Themes
+                  </label>
+                  <div class="flex flex-wrap gap-4">
+                    <label
+                      v-for="theme in allThemes"
+                      :key="theme"
+                      class="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        :value="theme"
+                        :checked="form.availableThemes?.includes(theme)"
+                        class="rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
+                        @change="toggleTheme(theme)" />
+                      {{ theme }}
+                    </label>
+                  </div>
+                </div>
+              </template>
+            </FormSubSection>
+          </FormSection>
+        </form>
+      </div>
+      <!-- sidebar -->
+      <aside
+        class="sidebar-container bg-[--app-sidebar-backgroundColor] text-[--app-sidebar-textColor] [border-left:var(--app-borderWidth)_solid_var(--app-borderColor)] p-6 fixed bottom-0 left-0 w-full lg:static">
+        <div class="sticky top-20 flex flex-col gap-6">
+          <div class="grid grid-cols-2 gap-2">
+            <Button variant="secondary">Cancel</Button>
+            <Button type="submit" variant="primary" :disabled="isSaving">
+              <SpinnerIcon v-if="isSaving" class="w-4 h-4 animate-spin" />
+              {{ isSaving ? "Saving..." : "Save" }}
+            </Button>
+          </div>
+          <SettingsTableOfContents class="hidden lg:block" />
+        </div>
+      </aside>
     </div>
   </DefaultLayout>
 </template>
@@ -252,7 +290,6 @@ import {
   getDefaultInstanceSettings,
 } from "@/queries/useInstanceSettingsQuery";
 import type { InstanceSettings, SelectOption } from "@/types";
-import { ChevronRightIcon } from "@/icons";
 
 const props = defineProps<{
   instanceId: number;
@@ -310,10 +347,13 @@ watch(
 );
 
 // Theme options for the select
-const themeOptions = computed((): SelectOption<string>[] => [
-  { id: "default", label: "Default" },
-  { id: "dark", label: "Dark" },
-]);
+const themeOptions = computed(
+  (): SelectOption<string>[] =>
+    settingsData.value?.availableThemes?.map((theme) => ({
+      id: theme,
+      label: theme,
+    })) ?? []
+);
 
 // Custom header display options
 const customHeaderOptions = computed((): SelectOption<0 | 1 | 2>[] => [
@@ -321,6 +361,35 @@ const customHeaderOptions = computed((): SelectOption<0 | 1 | 2>[] => [
   { id: 1, label: "Always" },
   { id: 2, label: "Only on Home Page" },
 ]);
+
+// Interface version options
+const interfaceVersionOptions = computed((): SelectOption<0 | 1>[] => [
+  { id: 0, label: "Classic" },
+  { id: 1, label: "VueJS" },
+]);
+
+// All available themes from config
+const allThemes = computed(() => config.instance.theming.availableThemes);
+
+// Table of contents sections
+const tocSections = [
+  { id: "general", label: "General" },
+  { id: "authentication", label: "Authentication" },
+  { id: "customization", label: "Customization" },
+  { id: "storage", label: "Storage" },
+  { id: "featured-asset", label: "Featured Asset" },
+  { id: "search-settings", label: "Search" },
+  { id: "assets", label: "Assets" },
+  { id: "user-interface", label: "User Interface" },
+] as const;
+
+function toggleTheme(theme: string) {
+  const current = form.value.availableThemes ?? [];
+  const isSelected = current.includes(theme);
+  form.value.availableThemes = isSelected
+    ? current.filter((t) => t !== theme)
+    : [...current, theme];
+}
 
 async function handleSave() {
   if (!props.instanceId) {
@@ -361,7 +430,7 @@ const ToggleField: FunctionalComponent<{
   label: string;
   "onUpdate:modelValue"?: (value: boolean) => void;
 }> = (props) => (
-  <div class="flex items-center justify-between py-2">
+  <div class="flex items-center justify-between gap-4 flex-wrap">
     <span class="text-sm text-neutral-700">{props.label}</span>
     <Toggle
       modelValue={props.modelValue}
@@ -372,14 +441,58 @@ const ToggleField: FunctionalComponent<{
 );
 
 // FormSection component for grouping fields
-const FormSection: FunctionalComponent<{ title: string }> = (
+const FormSection: FunctionalComponent<{ title: string; id?: string }> = (
   props,
-  { slots }
+  { slots, attrs }
 ) => (
-  <section class="bg-white rounded-lg border border-neutral-200 p-6 grid md:grid-cols-[15rem,1fr] gap-4 items-start">
+  <section
+    id={attrs.id as string}
+    class="border-t border-neutral-300 py-6 grid sm:grid-cols-[15rem,1fr] gap-4 items-start">
     <h2 class="text-lg font-semibold">{props.title}</h2>
     <div class="space-y-4">{slots.default?.()}</div>
   </section>
+);
+
+const FormSubSection: FunctionalComponent<{
+  isOpen: boolean;
+}> = ({ isOpen = false }, { slots }) => (
+  <section
+    class={`flex flex-col gap-4 ${
+      isOpen ? "border border-neutral-300 p-2 rounded-md" : ""
+    }`}>
+    {slots.default?.()}
+    {isOpen && slots.details?.()}
+  </section>
+);
+
+// SettingsTableOfContents component for sidebar navigation
+const SettingsTableOfContents: FunctionalComponent = () => (
+  <nav>
+    <h2 class="text-xs tracking-wide font-medium uppercase mb-2 opacity-70">
+      Contents
+    </h2>
+    <ol class="text-sm space-y-1">
+      {tocSections.map((section) => (
+        <li key={section.id}>
+          <a
+            href={`#${section.id}`}
+            class="block py-1 text-current opacity-70 hover:opacity-100 transition-opacity no-underline hover:no-underline"
+            onClick={(e: MouseEvent) => {
+              e.preventDefault();
+              const element = document.getElementById(section.id);
+              if (element) {
+                window.scrollTo({
+                  top: element.offsetTop - 80,
+                  behavior: "smooth",
+                });
+              }
+            }}>
+            {section.label}
+          </a>
+        </li>
+      ))}
+    </ol>
+  </nav>
 );
 </script>
 

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -1,0 +1,9 @@
+<template>
+  <DefaultLayout>
+    <div class="p-8 px-4">Instance Settings page</div>
+  </DefaultLayout>
+</template>
+<script setup lang="ts">
+import DefaultLayout from "@/layouts/DefaultLayout.vue";
+</script>
+<style scoped></style>

--- a/src/pages/LocalLoginPage/LocalLoginPage.vue
+++ b/src/pages/LocalLoginPage/LocalLoginPage.vue
@@ -96,7 +96,7 @@ import Button from "@/components/Button/Button.vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
-import { ref, reactive, computed, onMounted, nextTick } from "vue";
+import { ref, reactive, computed, onMounted } from "vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import { useRouter } from "vue-router";
 import { EyeIcon, EyeOffIcon, SpinnerIcon } from "@/icons";
@@ -184,9 +184,15 @@ const encodedCallbackUrl = computed(() =>
   encodeURIComponent(props.redirectURL)
 );
 
-onMounted(() => {
-  // if user is logged in, redirect
-  if (instanceStore.isLoggedIn) {
+onMounted(async () => {
+  // Only verify with server if cache says we're logged in
+  // (to check if session is still valid)
+  if (!instanceStore.isLoggedIn) return;
+
+  await instanceStore.refresh();
+
+  // Redirect only if refresh confirmed user is still logged in
+  if (instanceStore.fetchStatus === "success" && instanceStore.isLoggedIn) {
     router.push(props.redirectURL);
   }
 });

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -1,4 +1,5 @@
 export const INSTANCE_QUERY_KEY = "instance";
+export const INSTANCE_SETTINGS_QUERY_KEY = "instanceSettings";
 export const ASSETS_QUERY_KEY = "assets";
 export const TEMPLATES_QUERY_KEY = "templates";
 export const COLLECTIONS_QUERY_KEY = "collections";

--- a/src/queries/useInstanceSettingsQuery.ts
+++ b/src/queries/useInstanceSettingsQuery.ts
@@ -84,5 +84,7 @@ export function getDefaultInstanceSettings(
     maximumMoreLikeThis: null,
     defaultTextTruncationHeight: null,
     notes: null,
+    createdAt: null,
+    modifiedAt: null,
   };
 }

--- a/src/queries/useInstanceSettingsQuery.ts
+++ b/src/queries/useInstanceSettingsQuery.ts
@@ -18,6 +18,7 @@ export function useInstanceSettingsQuery(
       return fetchers.fetchInstanceSettings(id);
     },
     enabled: () => toValue(instanceId) !== null,
+    retry: false,
   });
 }
 
@@ -76,7 +77,7 @@ export function getDefaultInstanceSettings(
     interfaceVersion: 1,
     useCentralAuth: false,
     enableHLSStreaming: false,
-    enableThemes: false,
+    enableTheming: false,
     defaultTheme: null,
     availableThemes: null,
     customHomeRedirect: null,

--- a/src/queries/useInstanceSettingsQuery.ts
+++ b/src/queries/useInstanceSettingsQuery.ts
@@ -54,7 +54,7 @@ export function getDefaultInstanceSettings(
     featuredAsset: null,
     featuredAssetText: null,
     amazonS3Key: null,
-    // amazonS3Secret: null,
+    amazonS3Secret: null,
     defaultBucket: null,
     bucketRegion: null,
     showCollectionInSearchResults: false,

--- a/src/queries/useInstanceSettingsQuery.ts
+++ b/src/queries/useInstanceSettingsQuery.ts
@@ -1,0 +1,87 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import { INSTANCE_SETTINGS_QUERY_KEY, INSTANCE_QUERY_KEY } from "./queryKeys";
+import type { InstanceSettings } from "@/types";
+import type { MaybeRefOrGetter } from "vue";
+import { toValue } from "vue";
+
+export function useInstanceSettingsQuery(
+  instanceId: MaybeRefOrGetter<number | null>
+) {
+  return useQuery({
+    queryKey: [INSTANCE_SETTINGS_QUERY_KEY, instanceId],
+    queryFn: () => {
+      const id = toValue(instanceId);
+      if (!id) {
+        throw new Error("Instance ID is required");
+      }
+      return fetchers.fetchInstanceSettings(id);
+    },
+    enabled: () => toValue(instanceId) !== null,
+  });
+}
+
+export function useUpdateInstanceSettingsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: fetchers.updateInstanceSettings,
+    onSuccess: (_data, variables) => {
+      // Invalidate instance settings query
+      queryClient.invalidateQueries({
+        queryKey: [INSTANCE_SETTINGS_QUERY_KEY, variables.instanceId],
+      });
+      // Also invalidate the main instance query since some settings affect it
+      queryClient.invalidateQueries({
+        queryKey: [INSTANCE_QUERY_KEY],
+      });
+    },
+  });
+}
+
+/**
+ * Default/empty instance settings for form initialization
+ */
+export function getDefaultInstanceSettings(
+  instanceId: number
+): InstanceSettings {
+  return {
+    instanceId,
+    name: "",
+    domain: "",
+    ownerHomepage: null,
+    googleAnalyticsKey: null,
+    featuredAsset: null,
+    featuredAssetText: null,
+    amazonS3Key: null,
+    // amazonS3Secret: null,
+    defaultBucket: null,
+    bucketRegion: null,
+    showCollectionInSearchResults: false,
+    showTemplateInSearchResults: false,
+    showPreviousNextSearchResults: false,
+    hideVideoAudio: false,
+    allowIndexing: true,
+    useVoyagerViewer: false,
+    automaticAltText: false,
+    autoloadMaxSearchResults: false,
+    useCustomHeader: 0,
+    customHeaderText: null,
+    customFooterText: null,
+    useCustomCSS: false,
+    customHeaderCSS: null,
+    useHeaderLogo: false,
+    enableInterstitial: false,
+    interstitialText: null,
+    interfaceVersion: 1,
+    useCentralAuth: false,
+    enableHLSStreaming: false,
+    enableThemes: false,
+    defaultTheme: null,
+    availableThemes: null,
+    customHomeRedirect: null,
+    maximumMoreLikeThis: null,
+    defaultTextTruncationHeight: null,
+    notes: null,
+  };
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -226,6 +226,12 @@ const router = createRouter({
       }),
     },
     {
+      name: "editInstanceSettingsPage",
+      path: "/instances/edit/:instanceId",
+      component: () =>
+        import("@/pages/InstanceSettingsPage/InstanceSettingsPage.vue"),
+    },
+    {
       name: "search",
       path: "/search/s/:searchId",
       component: SearchResultsPage,
@@ -275,8 +281,7 @@ const router = createRouter({
     {
       name: "mapSingleClusterTest",
       path: "/tests/map-single-cluster",
-      component: () =>
-        import("@/pages/TestPages/MapSingleClusterTest.vue"),
+      component: () => import("@/pages/TestPages/MapSingleClusterTest.vue"),
     },
     {
       name: "mapStressTest",

--- a/src/router.ts
+++ b/src/router.ts
@@ -230,6 +230,9 @@ const router = createRouter({
       path: "/instances/edit/:instanceId",
       component: () =>
         import("@/pages/InstanceSettingsPage/InstanceSettingsPage.vue"),
+      props: (route) => ({
+        instanceId: parseIntFromParam(route.params.instanceId),
+      }),
     },
     {
       name: "search",

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -177,6 +177,7 @@ const actions = (state: ReturnType<typeof createState>) => ({
         const instanceId = state.instance.value.id;
         if (!instanceId) {
           resolve();
+          return;
         }
 
         state.instance.value.logoImg = {

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -23,6 +23,7 @@ import {
   flattenCollections,
   filterCollections,
 } from "@/helpers/collectionHelpers";
+import config from "@/config";
 
 const createState = () => ({
   fetchStatus: ref<FetchStatus>("idle"),
@@ -112,6 +113,13 @@ const actions = (state: ReturnType<typeof createState>) => ({
       state.currentUser.value = selectCurrentUserFromResponse(apiResponse);
       state.pages.value = apiResponse.pages;
       state.instance.value = selectInstanceFromResponse(apiResponse);
+
+      // add a timestamp to the logo URL to prevent caching issues
+      if (state.instance.value.logoImg) {
+        const timestamp = Date.now();
+        state.instance.value.logoImg.src += `?t=${timestamp}`;
+      }
+
       state.collections.value = normalizeAssetCollections(
         apiResponse.collections
       );
@@ -157,6 +165,26 @@ const actions = (state: ReturnType<typeof createState>) => ({
     // not on refresh
     executeScripts(state.customScripts.value as HTMLScriptElement[]);
     state.hasExecutedCustomScripts.value = true;
+  },
+
+  refreshLogoImage() {
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const instanceId = state.instance.value.id;
+        if (!instanceId) {
+          resolve();
+        }
+
+        state.instance.value.logoImg = {
+          src: `${
+            config.instance.base.origin
+          }/assets/instanceAssets/${instanceId}.png?t=${Date.now()}`,
+          alt: "Instance Logo",
+        };
+
+        resolve();
+      }, 100);
+    });
   },
 });
 

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -51,11 +51,14 @@ const createState = () => ({
   customFooter: ref<string | null>(null),
   customScripts: ref<HTMLScriptElement[]>([]),
   hasExecutedCustomScripts: ref(false),
+  hasInitialized: ref(false),
 });
 
 const getters = (state: ReturnType<typeof createState>) => ({
   isLoggedIn: computed(() => !!state.currentUser.value),
   isReady: computed(() => state.fetchStatus.value === "success"),
+  // Use hasData for gating UI that shouldn't unmount during refresh
+  hasData: computed(() => state.hasInitialized.value),
   collectionIndex: computed(() => toCollectionIndex(state.collections.value)),
   viewableCollections: computed((): AssetCollection[] =>
     filterCollections((col) => col.canView, state.collections.value)
@@ -149,6 +152,7 @@ const actions = (state: ReturnType<typeof createState>) => ({
       }));
 
       state.fetchStatus.value = "success";
+      state.hasInitialized.value = true;
     } catch (error) {
       console.error(error);
       state.fetchStatus.value = "error";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -656,7 +656,7 @@ export interface InstanceSettings {
 
   // Storage settings
   amazonS3Key: string | null;
-  // amazonS3Secret: string | null;
+  amazonS3Secret: string | null;
   defaultBucket: string | null;
   bucketRegion: string | null;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -686,7 +686,7 @@ export interface InstanceSettings {
   interfaceVersion: 0 | 1; // 0 = Classic, 1 = VueJS
   useCentralAuth: boolean;
   enableHLSStreaming: boolean;
-  enableThemes: boolean;
+  enableTheming: boolean;
   defaultTheme: string | null;
   availableThemes: string[] | null;
   customHomeRedirect: string | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -671,7 +671,7 @@ export interface InstanceSettings {
   autoloadMaxSearchResults: boolean;
 
   // Custom styling
-  useCustomHeader: 0 | 1 | 2; // 0 = none, 1 = header only, 2 = header and footer
+  useCustomHeader: 0 | 1 | 2; // 0 = none, 1 = header on all pages, 2 = header only on home page ("Only on Home Page")
   customHeaderText: string | null;
   customFooterText: string | null;
   useCustomCSS: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -695,7 +695,13 @@ export interface InstanceSettings {
 
   // Internal notes
   notes: string | null;
+
+  // timestamps
+  createdAt: ISODateTime | null; // legacy data may not have this
+  modifiedAt: ISODateTime | null; // legacy data may not have this
 }
+
+export type ISODateTime = string; // e.g. '2024-05-15T14:30:00+00:00'
 
 export interface RawAssetCollection {
   id: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -643,6 +643,60 @@ export interface ElevatorInstance {
   useVoyagerViewer: boolean; // whether or not to use the Voyager viewer
 }
 
+export interface InstanceSettings {
+  instanceId: number;
+  name: string;
+  domain: string;
+  ownerHomepage: string | null;
+  googleAnalyticsKey: string | null;
+
+  // Featured asset
+  featuredAsset: string | null;
+  featuredAssetText: string | null;
+
+  // Storage settings
+  amazonS3Key: string | null;
+  // amazonS3Secret: string | null;
+  defaultBucket: string | null;
+  bucketRegion: string | null;
+
+  // Display options
+  showCollectionInSearchResults: boolean;
+  showTemplateInSearchResults: boolean;
+  showPreviousNextSearchResults: boolean;
+  hideVideoAudio: boolean;
+  allowIndexing: boolean;
+  useVoyagerViewer: boolean;
+  automaticAltText: boolean;
+  autoloadMaxSearchResults: boolean;
+
+  // Custom styling
+  useCustomHeader: 0 | 1 | 2; // 0 = none, 1 = header only, 2 = header and footer
+  customHeaderText: string | null;
+  customFooterText: string | null;
+  useCustomCSS: boolean;
+  customHeaderCSS: string | null;
+  useHeaderLogo: boolean;
+
+  // Interstitial
+  enableInterstitial: boolean;
+  interstitialText: string | null;
+
+  // Vue interface options
+  interfaceVersion: 0 | 1; // 0 = Classic, 1 = VueJS
+  useCentralAuth: boolean;
+  enableHLSStreaming: boolean;
+  enableThemes: boolean;
+  defaultTheme: string | null;
+  availableThemes: string[] | null;
+  customHomeRedirect: string | null;
+  maximumMoreLikeThis: number | null;
+  defaultTextTruncationHeight: number | null;
+
+  // Internal notes
+  notes: string | null;
+}
+
 export interface RawAssetCollection {
   id: number;
   title: string;


### PR DESCRIPTION
<img width="800" alt="ScreenShot 2026-02-02 at 11 53 02@2x" src="https://github.com/user-attachments/assets/79f2b9cd-62c6-4889-95a4-aaca8f978bfa" />

- Adds page to view/edit admin instance settings.
- Fixes issue where `Login` modal wouldn't show after session expired.
- Fixes issue where `<RouterView>` completely remounts when refreshing login state.

On Dev.

Played around with grouping settings a little differently since now seemed like the time to experiment with changes. We'll probably need to shuffle a few things still, or go back to the old grouping. LMK.