### PR TITLE
fix uppy to work with dark themes

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -8,6 +8,7 @@
         width: '100%',
         proudlyDisplayPoweredByUppy: false,
         note,
+        theme: uppyTheme,
       }" />
   </div>
 </template>
@@ -27,6 +28,7 @@ import api from "@/api";
 import { pluralize } from "@/helpers/pluralize";
 import { computed, onBeforeUnmount } from "vue";
 import { useUploadStore } from "@/stores/uploadStore";
+import { useTheming } from "@/helpers/useTheming";
 
 const props = defineProps<{
   collectionId: number;
@@ -40,6 +42,23 @@ const emit = defineEmits<{
 }>();
 
 const uploadStore = useUploadStore();
+
+const { activeTheme } = useTheming();
+
+// Themes with dark backgrounds (surface lightness < 30%) need Uppy's dark color scheme.
+const DARK_THEMES = new Set([
+  "construction",
+  "dark",
+  "hotrod",
+  "matrix",
+  "nord-dark",
+  "tron",
+  "vaporwave",
+]);
+
+const uppyTheme = computed<"dark" | "light">(() =>
+  DARK_THEMES.has(activeTheme.value ?? "") ? "dark" : "light"
+);
 
 // Local index: filename → uploadId.
 const filenameToUploadId = new Map<string, string>();

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -45,7 +45,7 @@ const uploadStore = useUploadStore();
 
 const { activeTheme } = useTheming();
 
-// Themes with dark backgrounds (surface lightness < 30%) need Uppy's dark color scheme.
+// Explicit list of themes that should use Uppy's dark color scheme.
 const DARK_THEMES = new Set([
   "construction",
   "dark",


### PR DESCRIPTION
<img width="700" alt="ScreenShot 2026-03-17 at 15 32 39@2x" src="https://github.com/user-attachments/assets/0d5a543b-3807-455b-83c4-4c727056d025" />

Resolves #477 