### PR TITLE
warn if navigate during upload

### DIFF
--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -166,19 +166,16 @@ let resolveLeaveGuard: ((allow: boolean) => void) | null = null;
 
 // Trigger the browser's native "Leave site?" dialog when the user tries to
 // close the tab, reload, or navigate to an external URL while an upload is running.
-// Known limitation: beforeunload does NOT fire for in-app (Vue Router) navigation —
-// that's intentional browser behaviour, not a bug. The onBeforeRouteLeave guard
-// below handles that case. Both guards are needed.
-// The dialog text is always browser-controlled; we can only trigger it, not style it.
-// onCleanup (not onUnmounted) is used because the listener must be removed
-// as soon as uploads finish — not just when the component is destroyed. watchEffect
-// calls the cleanup before each re-run and on unmount, covering both cases.
 watchEffect((onCleanup) => {
   if (!uploadStore.hasActiveUploads) return;
   const handler = (e: BeforeUnloadEvent) => {
     e.preventDefault();
   };
   window.addEventListener("beforeunload", handler);
+
+  // onCleanup (not onUnmounted) is used because the listener must be removed
+  // as soon as uploads finish — not just when the component is destroyed.
+  // watchEffect calls the cleanup before each re-run and on unmount, covering both cases.
   onCleanup(() => window.removeEventListener("beforeunload", handler));
 });
 

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -165,7 +165,14 @@ const isLeaveConfirmOpen = ref(false);
 let resolveLeaveGuard: ((allow: boolean) => void) | null = null;
 
 // Trigger the browser's native "Leave site?" dialog when the user tries to
-// close the tab or navigate to a different origin while an upload is running.
+// close the tab, reload, or navigate to an external URL while an upload is running.
+// Known limitation: beforeunload does NOT fire for in-app (Vue Router) navigation —
+// that's intentional browser behaviour, not a bug. The onBeforeRouteLeave guard
+// below handles that case. Both guards are needed.
+// The dialog text is always browser-controlled; we can only trigger it, not style it.
+// onCleanup (not onUnmounted) is used because the listener must be removed
+// as soon as uploads finish — not just when the component is destroyed. watchEffect
+// calls the cleanup before each re-run and on unmount, covering both cases.
 watchEffect((onCleanup) => {
   if (!uploadStore.hasActiveUploads) return;
   const handler = (e: BeforeUnloadEvent) => {

--- a/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
+++ b/src/pages/CreateOrEditAssetPage/CreateOrEditAssetPage.vue
@@ -101,17 +101,27 @@
           </p>
         </div>
       </ConfirmModal>
+      <ConfirmModal
+        type="warning"
+        :isOpen="isLeaveConfirmOpen"
+        title="Upload in progress"
+        confirmLabel="Leave"
+        cancelLabel="Stay"
+        @confirm="handleLeaveConfirm"
+        @close="handleLeaveCancel">
+        Navigating away will cancel your upload. Are you sure you want to leave?
+      </ConfirmModal>
     </Teleport>
   </DefaultLayout>
 </template>
 <script setup lang="ts">
-import { computed, nextTick, onMounted, provide, reactive, watch } from "vue";
+import { computed, nextTick, onMounted, provide, reactive, ref, watch, watchEffect } from "vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import EditAssetForm from "@/pages/CreateOrEditAssetPage/EditAssetForm/EditAssetForm.vue";
 import { RelatedAssetSaveMessage, TemplateComparison } from "@/types";
 import Button from "@/components/Button/Button.vue";
 import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
-import { onBeforeRouteUpdate, useRoute, useRouter } from "vue-router";
+import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from "vue-router";
 import { SAVE_RELATED_ASSET_TYPE } from "@/constants/constants";
 import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import SpinnerIcon from "@/icons/SpinnerIcon.vue";
@@ -121,6 +131,7 @@ import { fetchTemplateComparison } from "@/api/fetchers";
 import { isEmpty } from "ramda";
 import { ASSET_EDITOR_PROVIDE_KEY } from "@/constants/constants";
 import { useToastStore } from "@/stores/toastStore";
+import { useUploadStore } from "@/stores/uploadStore";
 import { useAssetValidationProvider } from "./useAssetEditor/useAssetValidation";
 import { usePageAssetIdProvider } from "@/composables/usePageAssetId";
 
@@ -145,6 +156,45 @@ useAssetValidationProvider(
 );
 
 const toastStore = useToastStore();
+const uploadStore = useUploadStore();
+
+// --- Upload navigation guard ---
+
+const isLeaveConfirmOpen = ref(false);
+// Holds the resolve function for the pending onBeforeRouteLeave promise.
+let resolveLeaveGuard: ((allow: boolean) => void) | null = null;
+
+// Trigger the browser's native "Leave site?" dialog when the user tries to
+// close the tab or navigate to a different origin while an upload is running.
+watchEffect((onCleanup) => {
+  if (!uploadStore.hasActiveUploads) return;
+  const handler = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+  };
+  window.addEventListener("beforeunload", handler);
+  onCleanup(() => window.removeEventListener("beforeunload", handler));
+});
+
+// Show our custom ConfirmModal for in-app (Vue Router) navigation.
+onBeforeRouteLeave(async () => {
+  if (!uploadStore.hasActiveUploads) return true;
+  isLeaveConfirmOpen.value = true;
+  return new Promise<boolean>((resolve) => {
+    resolveLeaveGuard = resolve;
+  });
+});
+
+function handleLeaveConfirm() {
+  isLeaveConfirmOpen.value = false;
+  resolveLeaveGuard?.(true);
+  resolveLeaveGuard = null;
+}
+
+function handleLeaveCancel() {
+  isLeaveConfirmOpen.value = false;
+  resolveLeaveGuard?.(false);
+  resolveLeaveGuard = null;
+}
 
 watch(
   () => props.assetId,

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -25,7 +25,8 @@ import "@uppy/progress-bar/dist/style.min.css";
 import config from "@/config";
 import api from "@/api";
 import { pluralize } from "@/helpers/pluralize";
-import { computed } from "vue";
+import { computed, onBeforeUnmount } from "vue";
+import { useUploadStore } from "@/stores/uploadStore";
 
 const props = defineProps<{
   collectionId: number;
@@ -38,10 +39,12 @@ const emit = defineEmits<{
   (e: "error", error: Error): void;
 }>();
 
-const filenameToObjectIdMap = new Map<
-  string, // filename
-  Type.FileUploadRecord
->();
+const uploadStore = useUploadStore();
+
+// Local index: filename → uploadId. Used for O(1) lookups within Uppy's callbacks
+// (signPart, completeMultipartUpload, abortMultipartUpload all identify files by name).
+// Also serves as the cleanup list when this component unmounts mid-upload.
+const filenameToUploadId = new Map<string, string>();
 
 const note = computed(() => {
   if (props.maxNumberOfFiles) {
@@ -106,14 +109,12 @@ const uppy = new Uppy({
       uploadStatus: "in-progress",
     };
 
-    filenameToObjectIdMap.set(file.name, fileRecord);
+    filenameToUploadId.set(file.name, uploadId);
+    uploadStore.register(fileRecord);
 
     emit("start", fileRecord);
 
-    return {
-      uploadId,
-      key,
-    };
+    return { uploadId, key };
   },
   async signPart(
     file,
@@ -126,20 +127,28 @@ const uppy = new Uppy({
       throw new Error("File name is required to sign a part.");
     }
 
-    const fileRecord = filenameToObjectIdMap.get(file.name);
+    const uploadId = filenameToUploadId.get(file.name);
 
-    if (!fileRecord) {
+    if (!uploadId) {
       throw new Error(
-        `No file record found for file: ${file.name}. Please ensure the file upload has been started.`
+        `No upload record found for file: ${file.name}. Please ensure the file upload has been started.`
+      );
+    }
+
+    const record = uploadStore.uploads[uploadId];
+
+    if (!record) {
+      throw new Error(
+        `Upload record missing from store for uploadId: ${uploadId}.`
       );
     }
 
     const { url } = await api.signS3UploadPart({
       collectionId: props.collectionId,
-      fileObjectId: fileRecord.fileObjectId,
-      uploadId: fileRecord.uploadId,
+      fileObjectId: record.fileObjectId,
+      uploadId: record.uploadId,
       partNumber: partData.partNumber,
-      contentType: fileRecord.contentType,
+      contentType: record.contentType,
     });
 
     return { url };
@@ -152,34 +161,49 @@ const uppy = new Uppy({
       throw new Error("File name is required to complete a multipart upload.");
     }
 
-    const fileRecord = filenameToObjectIdMap.get(file.name);
+    const uploadId = filenameToUploadId.get(file.name);
 
-    if (!fileRecord) {
+    if (!uploadId) {
       throw new Error(
-        `No file record found for file: ${file.name}. Please ensure the file upload has been started.`
+        `No upload record found for file: ${file.name}. Please ensure the file upload has been started.`
       );
     }
 
-    const { location } = await api.completeS3MultipartUpload({
-      collectionId: props.collectionId,
-      fileObjectId: fileRecord.fileObjectId,
-      uploadId: fileRecord.uploadId,
-      contentType: fileRecord.contentType,
-    });
+    const record = uploadStore.uploads[uploadId];
 
-    // notify elevator backend that the upload is complete
-    await api.completeSourceFile(fileRecord.fileObjectId);
+    if (!record) {
+      throw new Error(
+        `Upload record missing from store for uploadId: ${uploadId}.`
+      );
+    }
 
-    const updatedFileRecord: Type.FileUploadRecord = {
-      ...fileRecord,
-      uploadStatus: "completed",
-      location, // store the S3 URL of the uploaded file
-    };
-    // update the file record status
-    filenameToObjectIdMap.set(file.name, updatedFileRecord);
+    // Remove from store in a finally block so the active count is corrected
+    // even if the completion API calls fail. abortMultipartUpload uses the same
+    // filenameToUploadId guard so there's no risk of double-removal.
+    let location: string | undefined;
+    try {
+      ({ location } = await api.completeS3MultipartUpload({
+        collectionId: props.collectionId,
+        fileObjectId: record.fileObjectId,
+        uploadId: record.uploadId,
+        contentType: record.contentType,
+      }));
 
-    // emit the complete event with the updated file record
-    emit("complete", updatedFileRecord);
+      // notify elevator backend that the upload is complete
+      await api.completeSourceFile(record.fileObjectId);
+
+      const completedRecord: Type.FileUploadRecord = {
+        ...record,
+        uploadStatus: "completed",
+        location,
+      };
+
+      // emit the complete event with the updated file record
+      emit("complete", completedRecord);
+    } finally {
+      filenameToUploadId.delete(file.name);
+      uploadStore.remove(uploadId);
+    }
 
     return { location };
   },
@@ -189,23 +213,31 @@ const uppy = new Uppy({
       throw new Error("File name is required to abort a multipart upload.");
     }
 
-    const fileRecord = filenameToObjectIdMap.get(file.name);
+    const uploadId = filenameToUploadId.get(file.name);
 
-    if (!fileRecord) {
+    if (!uploadId) {
       throw new Error(
-        `No file record found for file: ${file.name}. Please ensure the file upload has been started.`
+        `No upload record found for file: ${file.name}. Please ensure the file upload has been started.`
+      );
+    }
+
+    const record = uploadStore.uploads[uploadId];
+
+    if (!record) {
+      throw new Error(
+        `Upload record missing from store for uploadId: ${uploadId}.`
       );
     }
 
     await api.abortS3MultipartUpload({
       collectionId: props.collectionId,
-      fileObjectId: fileRecord.fileObjectId,
-      uploadId: fileRecord.uploadId,
-      contentType: fileRecord.contentType,
+      fileObjectId: record.fileObjectId,
+      uploadId: record.uploadId,
+      contentType: record.contentType,
     });
 
-    // remove the file record from the map
-    filenameToObjectIdMap.delete(file.name);
+    filenameToUploadId.delete(file.name);
+    uploadStore.remove(uploadId);
   },
 });
 
@@ -218,6 +250,13 @@ uppy.on("error", (error) => {
   // todo handle error
   console.error("Uppy error:", error);
   emit("error", error);
+});
+
+// If the component is destroyed while uploads are in flight (e.g. user confirmed
+// leaving in the navigation dialog), remove any orphaned records from the store.
+onBeforeUnmount(() => {
+  filenameToUploadId.forEach((uploadId) => uploadStore.remove(uploadId));
+  filenameToUploadId.clear();
 });
 </script>
 

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -41,9 +41,7 @@ const emit = defineEmits<{
 
 const uploadStore = useUploadStore();
 
-// Local index: filename → uploadId. Used for O(1) lookups within Uppy's callbacks
-// (signPart, completeMultipartUpload, abortMultipartUpload all identify files by name).
-// Also serves as the cleanup list when this component unmounts mid-upload.
+// Local index: filename → uploadId.
 const filenameToUploadId = new Map<string, string>();
 
 const note = computed(() => {
@@ -177,9 +175,6 @@ const uppy = new Uppy({
       );
     }
 
-    // Remove from store in a finally block so the active count is corrected
-    // even if the completion API calls fail. abortMultipartUpload uses the same
-    // filenameToUploadId guard so there's no risk of double-removal.
     let location: string | undefined;
     try {
       ({ location } = await api.completeS3MultipartUpload({

--- a/src/stores/uploadStore.test.ts
+++ b/src/stores/uploadStore.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useUploadStore } from "./uploadStore";
+import type { FileUploadRecord } from "@/types";
+
+function makeRecord(overrides: Partial<FileUploadRecord> = {}): FileUploadRecord {
+  return {
+    filename: "test.mp4",
+    fileObjectId: "obj-1",
+    contentType: "video/mp4",
+    uploadId: "upload-1",
+    key: "path/to/test.mp4",
+    uploadStatus: "in-progress",
+    ...overrides,
+  };
+}
+
+describe("uploadStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe("hasActiveUploads", () => {
+    it("is false when the store is empty", () => {
+      const store = useUploadStore();
+      expect(store.hasActiveUploads).toBe(false);
+    });
+
+    it("is true when there is an in-progress upload", () => {
+      const store = useUploadStore();
+      store.register(makeRecord());
+      expect(store.hasActiveUploads).toBe(true);
+    });
+
+    it("is false when all uploads are completed", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1", uploadStatus: "in-progress" }));
+      store.complete("u1");
+      expect(store.hasActiveUploads).toBe(false);
+    });
+
+    it("is false when all uploads are failed", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1", uploadStatus: "in-progress" }));
+      store.fail("u1");
+      expect(store.hasActiveUploads).toBe(false);
+    });
+
+    it("stays true while at least one upload remains in progress", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1", filename: "a.mp4" }));
+      store.register(makeRecord({ uploadId: "u2", filename: "b.mp4" }));
+      store.complete("u1");
+      expect(store.hasActiveUploads).toBe(true);
+    });
+  });
+
+  describe("activeUploads", () => {
+    it("returns only in-progress records", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1", filename: "a.mp4" }));
+      store.register(makeRecord({ uploadId: "u2", filename: "b.mp4" }));
+      store.complete("u2");
+      expect(store.activeUploads).toHaveLength(1);
+      expect(store.activeUploads[0].uploadId).toBe("u1");
+    });
+  });
+
+  describe("register", () => {
+    it("adds the record keyed by uploadId", () => {
+      const store = useUploadStore();
+      const record = makeRecord();
+      store.register(record);
+      expect(store.uploads["upload-1"]).toEqual(record);
+    });
+  });
+
+  describe("complete", () => {
+    it("sets uploadStatus to completed", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1" }));
+      store.complete("u1");
+      expect(store.uploads["u1"].uploadStatus).toBe("completed");
+    });
+
+    it("sets location when provided", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1" }));
+      store.complete("u1", "https://s3.example.com/path/to/file.mp4");
+      expect(store.uploads["u1"].location).toBe("https://s3.example.com/path/to/file.mp4");
+    });
+
+    it("is a no-op for unknown uploadIds", () => {
+      const store = useUploadStore();
+      expect(() => store.complete("nonexistent")).not.toThrow();
+    });
+  });
+
+  describe("fail", () => {
+    it("sets uploadStatus to failed", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1" }));
+      store.fail("u1");
+      expect(store.uploads["u1"].uploadStatus).toBe("failed");
+    });
+
+    it("is a no-op for unknown uploadIds", () => {
+      const store = useUploadStore();
+      expect(() => store.fail("nonexistent")).not.toThrow();
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes the record from uploads", () => {
+      const store = useUploadStore();
+      store.register(makeRecord({ uploadId: "u1" }));
+      store.remove("u1");
+      expect(store.uploads["u1"]).toBeUndefined();
+      expect(store.hasActiveUploads).toBe(false);
+    });
+
+    it("is a no-op for unknown uploadIds", () => {
+      const store = useUploadStore();
+      expect(() => store.remove("nonexistent")).not.toThrow();
+    });
+  });
+});

--- a/src/stores/uploadStore.ts
+++ b/src/stores/uploadStore.ts
@@ -1,0 +1,31 @@
+import { defineStore } from "pinia";
+import type { FileUploadRecord } from "@/types";
+
+export const useUploadStore = defineStore("uploadStore", {
+  state: () => ({
+    // Keyed by uploadId. Plain object (not Map) for Pinia reactivity compatibility.
+    uploads: {} as Record<string, FileUploadRecord>,
+  }),
+  getters: {
+    hasActiveUploads: (state) =>
+      Object.values(state.uploads).some((r) => r.uploadStatus === "in-progress"),
+    activeUploads: (state) =>
+      Object.values(state.uploads).filter((r) => r.uploadStatus === "in-progress"),
+  },
+  actions: {
+    register(record: FileUploadRecord) {
+      this.uploads[record.uploadId] = record;
+    },
+    complete(uploadId: string, location?: string) {
+      const record = this.uploads[uploadId];
+      if (record) this.uploads[uploadId] = { ...record, uploadStatus: "completed", location };
+    },
+    fail(uploadId: string) {
+      const record = this.uploads[uploadId];
+      if (record) this.uploads[uploadId] = { ...record, uploadStatus: "failed" };
+    },
+    remove(uploadId: string) {
+      delete this.uploads[uploadId];
+    },
+  },
+});

--- a/src/stores/uploadStore.ts
+++ b/src/stores/uploadStore.ts
@@ -3,14 +3,18 @@ import type { FileUploadRecord } from "@/types";
 
 export const useUploadStore = defineStore("uploadStore", {
   state: () => ({
-    // Keyed by uploadId. Plain object (not Map) for Pinia reactivity compatibility.
+    // Keyed by uploadId
     uploads: {} as Record<string, FileUploadRecord>,
   }),
   getters: {
     hasActiveUploads: (state) =>
-      Object.values(state.uploads).some((r) => r.uploadStatus === "in-progress"),
+      Object.values(state.uploads).some(
+        (r) => r.uploadStatus === "in-progress"
+      ),
     activeUploads: (state) =>
-      Object.values(state.uploads).filter((r) => r.uploadStatus === "in-progress"),
+      Object.values(state.uploads).filter(
+        (r) => r.uploadStatus === "in-progress"
+      ),
   },
   actions: {
     register(record: FileUploadRecord) {
@@ -18,11 +22,17 @@ export const useUploadStore = defineStore("uploadStore", {
     },
     complete(uploadId: string, location?: string) {
       const record = this.uploads[uploadId];
-      if (record) this.uploads[uploadId] = { ...record, uploadStatus: "completed", location };
+      if (record)
+        this.uploads[uploadId] = {
+          ...record,
+          uploadStatus: "completed",
+          location,
+        };
     },
     fail(uploadId: string) {
       const record = this.uploads[uploadId];
-      if (record) this.uploads[uploadId] = { ...record, uploadStatus: "failed" };
+      if (record)
+        this.uploads[uploadId] = { ...record, uploadStatus: "failed" };
     },
     remove(uploadId: string) {
       delete this.uploads[uploadId];

--- a/tests/e2e/upload-navigation-guard.spec.ts
+++ b/tests/e2e/upload-navigation-guard.spec.ts
@@ -6,28 +6,49 @@ import path from "path";
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const fixtureFile = path.join(testDir, "..", "fixtures", "test-image.jpg");
 
-// Pause the multipart complete endpoint so the upload stays in-progress
-// indefinitely. Returns a promise that resolves once the upload has reached
-// that endpoint — i.e. the upload is genuinely registered in the store.
-async function pauseUploadAtComplete(page: Page) {
-  await page.route("**/s3/multipart/*/complete", async (route) => {
-    await new Promise((r) => setTimeout(r, 30_000));
+// Long enough to interact with the modal, short enough to keep tests fast.
+const DEFAULT_UPLOAD_DELAY_MS = 8_000;
+
+/**
+ * Pick a file and start uploading it, but delay the S3 part PUT so the upload
+ * stays in-flight long enough to test navigation guards. Resolves once the
+ * part request has fired (hasActiveUploads is guaranteed true at that point).
+ */
+async function startUploadAndWaitUntilInFlight(
+  page: Page,
+  delayMs = DEFAULT_UPLOAD_DELAY_MS,
+) {
+  await page.route("**/s3/upload-part/**", async (route) => {
+    await new Promise((r) => setTimeout(r, delayMs));
     await route.continue();
   });
-  return page.waitForRequest("**/s3/multipart/*/complete");
-}
 
-async function startUpload(page: Page) {
-  const widget = page.locator("section.edit-widget-layout").first();
+  // Wait for the upload to start before proceeding with the test.
+  const inProgress = page.waitForRequest("**/s3/upload-part/**");
+
+  // Filter to the top-level "Upload" widget (not any nested one).
+  const widget = page
+    .locator("section.edit-widget-layout")
+    .filter({ has: page.getByRole("heading", { name: "Upload" }) })
+    .first();
+
+  // Scroll the widget into view so the button is interactable
   await widget.scrollIntoViewIfNeeded();
+
+  // start the upload by picking a file
   const chooserPromise = page.waitForEvent("filechooser");
   await widget.getByRole("button", { name: "browse files" }).click();
   const chooser = await chooserPromise;
   await chooser.setFiles(fixtureFile);
+
+  // Wait until the upload has officially started
+  // that is, when the S3 part request has fired and is in-flight
+  // Then we can test what happens when an upload is active
+  await inProgress;
 }
 
-// Trigger SPA navigation by clicking the app logo (a RouterLink to "/").
-// This fires onBeforeRouteLeave without causing a full page reload.
+// Trigger SPA navigation via the logo RouterLink (fires onBeforeRouteLeave,
+// not a full page reload).
 async function navigateHome(page: Page) {
   await page.locator(".app-header__logo-link").click();
 }
@@ -60,10 +81,13 @@ test.describe("Upload navigation guard", () => {
   }) => {
     test.setTimeout(30_000);
 
-    const inProgress = pauseUploadAtComplete(page);
-    await startUpload(page);
-    await inProgress;
+    // Log all requests to understand timing
+    const requests: string[] = [];
+    page.on("request", (req) => requests.push(`${req.method()} ${req.url()}`));
 
+    await startUploadAndWaitUntilInFlight(page);
+
+    // try to navigate away while upload is in-flight
     await navigateHome(page);
 
     await expect(
@@ -74,11 +98,12 @@ test.describe("Upload navigation guard", () => {
   test("stays on page when user clicks Stay", async ({ page }) => {
     test.setTimeout(30_000);
 
-    const inProgress = pauseUploadAtComplete(page);
-    await startUpload(page);
-    await inProgress;
+    await startUploadAndWaitUntilInFlight(page);
 
+    // try to navigate away while upload is in-flight
     await navigateHome(page);
+
+    // Click "Stay" to cancel navigation and keep uploading
     await page.getByRole("button", { name: "Stay" }).click();
 
     await expect(
@@ -90,26 +115,26 @@ test.describe("Upload navigation guard", () => {
   test("allows navigation when user clicks Leave", async ({ page }) => {
     test.setTimeout(30_000);
 
-    const inProgress = pauseUploadAtComplete(page);
-    await startUpload(page);
-    await inProgress;
+    await startUploadAndWaitUntilInFlight(page);
 
+    // try to navigate away, and click leave
     await navigateHome(page);
     await page.getByRole("button", { name: "Leave" }).click();
 
     await expect(page).not.toHaveURL(/\/assetManager\/addAsset/);
   });
 
-  test("no modal when navigating without an active upload", async ({
-    page,
-  }) => {
-    // Navigate home without starting any upload
+  test("no modal after upload has completed", async ({ page }) => {
+    test.setTimeout(30_000);
+
+    await startUploadAndWaitUntilInFlight(page, 500);
+
+    // Wait for the upload to fully complete (part finishes → completeMultipartUpload).
+    await page.waitForResponse("**/s3/multipart/*/complete");
+
     await navigateHome(page);
 
-    // Should navigate immediately — no modal
-    await expect(
-      page.getByText("Upload in progress")
-    ).not.toBeVisible();
+    await expect(page.getByText("Upload in progress")).not.toBeVisible();
     await expect(page).not.toHaveURL(/\/assetManager\/addAsset/);
   });
 
@@ -118,20 +143,17 @@ test.describe("Upload navigation guard", () => {
   }) => {
     test.setTimeout(30_000);
 
-    const inProgress = pauseUploadAtComplete(page);
-    await startUpload(page);
-    await inProgress;
+    await startUploadAndWaitUntilInFlight(page);
 
     const dialogPromise = page.waitForEvent("dialog");
-    // Reload is a browser-level navigation, triggering beforeunload rather than
-    // onBeforeRouteLeave. We fire it without awaiting so the dialog can surface.
+    // Reload is browser-level navigation — triggers beforeunload, not onBeforeRouteLeave.
+    // Don't await: the dialog must be handled before reload can proceed.
     page.reload().catch(() => {});
 
     const dialog = await dialogPromise;
     expect(dialog.type()).toBe("beforeunload");
     await dialog.dismiss();
 
-    // User dismissed — still on the upload page
     await expect(page).toHaveURL(/\/assetManager\/addAsset/);
   });
 });

--- a/tests/e2e/upload-navigation-guard.spec.ts
+++ b/tests/e2e/upload-navigation-guard.spec.ts
@@ -127,15 +127,21 @@ test.describe("Upload navigation guard", () => {
   test("no modal after upload has completed", async ({ page }) => {
     test.setTimeout(30_000);
 
-    await startUploadAndWaitUntilInFlight(page, 500);
+    // Save the asset first so we're on the edit page (no create-and-redirect).
+    await page.getByLabel(/title/i).first().fill("Upload Guard Test");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page).toHaveURL(/\/assetManager\/editAsset\//);
 
-    // Wait for the upload to fully complete (part finishes → completeMultipartUpload).
-    await page.waitForResponse("**/s3/multipart/*/complete");
+    // uploadStore.remove() runs after completeSourceFile — wait for that response
+    // so the store is clean before we attempt navigation.
+    const uploadCleanedUp = page.waitForResponse("**/completeSourceFile/**");
+    await startUploadAndWaitUntilInFlight(page, 500);
+    await uploadCleanedUp;
 
     await navigateHome(page);
 
     await expect(page.getByText("Upload in progress")).not.toBeVisible();
-    await expect(page).not.toHaveURL(/\/assetManager\/addAsset/);
+    await expect(page).not.toHaveURL(/\/assetManager\/editAsset/);
   });
 
   test("triggers browser native dialog when reloading during upload", async ({

--- a/tests/e2e/upload-navigation-guard.spec.ts
+++ b/tests/e2e/upload-navigation-guard.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type Page } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const fixtureFile = path.join(testDir, "..", "fixtures", "test-image.jpg");
+
+// Pause the multipart complete endpoint so the upload stays in-progress
+// indefinitely. Returns a promise that resolves once the upload has reached
+// that endpoint — i.e. the upload is genuinely registered in the store.
+async function pauseUploadAtComplete(page: Page) {
+  await page.route("**/s3/multipart/*/complete", async (route) => {
+    await new Promise((r) => setTimeout(r, 30_000));
+    await route.continue();
+  });
+  return page.waitForRequest("**/s3/multipart/*/complete");
+}
+
+async function startUpload(page: Page) {
+  const widget = page.locator("section.edit-widget-layout").first();
+  await widget.scrollIntoViewIfNeeded();
+  const chooserPromise = page.waitForEvent("filechooser");
+  await widget.getByRole("button", { name: "browse files" }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(fixtureFile);
+}
+
+// Trigger SPA navigation by clicking the app logo (a RouterLink to "/").
+// This fires onBeforeRouteLeave without causing a full page reload.
+async function navigateHome(page: Page) {
+  await page.locator(".app-header__logo-link").click();
+}
+
+test.describe("Upload navigation guard", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.route("**/arcgis.com/**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+    );
+    await page.route("**/basemaps-api.arcgis.com/**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+    );
+
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+
+    await page.goto("/assetManager/addAsset");
+    await page.getByLabel("Template").selectOption({ index: 1 });
+    await page.getByLabel("Collection").selectOption({ index: 1 });
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Create Asset" })
+    ).toBeVisible();
+  });
+
+  test("shows confirm modal when navigating in-app during upload", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+
+    const inProgress = pauseUploadAtComplete(page);
+    await startUpload(page);
+    await inProgress;
+
+    await navigateHome(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Upload in progress" })
+    ).toBeVisible();
+  });
+
+  test("stays on page when user clicks Stay", async ({ page }) => {
+    test.setTimeout(30_000);
+
+    const inProgress = pauseUploadAtComplete(page);
+    await startUpload(page);
+    await inProgress;
+
+    await navigateHome(page);
+    await page.getByRole("button", { name: "Stay" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Upload in progress" })
+    ).not.toBeVisible();
+    await expect(page).toHaveURL(/\/assetManager\/addAsset/);
+  });
+
+  test("allows navigation when user clicks Leave", async ({ page }) => {
+    test.setTimeout(30_000);
+
+    const inProgress = pauseUploadAtComplete(page);
+    await startUpload(page);
+    await inProgress;
+
+    await navigateHome(page);
+    await page.getByRole("button", { name: "Leave" }).click();
+
+    await expect(page).not.toHaveURL(/\/assetManager\/addAsset/);
+  });
+
+  test("no modal when navigating without an active upload", async ({
+    page,
+  }) => {
+    // Navigate home without starting any upload
+    await navigateHome(page);
+
+    // Should navigate immediately — no modal
+    await expect(
+      page.getByText("Upload in progress")
+    ).not.toBeVisible();
+    await expect(page).not.toHaveURL(/\/assetManager\/addAsset/);
+  });
+
+  test("triggers browser native dialog when reloading during upload", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+
+    const inProgress = pauseUploadAtComplete(page);
+    await startUpload(page);
+    await inProgress;
+
+    const dialogPromise = page.waitForEvent("dialog");
+    // Reload is a browser-level navigation, triggering beforeunload rather than
+    // onBeforeRouteLeave. We fire it without awaiting so the dialog can surface.
+    page.reload().catch(() => {});
+
+    const dialog = await dialogPromise;
+    expect(dialog.type()).toBe("beforeunload");
+    await dialog.dismiss();
+
+    // User dismissed — still on the upload page
+    await expect(page).toHaveURL(/\/assetManager\/addAsset/);
+  });
+});


### PR DESCRIPTION

<img width="500" alt="ScreenShot 2026-03-17 at 13 16 33@2x" src="https://github.com/user-attachments/assets/e6018757-2734-49a9-8af2-27a45f15a5be" />

Warns user if they attempt to navigate away during upload.

- Adds a Pinia store (`uploadStore`) to track active multipart uploads by `uploadId`
- `FileUploader.vue` registers/removes uploads in the store on start/end
- `CreateOrEditAssetPage.vue` installs two guards: a `beforeunload` listener for browser-level navigation and an `onBeforeRouteLeave` guard that presents the app's `ConfirmModal`
- Closes #465
