### PR TITLE
fix(AllUserAssetsPage): point add asset button to correct path

### DIFF
--- a/src/pages/AllUserAssetsPage/AllUserAssetsPage.vue
+++ b/src/pages/AllUserAssetsPage/AllUserAssetsPage.vue
@@ -3,7 +3,7 @@
     <div class="container py-10 mx-auto">
       <div class="flex justify-between items-center">
         <h1 class="text-4xl font-bold my-8">All My Assets</h1>
-        <RouterLink :to="{ name: 'editAsset' }" asChild>
+        <RouterLink :to="{ path: '/assetManager/addAsset' }" asChild>
           <Button variant="primary" class="mb-4">Add Asset</Button>
         </RouterLink>
       </div>


### PR DESCRIPTION
Fixes #466

The "Add Asset" button on the "All My Assets" page was using `{ name: 'editAsset' }` for navigation, which generates the URL `/assetManager/editAsset`. Refreshing that URL causes an error because the route expects an asset ID.

The fix is to navigate to `{ path: '/assetManager/addAsset' }` instead, which is the alias already defined on the `editAsset` route and the correct stable URL for creating a new asset.