### PR TITLE
Add CSS classes so they can be used for hiding remote or local login options

### DIFF
--- a/src/components/AuthDropDown/AuthDropDown.vue
+++ b/src/components/AuthDropDown/AuthDropDown.vue
@@ -20,15 +20,18 @@
     <template v-else>
       <DropDownItem
         v-if="instance.useCentralAuth && instance.centralAuthLabel"
+        class="auth-drop-down__remote-login"
         :href="`${config.instance.base.url}/loginManager/remoteLogin/?redirect=${encodedCallbackUrl}`">
         {{ instance.centralAuthLabel }} Login
       </DropDownItem>
-      <DropDownItem :to="`/loginManager/localLogin/?redirect=${route.path}`">
+      <DropDownItem
+        class="auth-drop-down__local-login"
+        :to="`/loginManager/localLogin/?redirect=${route.path}`">
         <span v-if="instance.useCentralAuth" class="guest-auth-label">
           <!--
           The label for the guest login option can be customized via the `--guest-auth-label` CSS variable. If not set, it will default to "Guest". Eventually, this could become an explicit instance setting.
         --></span>
-Login
+        Login
       </DropDownItem>
     </template>
   </DropDown>

--- a/src/pages/HomePage/SignInRequiredNotice.vue
+++ b/src/pages/HomePage/SignInRequiredNotice.vue
@@ -9,7 +9,7 @@
       <Button
         :to="`/loginManager/localLogin/?redirect=${$route.path}`"
         variant="tertiary"
-        class="border border-primary py-2 px-4">
+        class="sign-in-required__local-login border border-primary py-2 px-4">
         <span v-if="instance.useCentralAuth" class="guest-auth-label">
           <!--
           The label for the guest login option can be customized via the `--guest-auth-label` CSS variable. If not set, it will default to "Guest". Eventually, this could become an explicit instance setting.
@@ -20,7 +20,7 @@
         v-if="instance.useCentralAuth"
         :href="`${config.instance.base.url}/loginManager/remoteLogin/?redirect=${encodedCallbackUrl}`"
         variant="tertiary"
-        class="border border-primary py-2 px-4">
+        class="sign-in-required__remote-login border border-primary py-2 px-4">
         {{ instance.centralAuthLabel }} Login
       </Button>
     </div>


### PR DESCRIPTION
This should do the trick for hiding local login.

```css
.sign-in-required__local-login,
.auth-drop-down__local-login { 
  display: none;
}
```
<img width="500" alt="ScreenShot 2026-03-09 at 15 25 18@2x" src="https://github.com/user-attachments/assets/dd803d91-00ff-4fe5-a7d6-da8e5df38842" />
