### PR TITLE
make dupe event test less brittle

### DIFF
--- a/tests/e2e/duplicate-event-listeners.spec.ts
+++ b/tests/e2e/duplicate-event-listeners.spec.ts
@@ -90,7 +90,7 @@ test.describe("Event Listener Duplication Bug", () => {
       page.getByRole("heading", { name: "Elevator Home Page" })
     ).toBeVisible();
 
-    // wait until contentLoaded gets called once
+    // wait until imagesLoaded gets called once
     await pollUntil(() => window.eventListenerCallCounts.imagesLoaded, 1);
 
     // each event should have been dispatched exactly once


### PR DESCRIPTION
The test for duplicate event listeners used fixed timeouts, which can be brittle in CI. This rewrites things using polling: we poll until we get the expected value, or timeout (5s).