### PR TITLE
Fix "No assets found" flash on All My Assets page

### DIFF
--- a/src/pages/AllUserAssetsPage/AllUserAssetsPage.test.ts
+++ b/src/pages/AllUserAssetsPage/AllUserAssetsPage.test.ts
@@ -53,6 +53,7 @@ describe("AllUserAssetsPage", () => {
   it("does not show 'No assets found.' while the fetch is in flight", () => {
     const wrapper = mount({ isFetching: true, data: [] });
     expect(wrapper.text()).not.toContain("No assets found.");
+    expect(wrapper.text()).not.toContain("No results.");
   });
 
   it("shows 'No assets found.' when fetch completes with no results", () => {

--- a/src/pages/AllUserAssetsPage/AllUserAssetsPage.test.ts
+++ b/src/pages/AllUserAssetsPage/AllUserAssetsPage.test.ts
@@ -1,0 +1,68 @@
+/**
+ * AllUserAssetsPage tests.
+ *
+ * Regression test for issue #469: the page was showing "No assets found."
+ * while the initial fetch was still in flight. This happened because
+ * useAllUserAssets sets initialData to an empty array, so the query's `data`
+ * is [] immediately. The page was checking `!allUserAssets.length` without
+ * first confirming the fetch had completed.
+ *
+ * Fix: suppress the empty state message while `isFetching` is true.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import { ref } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("@/queries/useAllUserAssets", () => ({
+  useAllUserAssets: vi.fn(),
+}));
+
+vi.mock("@/queries/useDeleteAssetMutation", () => ({
+  useDeleteAssetMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/stores/errorStore", () => ({
+  useErrorStore: () => ({ setError: vi.fn() }),
+}));
+
+import AllUserAssetsPage from "./AllUserAssetsPage.vue";
+import { useAllUserAssets } from "@/queries/useAllUserAssets";
+
+const mockUseAllUserAssets = vi.mocked(useAllUserAssets);
+
+describe("AllUserAssetsPage", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  function mount({ isFetching = false, data = [] as unknown[] } = {}) {
+    mockUseAllUserAssets.mockReturnValue({
+      data: ref(data),
+      isFetching: ref(isFetching),
+    } as ReturnType<typeof useAllUserAssets>);
+
+    return shallowMount(AllUserAssetsPage, {
+      global: {
+        stubs: { DefaultLayout: { template: "<slot />" }, RouterLink: { template: "<a><slot /></a>" } },
+      },
+    });
+  }
+
+  it("does not show 'No assets found.' while the fetch is in flight", () => {
+    const wrapper = mount({ isFetching: true, data: [] });
+    expect(wrapper.text()).not.toContain("No assets found.");
+  });
+
+  it("shows 'No assets found.' when fetch completes with no results", () => {
+    const wrapper = mount({ isFetching: false, data: [] });
+    expect(wrapper.text()).toContain("No assets found.");
+  });
+
+  it("shows the table when fetch completes with results", () => {
+    const wrapper = mount({ isFetching: false, data: [{ id: "1", title: "My Asset" }] });
+    expect(wrapper.text()).not.toContain("No assets found.");
+    expect(wrapper.findComponent({ name: "UserAssetsTable" }).exists()).toBe(true);
+  });
+});

--- a/src/pages/AllUserAssetsPage/AllUserAssetsPage.vue
+++ b/src/pages/AllUserAssetsPage/AllUserAssetsPage.vue
@@ -7,7 +7,9 @@
           <Button variant="primary" class="mb-4">Add Asset</Button>
         </RouterLink>
       </div>
-      <p v-if="!allUserAssets.length" class="text-lg">No assets found.</p>
+      <p v-if="!isFetching && !allUserAssets.length" class="text-lg">
+        No assets found.
+      </p>
       <UserAssetsTable
         v-else
         :columns="columns"
@@ -25,7 +27,7 @@ import UserAssetsTable from "./UserAssetsTable.vue";
 import { useDeleteAssetMutation } from "@/queries/useDeleteAssetMutation";
 import { useErrorStore } from "@/stores/errorStore";
 
-const { data: allUserAssets } = useAllUserAssets();
+const { data: allUserAssets, isFetching } = useAllUserAssets();
 
 const { mutate: deleteAsset } = useDeleteAssetMutation();
 const errorStore = useErrorStore();


### PR DESCRIPTION
Fixes #469 

The All My Assets page was showing "No assets found." immediately on load, before the asset fetch had completed. Once the fetch returned, the message disappeared and the table rendered — creating a misleading flash.

`useAllUserAssets` sets `initialData: () => []`, so TanStack Query's `data` is an empty array from the start. The page was checking `!allUserAssets.length` without confirming the fetch had finished.

We use TSQuery's `isFetching` from `useAllUserAssets()` and add it as a guard on the empty-state condition.