### PR TITLE
fix(displayUtils): guard against empty upload widget entries from deleted file handlers

### DIFF
--- a/mock-server/routes/assets.ts
+++ b/mock-server/routes/assets.ts
@@ -19,6 +19,28 @@ app.get("/viewAsset/:assetId/true", async (c) => {
   return c.json(asset);
 });
 
+// DELETE /assetManager/deleteAsset/:assetId/true
+app.delete("/deleteAsset/:assetId/true", async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const assetId = c.req.param("assetId");
+
+  const asset = db.assets.get(assetId);
+  if (!asset) {
+    return c.json({ error: "Asset not found" }, 404);
+  }
+
+  // Soft delete: mark as deleted but keep the record (mirrors PHP backend behaviour)
+  db.assets.set(assetId, {
+    ...asset,
+    deleted: true,
+    deletedAt: new Date().toISOString(),
+    deletedBy: user?.id ?? null,
+  });
+
+  return c.body(null, 204);
+});
+
 // GET /asset/getAssetPreview/:assetId
 app.get("/getAssetPreview/:assetId", async (c) => {
   await delay(100);

--- a/mock-server/routes/assets.ts
+++ b/mock-server/routes/assets.ts
@@ -13,7 +13,7 @@ app.get("/viewAsset/:assetId/true", async (c) => {
   const db = c.get("db");
   const assetId = c.req.param("assetId");
   const asset = db.assets.get(assetId);
-  if (!asset) {
+  if (!asset || asset.deleted === true) {
     return c.json({ error: "Asset not found" }, 404);
   }
   return c.json(asset);

--- a/src/helpers/displayUtils.test.ts
+++ b/src/helpers/displayUtils.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { getWidgetContents } from "./displayUtils";
+import type { Asset, UploadWidgetDef, UploadWidgetContent } from "@/types";
+
+// Minimal asset/widget shape for testing getWidgetContents
+function makeAsset(uploadEntries: unknown[]): Partial<Asset> {
+  return { upload_1: uploadEntries } as Partial<Asset>;
+}
+
+const uploadWidget: UploadWidgetDef = {
+  widgetId: 1,
+  type: "upload",
+  fieldTitle: "upload_1",
+  label: "Photo",
+  tooltip: "",
+  fieldData: {},
+  allowMultiple: true,
+  attemptAutocomplete: false,
+  display: true,
+  displayInPreview: false,
+  required: false,
+  searchable: false,
+  directSearch: false,
+  clickToSearch: false,
+  clickToSearchType: 0,
+  viewOrder: 0,
+  templateOrder: 0,
+};
+
+const realEntry: UploadWidgetContent = {
+  fileId: "abc123",
+  fileDescription: "photo.jpg",
+  fileType: "jpg",
+  searchData: null,
+  loc: null,
+  sidecars: {},
+  isPrimary: true,
+};
+
+describe("getWidgetContents", () => {
+  it("returns null when the asset has no data for the widget field", () => {
+    const result = getWidgetContents({
+      asset: {} as Asset,
+      widget: uploadWidget,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns real entries unchanged", () => {
+    const asset = makeAsset([realEntry]) as Asset;
+    const result = getWidgetContents({ asset, widget: uploadWidget });
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({ fileId: "abc123" });
+  });
+
+  it("sorts primary entries first", () => {
+    const nonPrimary = { ...realEntry, isPrimary: false, fileId: "secondary" };
+    const primary = { ...realEntry, isPrimary: true, fileId: "primary" };
+    const asset = makeAsset([nonPrimary, primary]) as Asset;
+    const result = getWidgetContents({ asset, widget: uploadWidget });
+    expect(result?.[0].fileId).toBe("primary");
+    expect(result?.[1].fileId).toBe("secondary");
+  });
+
+  it("filters out empty {} entries produced by deleted file handlers", () => {
+    // The PHP backend returns empty objects when a file handler is deleted
+    // but the widget JSON hasn't been cleaned up:
+    //   "upload_1": [{real entry}, {}, {}, {}]
+    // These must not reach UploadWidget where fileId would be undefined,
+    // producing broken thumbnail requests to /tinyImageByFileId/undefined/.
+    const asset = makeAsset([realEntry, {}, {}, {}]) as Asset;
+    const result = getWidgetContents({ asset, widget: uploadWidget });
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({ fileId: "abc123" });
+  });
+
+  it("returns empty array (not null) when all entries are empty objects", () => {
+    const asset = makeAsset([{}, {}]) as Asset;
+    const result = getWidgetContents({ asset, widget: uploadWidget });
+    expect(result).toEqual([]);
+  });
+
+  it("filters out empty [] entries produced by deleted file handlers", () => {
+    // The backend can also serialise missing upload slots as empty arrays `[]`
+    // rather than empty objects `{}` — both should be treated the same.
+    const asset = makeAsset([realEntry, [], [], []]) as Asset;
+    const result = getWidgetContents({ asset, widget: uploadWidget });
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({ fileId: "abc123" });
+  });
+});

--- a/src/helpers/displayUtils.ts
+++ b/src/helpers/displayUtils.ts
@@ -40,6 +40,12 @@ export function getWidgetContents<
 
   if (!widgetContents) return null;
 
+  // The backend can return empty objects `{}` for upload entries whose file
+  // handlers were deleted. Filter them out before they reach widget components.
+  const populatedContents = widgetContents.filter(
+    (content) => Object.keys(content).length > 0
+  );
+
   // `partition(testFn, array)` will split a given array into two arrays
   // based on the test function that's passed in. If testFn is true
   // for an item, the item will be in the first array, otherwise the second
@@ -48,7 +54,7 @@ export function getWidgetContents<
   // see: https://ramdajs.com/docs/#partition
   const [primaryWidgetContents, nonPrimaryWidgetContents] = partition<U>(
     (content) => !!content.isPrimary,
-    widgetContents
+    populatedContents
   );
 
   return [...primaryWidgetContents, ...nonPrimaryWidgetContents];

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/toSaveableFormData.test.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/toSaveableFormData.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { toSaveableFormData } from "./toSaveableFormData";
+import type { Asset, Template, UploadWidgetDef, UploadWidgetContent } from "@/types";
+
+const uploadWidget: UploadWidgetDef = {
+  widgetId: 1,
+  type: "upload",
+  fieldTitle: "upload_1",
+  label: "Photo",
+  tooltip: "",
+  fieldData: {},
+  allowMultiple: true,
+  attemptAutocomplete: false,
+  display: true,
+  displayInPreview: false,
+  required: false,
+  searchable: false,
+  directSearch: false,
+  clickToSearch: false,
+  clickToSearchType: 0,
+  viewOrder: 0,
+  templateOrder: 0,
+};
+
+const template: Template = {
+  widgetArray: [uploadWidget],
+} as unknown as Template;
+
+const realEntry: UploadWidgetContent = {
+  fileId: "abc123",
+  fileDescription: "photo.jpg",
+  fileType: "jpg",
+  searchData: null,
+  loc: null,
+  sidecars: {},
+  isPrimary: true,
+};
+
+function makeAsset(uploadEntries: unknown[]): Asset {
+  return {
+    assetId: "asset-1",
+    templateId: 1,
+    collectionId: 1,
+    upload_1: uploadEntries,
+  } as unknown as Asset;
+}
+
+describe("toSaveableFormData — prepWidgetsForSave sanitisation", () => {
+  it("preserves real upload entries", () => {
+    const asset = makeAsset([realEntry]);
+    const result = toSaveableFormData(asset, template);
+    expect(result.upload_1).toHaveLength(1);
+    expect((result.upload_1 as unknown as UploadWidgetContent[])[0].fileId).toBe("abc123");
+  });
+
+  it("strips empty {} entries before save", () => {
+    // If corrupted data exists in local state, it should not be round-tripped
+    // back to the backend on the next save.
+    const asset = makeAsset([realEntry, {}, {}]);
+    const result = toSaveableFormData(asset, template);
+    expect(result.upload_1).toHaveLength(1);
+  });
+
+  it("strips empty [] entries before save", () => {
+    // The backend stores widget entries as JSON arrays. An empty upload slot
+    // can be serialised as `[]` rather than `{}` — both should be stripped.
+    const asset = makeAsset([realEntry, [], [], []]);
+    const result = toSaveableFormData(asset, template);
+    expect(result.upload_1).toHaveLength(1);
+  });
+
+  it("strips null entries before save", () => {
+    const asset = makeAsset([realEntry, null]);
+    const result = toSaveableFormData(asset, template);
+    expect(result.upload_1).toHaveLength(1);
+  });
+
+  it("returns empty array (not omitted) when all entries are empty", () => {
+    const asset = makeAsset([{}, {}]);
+    const result = toSaveableFormData(asset, template);
+    expect(result.upload_1).toEqual([]);
+  });
+
+  it("omits the field entirely when the widget value is not an array", () => {
+    // The backend could theoretically return a non-array for a widget field.
+    // We skip the field rather than crashing.
+    const asset = { ...makeAsset([]), upload_1: "unexpected" } as unknown as Asset;
+    const result = toSaveableFormData(asset, template);
+    expect(result).not.toHaveProperty("upload_1");
+  });
+});

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/toSaveableFormData.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/toSaveableFormData.ts
@@ -58,18 +58,23 @@ function prepWidgetsForSave(
       | WidgetContent[]
       | undefined;
 
-    if (!widgetContents) return acc;
+    if (!Array.isArray(widgetContents)) return acc;
 
-    const cleanedWidgetContents = widgetContents.map((content) => {
-      const contentWithoutId = omit(["id"], content);
-      if (
-        widgetDef.type === WIDGET_TYPES.TEXT_AREA &&
-        isTextAreaWidgetContent(contentWithoutId)
-      ) {
-        return cleanTextAreaWidgetContent(contentWithoutId);
-      }
-      return contentWithoutId;
-    });
+    // Filter out empty/null entries the backend may have stored (e.g. `{}`
+    // for upload fields whose file handlers were deleted). This prevents
+    // corrupted data from being round-tripped back on the next save.
+    const cleanedWidgetContents = widgetContents
+      .filter((content) => content != null && Object.keys(content).length > 0)
+      .map((content) => {
+        const contentWithoutId = omit(["id"], content);
+        if (
+          widgetDef.type === WIDGET_TYPES.TEXT_AREA &&
+          isTextAreaWidgetContent(contentWithoutId)
+        ) {
+          return cleanTextAreaWidgetContent(contentWithoutId);
+        }
+        return contentWithoutId;
+      });
 
     return {
       ...acc,

--- a/tests/e2e/delete-asset.spec.ts
+++ b/tests/e2e/delete-asset.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
+import mockServerConfig from "../../mock-server/config";
+
+const MOCK_SERVER_BASE = `${mockServerConfig.ORIGIN}:${mockServerConfig.PORT}`;
+
+// Asset 1 from seed data — has exactly 1 upload_1 entry with fileId "6875872f4eb080a4880a0f45"
+const KNOWN_ASSET_ID = "6875871d4eb080a4880a0f44";
+
+test.describe("Delete Asset", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+    await page.goto("/");
+  });
+
+  test("navigating to a deleted asset's URL returns 404, not the asset data", async ({
+    page,
+    request,
+  }) => {
+    const workerId = test.info().workerIndex.toString();
+
+    // Confirm the asset loads normally before deletion
+    const [beforeResponse] = await Promise.all([
+      page.waitForResponse((r) =>
+        r.url().includes(`/asset/viewAsset/${KNOWN_ASSET_ID}/true`)
+      ),
+      page.goto(`/asset/viewAsset/${KNOWN_ASSET_ID}`),
+    ]);
+    expect(beforeResponse.status()).toBe(200);
+
+    // Delete the asset
+    const deleteResponse = await request.delete(
+      `${MOCK_SERVER_BASE}/defaultinstance/assetManager/deleteAsset/${KNOWN_ASSET_ID}/true`,
+      { headers: { "x-worker-id": workerId } }
+    );
+    expect(deleteResponse.status()).toBe(204);
+
+    // Navigate to the deleted asset's URL and capture the viewAsset API response
+    const [afterResponse] = await Promise.all([
+      page.waitForResponse((r) =>
+        r.url().includes(`/asset/viewAsset/${KNOWN_ASSET_ID}/true`)
+      ),
+      page.goto(`/asset/viewAsset/${KNOWN_ASSET_ID}`),
+    ]);
+
+    // The backend should return 404 for a deleted asset, not 200
+    expect(afterResponse.status()).toBe(404);
+  });
+
+});


### PR DESCRIPTION
## Summary

When file handlers are deleted, the backend can leave empty `{}` objects in an asset's upload widget JSON which may appear as `[[],[],[],...]`. This PR filters them out before they are displayed in widget components and before they're re-submitted to the backend, which will clean-up the corrupted JSON when re-saved.

Resolves:
- #467 (front-end).

See also: 
- https://github.com/UMN-LATIS/elevator/pull/216
- https://github.com/UMN-LATIS/elevator/issues/218 (and forthcoming PR)

## The Problem

Any asset whose upload widget JSON contains empty objects — `[{}, {}, {}]` — would trigger broken thumbnail requests when viewed. `UploadWidget` builds thumbnail URLs from `content.fileId`; when `content` is `{}`, `fileId` is `undefined`, and every page load fires broken requests to:

```
/fileManager/tinyImageByFileId/undefined/true
```

**To Reproduce:**
See: `src/helpers/displayUtils.test.ts` > `"filters out empty {} entries produced by deleted file handlers"`

1. Obtain (or manufacture) an asset whose upload widget JSON contains empty entries: `[{}, {}, {}]`
2. Navigate to the asset's view URL (e.g. `/asset/viewAsset/{assetId}`)
3. Open the network tab and observe requests to `/tinyImageByFileId/undefined/true`

**Expected:** Upload widget renders real entries only; no requests with `undefined` in the path.

**Actual:** Broken thumbnail requests for every empty entry; possible JS errors.

## The Fix

**Cause**

The `{}` entries originate in the backend: when a save is processed and a referenced file handler no longer exists, `Upload_contents::getAsArray()` returns `[]` for that entry, which gets written back as an empty object. `getWidgetContents()` returned the raw array without validation — `UploadWidgetContent` types `fileId: string` as required, but that's a runtime contract the backend can violate. `prepWidgetsForSave()` then round-tripped the empty entries back on every save, keeping the corruption alive indefinitely.

Two filters added:

- **Display path** — `getWidgetContents()` now drops entries where `Object.keys(content).length === 0` before returning, so no empty entry ever reaches a widget component.
- **Save path** — `toSaveableFormData` applies the same filter (plus a `content != null` guard) before serializing. An asset with corrupted entries in the DB will self-heal on the user's next save.

## Notables

- **Mock server was missing the delete endpoint.** `DELETE /assetManager/deleteAsset/:assetId/true` didn't exist. Added with soft-delete behaviour to mirror the PHP backend. Also fixed `viewAsset` to return 404 for deleted assets — required by the Playwright e2e test.

- **`getWidgetContents` now returns `[]` instead of `null` when all entries are empty.** `assetHasWidgetContents` treats both as "no contents"; no other callers distinguish `null` from empty.

- **Companion to [`elevator` PR #216](https://github.com/UMN-LATIS/elevator/pull/216)**, which adds the backend 404 for deleted assets and closes the main corruption path.

- [`elevator` Issue #218](https://github.com/UMN-LATIS/elevator/issues/218) is also related. If the frontend save resurrects deleted assets, corruption could continue. (e.g. User Deletes asset, but has it open in another tab. Later user saves asset in other tab, asset is no longer deleted, but may not longer have valid upload data).