### PR TITLE
fix: apply map style change when clicking style buttons

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
@@ -236,8 +236,9 @@ function getArcGISUrl(styleKey: string) {
 }
 
 function handleActiveStyleChange(styleKey: keyof typeof mapStyles) {
-  invariant(map, "Map is not initialized");
+  invariant(map.value, "Map is not initialized");
   state.activeMapStyleKey = styleKey;
+  map.value.setStyle(getArcGISUrl(styleKey));
 }
 
 onMounted(() => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/ef1402bc-9cb1-4638-951a-38acfd9bc002

The handleActiveStyleChange function was only updating the UI state (activeMapStyleKey) without calling setStyle() on the map instance.

Resolves #419 