### PR TITLE
Add edit button on metadata-only asset pages

### DIFF
--- a/mock-server/db/assets.ts
+++ b/mock-server/db/assets.ts
@@ -233,6 +233,23 @@ const assetSeeds: Asset[] = [
     collectionId: 1,
     modifiedBy: 1,
   },
+  // Metadata-only asset (no file uploads)
+  {
+    ...baseAsset,
+    title_1: [{ isPrimary: false, fieldContents: "Metadata Only Asset" }],
+    upload_1: [],
+    assetId: "metadata_only_asset_001",
+    firstFileHandlerId: null,
+    firstObjectId: null,
+    title: ["Metadata Only Asset"],
+    modified: {
+      date: "2025-07-14 22:40:25.000000",
+      timezone_type: 3,
+      timezone: "UTC",
+    },
+    collectionId: 1,
+    modifiedBy: 1,
+  },
   // Special test asset for multiselect cascade tests
   {
     ...baseAsset,

--- a/src/pages/AssetViewPage/MetaDataOnlyView.vue
+++ b/src/pages/AssetViewPage/MetaDataOnlyView.vue
@@ -2,11 +2,20 @@
   <div class="asset-view-page__meta-data-only-view h-full relative">
     <div class="meta-data-only-view__inner h-full sm:p-8">
       <article
-        class="meta-data-only-view__article m-auto sm:max-w-3xl h-full overflow-auto p-4 sm:p-12 rounded shadow sm:px-12">
-        <h2
-          class="text-3xl mb-12 sm:text-5xl font-bold py-8 after:content-[''] after:w-8 after:h-2 after:block relative after:absolute after:bottom-0 after:left-0">
-          {{ assetTitle || "(No Title)" }}
-        </h2>
+        class="meta-data-only-view__article bg-surface-container m-auto sm:max-w-3xl h-full overflow-auto p-4 sm:p-12 rounded shadow-md sm:px-12">
+        <header class="flex justify-between items-baseline">
+          <h2
+            class="text-3xl mb-12 sm:text-5xl font-bold after:content-[''] after:w-8 after:h-2 after:block relative after:absolute after:bottom-0 after:left-0 after:bg-on-surface pb-8">
+            {{ assetTitle || "(No Title)" }}
+          </h2>
+          <IconButton
+            v-if="assetId && instanceStore.currentUser?.canManageAssets"
+            :to="`/assetManager/editAsset/${assetId}`"
+            title="Edit Asset">
+            <span class="sr-only">Edit Asset</span>
+            <PencilIcon class="size-4" />
+          </IconButton>
+        </header>
 
         <WidgetList v-if="assetId" :assetId="assetId" />
         <MoreLikeThis
@@ -25,6 +34,9 @@ import { useAsset } from "@/helpers/useAsset";
 import { SearchResultMatch } from "@/types";
 import MoreLikeThis from "@/components/MoreLikeThis/MoreLikeThis.vue";
 import api from "@/api";
+import { useInstanceStore } from "@/stores/instanceStore";
+import IconButton from "@/components/IconButton/IconButton.vue";
+import { PencilIcon } from "lucide-vue-next";
 
 const props = defineProps<{
   assetId: string | null;
@@ -36,6 +48,7 @@ const assetTitle = computed(() =>
   asset.value ? getAssetTitle(asset.value) : "Unknown"
 );
 const moreLikeThisItems = ref<SearchResultMatch[]>([]);
+const instanceStore = useInstanceStore();
 
 watch(
   assetIdRef,
@@ -45,16 +58,4 @@ watch(
   { immediate: true }
 );
 </script>
-<style scoped>
-.meta-data-only-view__inner {
-  background: var(--surface-container-low);
-}
-.meta-data-only-view__article {
-  background: var(--surface);
-  color: var(--on-surface);
-}
-
-.meta-data-only-view__article h2:after {
-  background: var(--on-surface);
-}
-</style>
+<style scoped></style>


### PR DESCRIPTION
<img width="600" alt="ScreenShot 2026-02-24 at 16 49 22@2x" src="https://github.com/user-attachments/assets/b8972eae-1dcb-4841-85a0-79dbf1167df7" />

Resolves #445 
