### PR TITLE
fix asset create race condition

### DIFF
--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -39,7 +39,7 @@
         :asset="assetEditor.localAsset!"
         :savedAssetTitle="assetEditor.savedAssetTitle"
         :localAssetTitle="assetEditor.localAssetTitle"
-        :saveStatus="assetEditor.saveAssetStatus"
+        :saveStatus="assetEditor.saveAssetIndicator"
         :hasUnsavedChanges="assetEditor.hasAssetChanged"
         class="flex-1"
         @update:templateId="handleConfirmTemplateChange($event)"

--- a/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetFormSidebar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetFormSidebar.vue
@@ -16,7 +16,7 @@
         variant="primary"
         type="submit"
         :disabled="!isAssetValid || displayStatus === 'pending'"
-        @click="$emit('save')">
+        @click="handleSave">
         Save
         <SpinnerIcon
           v-if="displayStatus === 'pending'"
@@ -239,6 +239,11 @@ watch(
 function handleUpdateTemplateId(templateId: number | string | null) {
   invariant(typeof templateId === "number", "Template ID must be a number");
   emit("update:templateId", templateId);
+}
+
+function handleSave() {
+  displayStatus.value = "pending";
+  emit("save");
 }
 
 function handleUpdateCollectionId(collectionId: number | string | null) {

--- a/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetFormSidebar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetFormSidebar.vue
@@ -15,14 +15,16 @@
       <Button
         variant="primary"
         type="submit"
-        :disabled="!isAssetValid || saveStatus === 'pending'"
+        :disabled="!isAssetValid || displayStatus === 'pending'"
         @click="$emit('save')">
         Save
         <SpinnerIcon
-          v-if="saveStatus === 'pending'"
+          v-if="displayStatus === 'pending'"
           class="size-4 animate-spin" />
-        <TriangleAlert v-else-if="saveStatus === 'error'" class="size-4" />
-        <CheckCircle2Icon v-else-if="saveStatus === 'success'" class="size-4" />
+        <TriangleAlert v-else-if="displayStatus === 'error'" class="size-4" />
+        <CheckCircle2Icon
+          v-else-if="displayStatus === 'success'"
+          class="size-4" />
       </Button>
 
       <div class="col-start-1 -col-end-1 text-xs text-right">
@@ -111,7 +113,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from "vue";
+import { computed, onUnmounted, reactive, ref, watch } from "vue";
 import Button from "@/components/Button/Button.vue";
 import { Asset, UnsavedAsset, Template, PHPDateTime } from "@/types";
 import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
@@ -144,6 +146,31 @@ const emit = defineEmits<{
 
 const state = reactive({
   localCollectionId: props.asset.collectionId,
+});
+
+// Hold success/error visible for a few seconds after a save, then reset to idle.
+// This is pure UI state — the raw mutation status resets only on the next save.
+const displayStatus = ref<MutationStatus>("idle");
+let displayTimer: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => props.saveStatus,
+  (status) => {
+    if (displayTimer) clearTimeout(displayTimer);
+    if (status === "pending") {
+      displayStatus.value = "pending";
+    } else if (status === "success") {
+      displayStatus.value = "success";
+      displayTimer = setTimeout(() => (displayStatus.value = "idle"), 3000);
+    } else if (status === "error") {
+      displayStatus.value = "error";
+      displayTimer = setTimeout(() => (displayStatus.value = "idle"), 10000);
+    }
+  }
+);
+
+onUnmounted(() => {
+  if (displayTimer) clearTimeout(displayTimer);
 });
 
 // Use controlled value for template ID - either selected or asset's current

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidget.vue
@@ -59,13 +59,12 @@
         v-show="widgetDef.allowMultiple || !hasContents"
         :collectionId="props.collectionId"
         :maxNumberOfFiles="widgetDef.allowMultiple ? undefined : 1"
-        @complete="handleCompleteUpload"
-        @allComplete="handleAllComplete" />
+        @complete="handleCompleteUpload" />
     </template>
   </EditWidgetLayout>
 </template>
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 import * as Type from "@/types";
 import EditWidgetLayout from "../EditWidgetLayout.vue";
 import * as ops from "../helpers/editWidgetOps";
@@ -78,7 +77,6 @@ import DropDownItem from "@/components/DropDown/DropDownItem.vue";
 import { VerticalDotsIcon } from "@/icons";
 import { Circle } from "lucide-vue-next";
 import CircleFilledCheckIcon from "@/icons/CircleFilledCheckIcon.vue";
-import { useDebounceFn } from "@vueuse/core";
 
 const props = defineProps<{
   collectionId: number;
@@ -101,39 +99,6 @@ const hasContents = computed(() => {
   return props.widgetContents.length > 0;
 });
 
-const hasPendingSave = ref(false);
-
-const debouncedEmitSave = useDebounceFn(
-  () => {
-    // Guard against double-save: handleAllComplete may have already saved
-    if (!hasPendingSave.value) return;
-    emit("save");
-    hasPendingSave.value = false;
-  },
-  2000,
-  {
-    maxWait: 4_000,
-  }
-);
-
-function scheduleSave() {
-  hasPendingSave.value = true;
-  debouncedEmitSave();
-}
-
-function handleAllComplete() {
-  if (!hasPendingSave.value) return;
-  // Clear the flag first so the still-pending debounce becomes a no-op
-  hasPendingSave.value = false;
-  emit("save");
-}
-
-onBeforeUnmount(() => {
-  if (hasPendingSave.value) {
-    emit("save");
-  }
-});
-
 async function handleCompleteUpload(fileRecord: Type.FileUploadRecord) {
   const uploadedItem: Type.WithId<Type.UploadWidgetContent> = {
     ...createDefaultWidgetContent(props.widgetDef),
@@ -150,8 +115,10 @@ async function handleCompleteUpload(fileRecord: Type.FileUploadRecord) {
     uploadedItem,
   ] as Type.WithId<Type.UploadWidgetContent>[]);
 
+  // Wait for Vue to flush the state update into localAsset before saving,
+  // so the new file is included in the save payload.
   await nextTick();
-  scheduleSave();
+  emit("save");
 }
 
 async function handleDeleteContent(id: string) {
@@ -180,7 +147,7 @@ async function handleDeleteContent(id: string) {
   );
 
   await nextTick();
-  scheduleSave();
+  emit("save");
 }
 
 function handleUpdateItem(item: Type.WithId<Type.UploadWidgetContent>) {

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -35,7 +35,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "start", fileRecord: Type.FileUploadRecord): void;
   (e: "complete", fileRecord: Type.FileUploadRecord): void;
-  (e: "allComplete"): void;
   (e: "error", error: Error): void;
 }>();
 
@@ -213,7 +212,6 @@ const uppy = new Uppy({
 // clear upload state on success
 uppy.on("complete", ({ successful, _failed }) => {
   successful?.forEach((file) => uppy.removeFile(file.id));
-  emit("allComplete");
 });
 
 uppy.on("error", (error) => {

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.test.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSaveQueue } from "./createSaveQueue";
+
+// Flush all pending microtasks (Promise chains).
+// With fake timers, setTimeout is frozen, but microtasks still drain automatically —
+// this helper just ensures we've yielded enough for async chains to settle.
+const flushMicrotasks = () => new Promise<void>((r) => queueMicrotask(r));
+
+describe("createSaveQueue", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  // Returns a saveFn mock plus manual controls for each invocation.
+  function makeControllableSaveFn() {
+    const resolves: Array<() => void> = [];
+    const rejects: Array<(e: unknown) => void> = [];
+    const fn = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((res, rej) => {
+          resolves.push(res);
+          rejects.push(rej);
+        }),
+    );
+    return { fn, resolves, rejects };
+  }
+
+  describe("basic behavior", () => {
+    it("fires the save immediately when no save is in flight", async () => {
+      const saveFn = vi.fn().mockResolvedValue(undefined);
+      const { save } = createSaveQueue(saveFn, 100);
+
+      save();
+      await flushMicrotasks();
+
+      expect(saveFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns a promise that resolves after the save completes", async () => {
+      const { fn, resolves } = makeControllableSaveFn();
+      const { save } = createSaveQueue(fn, 0);
+
+      const result = save();
+      await flushMicrotasks();
+      resolves[0]();
+      await flushMicrotasks();
+
+      await expect(result).resolves.toBeUndefined();
+    });
+
+    it("starts a fresh save immediately after the queue becomes idle", async () => {
+      const saveFn = vi.fn().mockResolvedValue(undefined);
+      const { save } = createSaveQueue(saveFn, 100);
+
+      // First cycle: let save complete and cooldown expire so loop exits
+      save();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(100);
+      await flushMicrotasks();
+
+      expect(saveFn).toHaveBeenCalledTimes(1);
+
+      // Second call should fire immediately — no in-flight save
+      save();
+      await flushMicrotasks();
+
+      expect(saveFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("coalescing", () => {
+    it("coalesces saves requested while one is in flight into a single additional call", async () => {
+      const { fn, resolves } = makeControllableSaveFn();
+      const { save } = createSaveQueue(fn, 0);
+
+      const p1 = save();
+      await flushMicrotasks(); // first save now in flight
+
+      // Multiple saves arrive while first is in flight
+      const p2 = save();
+      const p3 = save();
+      const p4 = save();
+
+      // Complete the first save
+      resolves[0]();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(0); // advance past 0ms cooldown
+      await flushMicrotasks();
+
+      await expect(p1).resolves.toBeUndefined();
+
+      // p2/p3/p4 were coalesced — only one additional saveFn call
+      resolves[1]();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(0);
+      await flushMicrotasks();
+
+      await expect(p2).resolves.toBeUndefined();
+      await expect(p3).resolves.toBeUndefined();
+      await expect(p4).resolves.toBeUndefined();
+
+      expect(fn).toHaveBeenCalledTimes(2); // 4 saves → 2 actual calls
+    });
+  });
+
+  describe("cooldown", () => {
+    it("does not fire a second save until the cooldown has elapsed", async () => {
+      const saveFn = vi.fn().mockResolvedValue(undefined);
+      const { save } = createSaveQueue(saveFn, 1000);
+
+      save();
+      await flushMicrotasks(); // first save completes
+
+      save(); // queue another during cooldown
+      await flushMicrotasks();
+
+      expect(saveFn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(999);
+      await flushMicrotasks();
+      expect(saveFn).toHaveBeenCalledTimes(1); // still cooling down
+
+      await vi.advanceTimersByTimeAsync(1);
+      await flushMicrotasks();
+      expect(saveFn).toHaveBeenCalledTimes(2); // cooldown expired, second save fired
+    });
+
+    it("resolves the save promise before the cooldown finishes", async () => {
+      const saveFn = vi.fn().mockResolvedValue(undefined);
+      const { save } = createSaveQueue(saveFn, 1000);
+
+      const p = save();
+      await flushMicrotasks(); // saveFn resolves, callbacks called
+
+      // Promise should be resolved even though cooldown hasn't expired
+      await expect(p).resolves.toBeUndefined();
+    });
+  });
+
+  describe("error handling", () => {
+    it("rejects the promise when saveFn throws", async () => {
+      const error = new Error("network error");
+      const saveFn = vi.fn().mockRejectedValue(error);
+      const { save } = createSaveQueue(saveFn, 0);
+
+      const result = save();
+      await flushMicrotasks();
+
+      await expect(result).rejects.toThrow("network error");
+    });
+
+    it("rejects all promises snapshotted in the failing iteration", async () => {
+      // To get multiple saves into the same snapshot, we queue them during a
+      // cooldown period — the loop hasn't started its next iteration yet, so
+      // all three callbacks are snapshotted together when it does.
+      const error = new Error("save failed");
+      const { fn, resolves, rejects } = makeControllableSaveFn();
+      // First invocation succeeds, second fails
+      fn.mockImplementationOnce(() => new Promise<void>((r) => resolves.push(r)));
+      fn.mockImplementationOnce(() => new Promise<void>((_, rej) => rejects.push(rej)));
+
+      const { save } = createSaveQueue(fn, 100);
+
+      // Complete the first save so we're in the cooldown
+      save();
+      await flushMicrotasks();
+      resolves[0]();
+      await flushMicrotasks();
+
+      // Queue three saves during the cooldown — all will be snapshotted together
+      const p1 = save();
+      const p2 = save();
+      const p3 = save();
+
+      // Advance past cooldown — loop runs second iteration, snapshots all three
+      await vi.advanceTimersByTimeAsync(100);
+      await flushMicrotasks();
+
+      // Second save is now in flight — reject it
+      rejects[0](error);
+      await flushMicrotasks();
+
+      await expect(p1).rejects.toThrow("save failed");
+      await expect(p2).rejects.toThrow("save failed");
+      await expect(p3).rejects.toThrow("save failed");
+    });
+
+    it("rejects saves that arrived during a failing in-flight save", async () => {
+      // Bug: saves added to the queue AFTER the snapshot is taken (i.e. while
+      // saveFn() is awaiting) are not in rejectSnapshot. When the catch block
+      // fires it only rejects the snapshot, leaving the in-flight arrivals
+      // hanging forever unless a subsequent save() happens to pick them up.
+      const error = new Error("save failed");
+      const { fn, rejects } = makeControllableSaveFn();
+      const { save } = createSaveQueue(fn, 0);
+
+      // p1 starts the loop; the loop synchronously snapshots p1 and awaits saveFn
+      const p1 = save();
+      await flushMicrotasks(); // saveFn now in flight
+
+      // p2 and p3 arrive after the snapshot — their callbacks are NOT in rejectSnapshot
+      const p2 = save();
+      const p3 = save();
+
+      // Fail the in-flight save
+      rejects[0](error);
+      await flushMicrotasks();
+
+      await expect(p1).rejects.toThrow("save failed");
+      await expect(p2).rejects.toThrow("save failed");
+      await expect(p3).rejects.toThrow("save failed");
+    });
+
+    it("starts a fresh loop on the next save() call after an error", async () => {
+      const error = new Error("save failed");
+      const saveFn = vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue(undefined);
+
+      const { save } = createSaveQueue(saveFn, 0);
+
+      // First save fails
+      const p1 = save();
+      await flushMicrotasks();
+      await expect(p1).rejects.toThrow("save failed");
+
+      // Second save should start fresh and succeed
+      const p2 = save();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(0);
+      await flushMicrotasks();
+
+      await expect(p2).resolves.toBeUndefined();
+      expect(saveFn).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.ts
@@ -1,0 +1,90 @@
+/**
+ * - prevents race which could result in duplicate asset creation. Serializes saves so the `assetId` from a CREATE is always written back before the next save reads it.
+ * - Coalesces concurrent requests: at most one save pending behind the in-flight one
+ * - Enforces a cooldown between saves to avoid spamming the server
+ * - Fires the first save immediately (no debounce delay)
+ */
+export function createSaveQueue(saveFn: () => Promise<void>, cooldown = 2000) {
+  // promise of the running save loop
+  let saveLoopPromise: Promise<void> | null = null;
+
+  // should save again after this save finishes
+  let hasPendingSave = false;
+
+  // as each save is requested, we'll add its promised
+  // resolve/reject to these sets, and call them when
+  // the next save finishes
+  const resolveCallbacks = new Set<() => void>();
+  const rejectCallbacks = new Set<(error: unknown) => void>();
+
+  /**
+   * Processes save requests until there are no more
+   * pending saves.
+   */
+  async function runSaveLoop() {
+    let resolveSnapshot = new Set<() => void>();
+    let rejectSnapshot = new Set<(error: unknown) => void>();
+
+    try {
+      while (hasPendingSave) {
+        // reset the flag
+        hasPendingSave = false;
+
+        // snapshot the current callbacks and clear the sets,
+        // so new requests can come in while we're saving
+        resolveSnapshot = new Set(resolveCallbacks);
+        rejectSnapshot = new Set(rejectCallbacks);
+        resolveCallbacks.clear();
+        rejectCallbacks.clear();
+
+        // run the save
+        await saveFn();
+
+        // if it succeeds, resolve all pending promises
+        resolveSnapshot.forEach((cb) => cb());
+
+        // wait a bit before the next save, to avoid spamming saves if the user is making rapid changes
+        await new Promise((resolve) => setTimeout(resolve, cooldown));
+      }
+    } catch (error) {
+      // reject the saves that were snapshotted when this iteration started
+      rejectSnapshot.forEach((cb) => cb(error));
+
+      // also reject any saves that arrived while saveFn() was awaiting —
+      // they were added after the snapshot was taken and won't be picked up
+      // by a future iteration because the loop is exiting
+      rejectCallbacks.forEach((cb) => cb(error));
+      resolveCallbacks.clear();
+      rejectCallbacks.clear();
+      hasPendingSave = false;
+    }
+
+    // when the loop finishes, reset the promise
+    saveLoopPromise = null;
+  }
+
+  /**
+   * Requests a save. If a save is already in progress, it will be
+   * - If the save loop is not running, start it.
+   * - If it is, just set the pending flag to signal we
+   *  need to save again after the current save finishes.
+   *
+   * @returns a promise that resolves when the save completes, or rejects if it fails
+   */
+  async function save() {
+    return new Promise<void>((resolve, reject) => {
+      hasPendingSave = true;
+
+      resolveCallbacks.add(resolve);
+      rejectCallbacks.add(reject);
+
+      if (!saveLoopPromise) {
+        saveLoopPromise = runSaveLoop();
+      }
+
+      return saveLoopPromise;
+    });
+  }
+
+  return { save };
+}

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.ts
@@ -64,14 +64,13 @@ export function createSaveQueue(saveFn: () => Promise<void>, cooldown = 2000) {
   }
 
   /**
-   * Requests a save. If a save is already in progress, it will be
-   * - If the save loop is not running, start it.
-   * - If it is, just set the pending flag to signal we
-   *  need to save again after the current save finishes.
+   * Requests a save. If the save loop is not running, start it.
+   * If it is already running, set the pending flag to signal we
+   * need to save again after the current save finishes.
    *
    * @returns a promise that resolves when the save completes, or rejects if it fails
    */
-  async function save() {
+  function save() {
     return new Promise<void>((resolve, reject) => {
       hasPendingSave = true;
 
@@ -81,8 +80,6 @@ export function createSaveQueue(saveFn: () => Promise<void>, cooldown = 2000) {
       if (!saveLoopPromise) {
         saveLoopPromise = runSaveLoop();
       }
-
-      return saveLoopPromise;
     });
   }
 

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/createSaveQueue.ts
@@ -11,7 +11,7 @@ export function createSaveQueue(saveFn: () => Promise<void>, cooldown = 2000) {
   // should save again after this save finishes
   let hasPendingSave = false;
 
-  // as each save is requested, we'll add its promised
+  // as each save is requested, we'll add its promise's
   // resolve/reject to these sets, and call them when
   // the next save finishes
   const resolveCallbacks = new Set<() => void>();

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -1,6 +1,5 @@
 import * as T from "@/types";
-import { type MutationStatus } from "@tanstack/vue-query";
-import { computed, inject, nextTick, reactive, ref, toRefs } from "vue";
+import { computed, inject, nextTick, reactive, toRefs } from "vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import {
   hasAssetChanged as hasAssetChangedPure,
@@ -11,6 +10,7 @@ import invariant from "tiny-invariant";
 import * as fetchers from "@/api/fetchers";
 import { ASSET_EDITOR_PROVIDE_KEY } from "@/constants/constants";
 import { useUpdateAssetMutation } from "@/queries/useUpdateAssetMutation";
+import { createSaveQueue } from "./createSaveQueue";
 
 interface AssetEditorState {
   editorId: string; // unique ID for this editor instance
@@ -53,12 +53,6 @@ export const createAssetEditor = () => {
 
   const instanceStore = useInstanceStore();
   const updateAssetMutation = useUpdateAssetMutation();
-
-  // Mirrors mutation status but delays the "idle" reset so the success/error
-  // indicator stays visible for a few seconds after a save completes.
-  const saveAssetIndicator = ref<MutationStatus>("idle");
-  let successResetTimer: ReturnType<typeof setTimeout> | null = null;
-  let errorResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   ////////////////////////////////////////////////
   // COMPUTED
@@ -204,48 +198,21 @@ export const createAssetEditor = () => {
     return initExistingAsset(state.localAsset.assetId, { force: true });
   }
 
-  // Coalescing save queue: any number of concurrent saveAsset() callers share
-  // a single loop that runs at most one save at a time. A 2s cooldown between
-  // saves prevents rapid-fire requests while still persisting data promptly.
-  // This ensures the assetId from the first CREATE is always written back to
-  // localAsset before any subsequent save reads it, preventing duplicate assets.
-  const SAVE_COOLDOWN_MS = 2000;
-  const sleep = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  let saveLoopPromise: Promise<void> | null = null;
-  let hasPendingSave = false;
-
-  async function runSaveLoop(): Promise<void> {
-    try {
-      while (hasPendingSave) {
-        hasPendingSave = false;
-        await doSave();
-        if (hasPendingSave) {
-          console.debug("[useAssetEditor] save cooldown before next save");
-          await sleep(SAVE_COOLDOWN_MS);
-        }
-      }
-    } finally {
-      saveLoopPromise = null;
-    }
-  }
+  // Coalescing save queue: at most one save in flight, with a 2s cooldown
+  // between saves. Ensures the assetId from the first CREATE is written back
+  // before any subsequent save reads it, preventing duplicate assets.
+  const { save: enqueueSave } = createSaveQueue(doSave, 2000);
 
   /**
    * Save the current local asset to the backend.
    *
-   * Coalescing: concurrent callers all share the same in-flight loop and
-   * receive the same promise. The loop runs one save at a time with a 2s
-   * cooldown between saves, collapsing any number of queued requests into
+   * Coalescing: concurrent callers all share the same in-flight save and
+   * receive individual promises that resolve together. The queue enforces a
+   * 2s cooldown between saves, collapsing any number of queued requests into
    * at most one pending save.
    */
   function saveAsset(): Promise<void> {
-    if (successResetTimer) clearTimeout(successResetTimer);
-    if (errorResetTimer) clearTimeout(errorResetTimer);
-    saveAssetIndicator.value = "pending";
-
-    hasPendingSave = true;
-    saveLoopPromise ??= runSaveLoop();
-    return saveLoopPromise;
+    return enqueueSave();
   }
 
   async function doSave(): Promise<void> {
@@ -273,32 +240,11 @@ export const createAssetEditor = () => {
       collectionId: state.localAsset.collectionId,
     });
 
-    if (successResetTimer) clearTimeout(successResetTimer);
-    if (errorResetTimer) clearTimeout(errorResetTimer);
-    saveAssetIndicator.value = "pending";
-
-    let objectId: string;
-    try {
-      ({ objectId } = await updateAssetMutation.mutateAsync(formData));
-      console.debug("[useAssetEditor] doSave: save succeeded", {
-        objectId,
-        operation: isCreate ? "CREATE" : "UPDATE",
-      });
-      saveAssetIndicator.value = "success";
-      successResetTimer = setTimeout(() => {
-        saveAssetIndicator.value = "idle";
-      }, 3000);
-    } catch (err) {
-      console.debug("[useAssetEditor] doSave: save failed", {
-        error: err,
-        assetId: state.localAsset?.assetId || "(new)",
-      });
-      saveAssetIndicator.value = "error";
-      errorResetTimer = setTimeout(() => {
-        saveAssetIndicator.value = "idle";
-      }, 10000);
-      throw err;
-    }
+    const { objectId } = await updateAssetMutation.mutateAsync(formData);
+    console.debug("[useAssetEditor] doSave: save succeeded", {
+      objectId,
+      operation: isCreate ? "CREATE" : "UPDATE",
+    });
     invariant(objectId, "Expected objectId to be defined after saveAsset");
 
     const savedAsset = await fetchers.fetchAsset(objectId);
@@ -452,7 +398,7 @@ export const createAssetEditor = () => {
     localAssetTitle,
     savedAssetTitle,
     hasAssetChanged,
-    saveAssetIndicator,
+    saveAssetIndicator: updateAssetMutation.status,
     lastModified: computed(() => {
       if (!state.localAsset?.modified?.date) return null;
       return new Date(state.localAsset.modified.date).toLocaleString();

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/useAssetEditor.ts
@@ -1,6 +1,6 @@
 import * as T from "@/types";
-import { MutationStatus } from "@tanstack/vue-query";
-import { computed, inject, nextTick, reactive, toRefs } from "vue";
+import { type MutationStatus } from "@tanstack/vue-query";
+import { computed, inject, nextTick, reactive, ref, toRefs } from "vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import {
   hasAssetChanged as hasAssetChangedPure,
@@ -10,6 +10,7 @@ import { toSaveableFormData } from "./toSaveableFormData";
 import invariant from "tiny-invariant";
 import * as fetchers from "@/api/fetchers";
 import { ASSET_EDITOR_PROVIDE_KEY } from "@/constants/constants";
+import { useUpdateAssetMutation } from "@/queries/useUpdateAssetMutation";
 
 interface AssetEditorState {
   editorId: string; // unique ID for this editor instance
@@ -17,7 +18,6 @@ interface AssetEditorState {
   savedAsset: T.Asset | null;
   template: T.Template | null;
   isInitialized: boolean;
-  saveAssetStatus: MutationStatus;
   modifiedInlineRelatedAssetWidgets: Set<T.Asset["assetId"]>;
   isTemplateLoading?: boolean;
 }
@@ -28,7 +28,6 @@ const initState = (opts?: Partial<AssetEditorState>): AssetEditorState => ({
   savedAsset: null,
   template: null,
   isInitialized: false,
-  saveAssetStatus: "idle",
   isTemplateLoading: false,
 
   // inline related assets are part of this local asset
@@ -53,6 +52,13 @@ export const createAssetEditor = () => {
   );
 
   const instanceStore = useInstanceStore();
+  const updateAssetMutation = useUpdateAssetMutation();
+
+  // Mirrors mutation status but delays the "idle" reset so the success/error
+  // indicator stays visible for a few seconds after a save completes.
+  const saveAssetIndicator = ref<MutationStatus>("idle");
+  let successResetTimer: ReturnType<typeof setTimeout> | null = null;
+  let errorResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   ////////////////////////////////////////////////
   // COMPUTED
@@ -198,10 +204,51 @@ export const createAssetEditor = () => {
     return initExistingAsset(state.localAsset.assetId, { force: true });
   }
 
+  // Coalescing save queue: any number of concurrent saveAsset() callers share
+  // a single loop that runs at most one save at a time. A 2s cooldown between
+  // saves prevents rapid-fire requests while still persisting data promptly.
+  // This ensures the assetId from the first CREATE is always written back to
+  // localAsset before any subsequent save reads it, preventing duplicate assets.
+  const SAVE_COOLDOWN_MS = 2000;
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+  let saveLoopPromise: Promise<void> | null = null;
+  let hasPendingSave = false;
+
+  async function runSaveLoop(): Promise<void> {
+    try {
+      while (hasPendingSave) {
+        hasPendingSave = false;
+        await doSave();
+        if (hasPendingSave) {
+          console.debug("[useAssetEditor] save cooldown before next save");
+          await sleep(SAVE_COOLDOWN_MS);
+        }
+      }
+    } finally {
+      saveLoopPromise = null;
+    }
+  }
+
   /**
-   * Save the current local asset to the backend
+   * Save the current local asset to the backend.
+   *
+   * Coalescing: concurrent callers all share the same in-flight loop and
+   * receive the same promise. The loop runs one save at a time with a 2s
+   * cooldown between saves, collapsing any number of queued requests into
+   * at most one pending save.
    */
-  async function saveAsset(): Promise<void> {
+  function saveAsset(): Promise<void> {
+    if (successResetTimer) clearTimeout(successResetTimer);
+    if (errorResetTimer) clearTimeout(errorResetTimer);
+    saveAssetIndicator.value = "pending";
+
+    hasPendingSave = true;
+    saveLoopPromise ??= runSaveLoop();
+    return saveLoopPromise;
+  }
+
+  async function doSave(): Promise<void> {
     invariant(state.localAsset, "Cannot save: no local asset");
     invariant(state.template, "Cannot save: no template");
     invariant(
@@ -209,66 +256,75 @@ export const createAssetEditor = () => {
       "Cannot save: localAsset.templateId !== template.templateId"
     );
 
-    if (state.saveAssetStatus === "pending") {
-      // TODO: if already saving, wait until the current save is done? and return that promise?
-      // For now, just log a warning
-      console.warn("Already saving asset, waiting for current save to finish.");
-    }
+    await runBeforeSaveCallbacks();
 
-    state.saveAssetStatus = "pending";
+    // toSaveableFormData uses state.localAsset.assetId (not the route prop) to
+    // decide create vs. update: empty string = create, non-empty = update.
+    // localAsset.assetId is the editor's source of truth — after the first save
+    // populates it, all subsequent saves (including auto-saves from upload
+    // widgets before the URL has been updated) correctly send an update.
+    const formData = toSaveableFormData(state.localAsset, state.template);
+    const isCreate = !state.localAsset.assetId;
+
+    console.debug("[useAssetEditor] doSave: saving asset", {
+      operation: isCreate ? "CREATE" : "UPDATE",
+      assetId: state.localAsset.assetId || "(new)",
+      templateId: state.template.templateId,
+      collectionId: state.localAsset.collectionId,
+    });
+
+    if (successResetTimer) clearTimeout(successResetTimer);
+    if (errorResetTimer) clearTimeout(errorResetTimer);
+    saveAssetIndicator.value = "pending";
+
+    let objectId: string;
     try {
-      await runBeforeSaveCallbacks();
-
-      const formData = toSaveableFormData(state.localAsset, state.template);
-
-      const { objectId } = await fetchers.updateAsset(formData);
-      invariant(objectId, "Expected objectId to be defined after saveAsset");
-
-      const savedAsset = await fetchers.fetchAsset(objectId);
-      invariant(
-        savedAsset,
-        "Expected saved asset to be defined after saveAsset"
-      );
-
-      state.savedAsset = savedAsset;
-
-      // make some targeted updates to the local asset to avoid unnecessary reactivity
-      state.localAsset.assetId = savedAsset.assetId;
-      state.localAsset.title = savedAsset.title;
-      state.localAsset.modified = savedAsset.modified;
-      state.localAsset.modifiedBy = savedAsset.modifiedBy;
-      state.localAsset.firstFileHandlerId = savedAsset.firstFileHandlerId;
-
-      // clear any upload widget `regenerate` flags
-      const uploadWidgetItems = state.template.widgetArray
-        .filter((w) => w.type === T.WIDGET_TYPES.UPLOAD)
-        .flatMap(
-          (w) =>
-            state.localAsset?.[
-              w.fieldTitle
-            ] as T.WithId<T.UploadWidgetContent>[]
-        )
-        .filter(Boolean);
-
-      uploadWidgetItems.forEach((item) => {
-        item.regenerate = undefined;
+      ({ objectId } = await updateAssetMutation.mutateAsync(formData));
+      console.debug("[useAssetEditor] doSave: save succeeded", {
+        objectId,
+        operation: isCreate ? "CREATE" : "UPDATE",
       });
-
-      state.saveAssetStatus = "success";
-      setTimeout(() => {
-        state.saveAssetStatus = "idle"; // Reset status after a delay
+      saveAssetIndicator.value = "success";
+      successResetTimer = setTimeout(() => {
+        saveAssetIndicator.value = "idle";
       }, 3000);
     } catch (err) {
-      console.error(`Cannot save asset: ${err}`);
-
-      state.saveAssetStatus = "error";
-
-      setTimeout(() => {
-        state.saveAssetStatus = "idle"; // Reset status after a delay
+      console.debug("[useAssetEditor] doSave: save failed", {
+        error: err,
+        assetId: state.localAsset?.assetId || "(new)",
+      });
+      saveAssetIndicator.value = "error";
+      errorResetTimer = setTimeout(() => {
+        saveAssetIndicator.value = "idle";
       }, 10000);
-
       throw err;
     }
+    invariant(objectId, "Expected objectId to be defined after saveAsset");
+
+    const savedAsset = await fetchers.fetchAsset(objectId);
+    invariant(savedAsset, "Expected saved asset to be defined after saveAsset");
+
+    state.savedAsset = savedAsset;
+
+    // make some targeted updates to the local asset to avoid unnecessary reactivity
+    state.localAsset.assetId = savedAsset.assetId;
+    state.localAsset.title = savedAsset.title;
+    state.localAsset.modified = savedAsset.modified;
+    state.localAsset.modifiedBy = savedAsset.modifiedBy;
+    state.localAsset.firstFileHandlerId = savedAsset.firstFileHandlerId;
+
+    // clear any upload widget `regenerate` flags
+    const uploadWidgetItems = state.template.widgetArray
+      .filter((w) => w.type === T.WIDGET_TYPES.UPLOAD)
+      .flatMap(
+        (w) =>
+          state.localAsset?.[w.fieldTitle] as T.WithId<T.UploadWidgetContent>[]
+      )
+      .filter(Boolean);
+
+    uploadWidgetItems.forEach((item) => {
+      item.regenerate = undefined;
+    });
   }
 
   async function updateCollection(newCollectionId: number): Promise<void> {
@@ -336,7 +392,13 @@ export const createAssetEditor = () => {
       await migrateToTemplate(updatedAsset.templateId);
     }
 
-    state.localAsset = updatedAsset;
+    state.localAsset = {
+      ...updatedAsset,
+      // if updatedAsset contains a stale empty (new) assetId,
+      // but current localAsset has a non-empty assetId, preserve the
+      // non-empty one to prevent accidentally creating a new asset on save.
+      assetId: updatedAsset.assetId || state.localAsset.assetId,
+    };
   }
 
   function updateAssetField(
@@ -390,6 +452,7 @@ export const createAssetEditor = () => {
     localAssetTitle,
     savedAssetTitle,
     hasAssetChanged,
+    saveAssetIndicator,
     lastModified: computed(() => {
       if (!state.localAsset?.modified?.date) return null;
       return new Date(state.localAsset.modified.date).toLocaleString();

--- a/tests/e2e/multiple-file-upload.spec.ts
+++ b/tests/e2e/multiple-file-upload.spec.ts
@@ -5,6 +5,86 @@ import path from "path";
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 
+test.describe("Race condition: no duplicate assets on concurrent saves", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.route("**/arcgis.com/**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+    );
+    await page.route("**/basemaps-api.arcgis.com/**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+    );
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+    await page.goto("/assetManager/addAsset");
+  });
+
+  test("concurrent saves during creation only create one asset", async ({
+    page,
+  }) => {
+    // Track how many requests arrive with an empty objectId (i.e. "create new asset").
+    // We add an artificial delay so the second save fires while the first is still
+    // in-flight — widening the race window. With the mutex fix only one create should
+    // ever reach the server; without it, both would arrive with objectId="" and the
+    // backend would produce two assets.
+    let createCount = 0;
+
+    await page.route("**/assetManager/submission/true", async (route) => {
+      const postData = route.request().postData() ?? "";
+      // The payload is multipart form data; the JSON field contains `"objectId":""`
+      // for new assets and `"objectId":"<id>"` for updates.
+      if (postData.includes('"objectId":""')) {
+        createCount++;
+      }
+      // Extra delay on top of the mock server's own delay — ensures the first
+      // create is still in-flight when a second save is triggered.
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.continue();
+    });
+
+    // Select the "Multiple Upload Widgets" template so there are two independent
+    // upload widgets, each with its own debounce — maximising the chance that
+    // both fire their saves within the race window.
+    await page.getByLabel("Template").selectOption({ label: "Multiple Upload Widgets" });
+    await page.getByLabel("Collection").selectOption({ index: 1 });
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByRole("heading", { name: "Create Asset" })).toBeVisible();
+
+    await page.getByLabel("Title").fill("Race condition test asset");
+
+    const fixtureFile = path.join(testDir, "..", "fixtures", "test-image.jpg");
+
+    // Upload to the first widget
+    const widget1 = page.locator("section.edit-widget-layout").filter({
+      has: page.getByRole("heading", { name: "Multiple Uploads" }),
+    });
+    const chooser1Promise = page.waitForEvent("filechooser");
+    await widget1.getByRole("button", { name: "browse files" }).click();
+    const chooser1 = await chooser1Promise;
+    await chooser1.setFiles(fixtureFile);
+
+    // Upload to the second widget immediately — both debounces will fire close
+    // together, giving us two concurrent saveAsset() calls.
+    const widget2 = page.locator("section.edit-widget-layout").filter({
+      has: page.getByRole("heading", { name: "Single Upload" }),
+    });
+    await widget2.scrollIntoViewIfNeeded();
+    const chooser2Promise = page.waitForEvent("filechooser");
+    await widget2.getByRole("button", { name: "browse files" }).click();
+    const chooser2 = await chooser2Promise;
+    await chooser2.setFiles(fixtureFile);
+
+    // Wait for all network activity (uploads + saves) to settle.
+    await page.waitForLoadState("networkidle");
+
+    expect(createCount).toBe(1);
+
+    // Confirm we landed on the edit page (not still on /addAsset).
+    await expect(page).toHaveURL(/\/assetManager\/editAsset/);
+  });
+});
+
 test.describe("Multiple File Upload", () => {
   test.beforeEach(async ({ page, request }) => {
     // Block ArcGIS requests

--- a/tests/e2e/multiple-file-upload.spec.ts
+++ b/tests/e2e/multiple-file-upload.spec.ts
@@ -8,10 +8,18 @@ const testDir = path.dirname(fileURLToPath(import.meta.url));
 test.describe("Race condition: no duplicate assets on concurrent saves", () => {
   test.beforeEach(async ({ page, request }) => {
     await page.route("**/arcgis.com/**", (route) =>
-      route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      })
     );
     await page.route("**/basemaps-api.arcgis.com/**", (route) =>
-      route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      })
     );
     const workerId = test.info().workerIndex.toString();
     await setupWorkerHTTPHeader({ page, workerId });
@@ -46,10 +54,14 @@ test.describe("Race condition: no duplicate assets on concurrent saves", () => {
     // Select the "Multiple Upload Widgets" template so there are two independent
     // upload widgets, each with its own debounce — maximising the chance that
     // both fire their saves within the race window.
-    await page.getByLabel("Template").selectOption({ label: "Multiple Upload Widgets" });
+    await page
+      .getByLabel("Template")
+      .selectOption({ label: "Multiple Upload Widgets" });
     await page.getByLabel("Collection").selectOption({ index: 1 });
     await page.getByRole("button", { name: "Continue" }).click();
-    await expect(page.getByRole("heading", { name: "Create Asset" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Create Asset" })
+    ).toBeVisible();
 
     await page.getByLabel("Title").fill("Race condition test asset");
 
@@ -166,6 +178,9 @@ test.describe("Multiple File Upload", () => {
     // verify that the image widget now has 4 entries
     const imageEntries = imageWidget.locator(".edit-upload-widget-item");
     await expect(imageEntries).toHaveCount(4);
+
+    // sleep for 4s to accommodate save cooldown
+    await new Promise((r) => setTimeout(r, 4000));
 
     // wait for network requests to complete
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
Fixes #473

This resolves an issue where a double asset creation race could happen by:
1. Moving save asset handling from upload debounce to a centralized **coalescing save queue**.
2. Guarding against a save accidentally stomping a pre-existing `assetId`.

## Issues and Fixes

### Issue 1: Double asset creation during upload

When creating a new asset and uploading multiple files in rapid succession, the upload widgets each trigger an auto-save. If two saves fired before the first one returned its `assetId`, both sent `objectId: ""` to the backend — the signal for "create new asset". The backend would silently create two separate assets.

Debouncing the upload widget in a previous PR would make the problem less likely, but still possible since saves can come from multiple sources (user click, upload complete, related asset save). Extreme latency could be an issue.

#### Fix

This PR moves to a centralized coalescing save queue in `useAssetEditor` instead of managing save requests in individual widgets. By "coalescing" we mean that there is at most one pending save queued — additional save requests coalesce to use the pending request.

All concurrent `saveAsset()` callers share a single loop (`runSaveLoop`) that runs one save at a time. Any caller that arrives while a save is in-flight just sets a `hasPendingSave` flag and joins the existing promise. By the time the queue runs the second save, the first has already populated `state.localAsset.assetId`, so it correctly sends an update rather than a create.

A 2s cooldown runs between consecutive saves. If a user clicks "Save" and nothing is in flight, the asset saves immediately with no delay, but it will still add a wait before letting another save proceed. This makes the behavior similar to debounce, but we don't block the first save with a wait.

The coalescing save queue logic is extracted to a separate `createSaveQueue()` function for testability (and to improve the readability of the already-large `useAssetEditor`).

### Issue 2: Save accidentally stomping a pre-existing `assetId`

The `EditAssetFormSidebar` emits `update:asset` by spreading `{ ...props.asset, <field change> }`. If the sidebar rendered before the first save returned (so `props.asset.assetId` was still `""`), any user interaction — changing Status, Available After, or Collection — would emit an `update:asset` event carrying an empty `assetId`. This window is small but real, especially on slow connections or when the server is under load.

Without a guard, `updateLocalAsset` could write that empty `assetId` back into `state.localAsset`, silently reverting the editor to create mode.

#### Fix

The fix preserves the non-empty `assetId` whenever the incoming update has an empty one:

```ts
assetId: updatedAsset.assetId || state.localAsset.assetId,
```

This is a separate, independent guard from the coalescing queue — the queue prevents concurrent saves from racing; this guard prevents a stale-props event from undoing the `assetId` the queue already secured.

## Related

- As part of this change, the raw `fetchers.updateAsset()` call is replaced with the existing `useUpdateAssetMutation()` hook, which properly invalidates the TanStack Query cache on success (previously the cache was never invalidated after a save).
- The save debounce and `allComplete` shortcut previously living in `EditUploadWidget` are removed — the coalescing queue in `useAssetEditor` now handles the "don't spam the server" concern at the right level.
- Remove our code to show update status and instead use TanStack's internal `updateAssetMutation.status`.
- Tests added for the save queue.


On dev for testing.