### PR TITLE
add graceful handling when search totalResults and matches mismatch; prevent negative skeleton cards

### DIFF
--- a/mock-server/db/searches.ts
+++ b/mock-server/db/searches.ts
@@ -48,7 +48,10 @@ export function createSearchesTable({
   return {
     ...baseTable,
     // Table-specific methods
-    create: (query: string): SearchResultsResponse => {
+    create: (
+      query: string,
+      { totalResultsOverride }: { totalResultsOverride?: number } = {}
+    ): SearchResultsResponse => {
       const searchId = crypto.randomUUID();
 
       // find any matches in the assets
@@ -83,10 +86,12 @@ export function createSearchesTable({
           "Modified Date (oldest to newest)" as const,
       };
 
+      const totalResults = totalResultsOverride ?? matchedAssets.length;
+
       // Store complete results for pagination
       completeSearchResults.set(searchId, {
         allMatches: allSearchMatches,
-        totalResults: matchedAssets.length,
+        totalResults,
         searchEntry,
         sortableWidgets,
       });
@@ -97,7 +102,7 @@ export function createSearchesTable({
       const newSearch: SearchResultsResponse = {
         searchId,
         matches: paginatedMatches,
-        totalResults: matchedAssets.length,
+        totalResults,
         searchResults: paginatedMatches.map((match) => match.objectId),
         searchEntry,
         sortableWidgets,

--- a/mock-server/db/searches.ts
+++ b/mock-server/db/searches.ts
@@ -86,6 +86,7 @@ export function createSearchesTable({
           "Modified Date (oldest to newest)" as const,
       };
 
+      // permit override for testing when there's a mismatch between the number of matched assets and the expected total results (e.g. when testing pagination)
       const totalResults = totalResultsOverride ?? matchedAssets.length;
 
       // Store complete results for pagination

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -153,6 +153,13 @@ app.get("/_tests/db/assets/count", (c) => {
   return c.json({ count: db.assets.size() });
 });
 
+app.post("/_tests/search/create", async (c) => {
+  const db = c.get("db");
+  const { query = "", totalResultsOverride } = await c.req.json();
+  const results = db.searches.create(query, { totalResultsOverride });
+  return c.json(results);
+});
+
 // Endpoint that delays response to test timeout behavior
 app.get("/_tests/slow-image.jpg", async (c) => {
   // Delay for 15 seconds (longer than the 10-second timeout in onAllImagesLoaded)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -37,6 +37,9 @@ function createCache() {
     moreLikeThisMatches: new Map<string, SearchResultMatch[]>(),
     fileMetaData: new Map<string, FileMetaData>(),
     fileDownloadResponses: new Map<string, FileDownloadNormalized[]>(),
+    // TODO: consider migrating search caching to TanStack Query —
+    // this hand-rolled cache doesn't key on loadAll and can drift
+    // from store state on back-navigation.
     paginatedSearchResults: new Map<
       string,
       Record<number, SearchResultsResponse>

--- a/src/components/SearchResultsGrid/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid/SearchResultsGrid.vue
@@ -9,7 +9,7 @@
         :showDetails="false"
         :drawerId="drawerId" />
       <SkeletonCard
-        v-for="i in Math.min(30, (totalResults ?? Infinity) - matches.length)"
+        v-for="i in skeletonCount"
         v-show="status === 'fetching'"
         :key="i" />
     </div>
@@ -27,6 +27,7 @@ const props = withDefaults(
     totalResults?: number;
     matches: SearchResultMatch[];
     status: FetchStatus;
+    hasMoreResults: boolean;
     drawerId?: number;
   }>(),
   {
@@ -52,7 +53,7 @@ watch(
 
     if (
       arrived.bottom &&
-      hasMoreResults.value &&
+      props.hasMoreResults &&
       props.status !== "fetching" &&
       hasInitialData
     ) {
@@ -62,8 +63,13 @@ watch(
   { immediate: true }
 );
 
-const hasMoreResults = computed(() => {
-  return (props.totalResults ?? Infinity) > props.matches.length;
+const MAX_SKELETONS = 30;
+
+// Guard against negative counts — the server's totalResults can exceed
+// actual match count when the server-side cache is out of sync.
+const skeletonCount = computed(() => {
+  const remaining = (props.totalResults ?? Infinity) - props.matches.length;
+  return Math.max(0, Math.min(MAX_SKELETONS, remaining));
 });
 </script>
 <style scoped></style>

--- a/src/components/SearchResultsList/SearchResultsList.vue
+++ b/src/components/SearchResultsList/SearchResultsList.vue
@@ -8,7 +8,7 @@
         :searchMatch="match"
         :showDetails="false" />
       <SkeletonResultRow
-        v-for="i in Math.min(30, (totalResults ?? Infinity) - matches.length)"
+        v-for="i in skeletonCount"
         v-show="status === 'fetching'"
         :key="i" />
     </div>
@@ -25,6 +25,7 @@ const props = defineProps<{
   totalResults?: number;
   matches: SearchResultMatch[];
   status: FetchStatus;
+  hasMoreResults: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -44,7 +45,7 @@ watch(
 
     if (
       arrived.bottom &&
-      hasMoreResults.value &&
+      props.hasMoreResults &&
       props.status !== "fetching" &&
       hasInitialData
     ) {
@@ -54,8 +55,13 @@ watch(
   { immediate: true }
 );
 
-const hasMoreResults = computed(() => {
-  return (props.totalResults ?? Infinity) > props.matches.length;
+const MAX_SKELETONS = 30;
+
+// Guard against negative counts — the server's totalResults can exceed
+// actual match count when the server-side cache is out of sync.
+const skeletonCount = computed(() => {
+  const remaining = (props.totalResults ?? Infinity) - props.matches.length;
+  return Math.max(0, Math.min(MAX_SKELETONS, remaining));
 });
 </script>
 <style scoped></style>

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -63,6 +63,7 @@
               :totalResults="searchStore.totalResults"
               :matches="searchStore.matches"
               :status="searchStore.status"
+              :hasMoreResults="searchStore.hasMoreResults"
               :showAddToDrawerButton="
                 instanceStore.currentUser?.canManageDrawers
               "
@@ -73,6 +74,7 @@
               :totalResults="searchStore.totalResults"
               :matches="searchStore.matches"
               :status="searchStore.status"
+              :hasMoreResults="searchStore.hasMoreResults"
               @loadMore="() => searchStore.loadMore()" />
           </Tab>
           <Tab id="timeline" label="Timeline">

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -709,6 +709,16 @@ const actions = (state: SearchStoreState) => ({
       ...opts,
     };
 
+    // If we already have results for this searchId, keep them.
+    // This prevents back-navigation from resetting state while
+    // the API cache still holds the old pages — which would cause
+    // duplicate appends as loadMore re-walks cached pages.
+    if (state.searchId.value === searchId && state.matches.value.length > 0) {
+      state.status.value = "success";
+      state.afterNewSearchHandlers.forEach((fn) => fn(state));
+      return state.searchId.value;
+    }
+
     // call all registered before handlers
     state.beforeNewSearchHandlers.forEach((fn) => fn());
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -782,11 +782,11 @@ const actions = (state: SearchStoreState) => ({
       // If the API returned fewer results than expected, adjust totalResults
       // to match reality. This handles index/count divergence (e.g., deleted
       // items still counted in totalResults).
-      const exhausted =
+      const hasNoMoreMatches =
         res.matches.length === 0 || loadAll;
 
       if (
-        exhausted &&
+        hasNoMoreMatches &&
         state.matches.value.length < (state.totalResults.value ?? 0)
       ) {
         console.warn(

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -768,6 +768,23 @@ const actions = (state: SearchStoreState) => ({
       });
       state.matches.value.push(...res.matches);
       state.searchEntry.value = res.searchEntry;
+
+      // If the API returned fewer results than expected, adjust totalResults
+      // to match reality. This handles index/count divergence (e.g., deleted
+      // items still counted in totalResults).
+      const exhausted =
+        res.matches.length === 0 || loadAll;
+
+      if (
+        exhausted &&
+        state.matches.value.length < (state.totalResults.value ?? 0)
+      ) {
+        console.warn(
+          `totalResults (${state.totalResults.value}) exceeds actual results (${state.matches.value.length}). Adjusting.`
+        );
+        state.totalResults.value = state.matches.value.length;
+      }
+
       state.status.value = "success";
     } catch (error) {
       state.status.value = "error";

--- a/tests/e2e/search-result-count.spec.ts
+++ b/tests/e2e/search-result-count.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test";
+import {
+  setupWorkerHTTPHeader,
+  loginUser,
+  refreshDatabase,
+  createMismatchedSearch,
+} from "../setup";
+
+test.describe("Search Result Count Mismatch (#451)", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId });
+  });
+
+  test("single-page: adjusts totalResults when actual matches are fewer", async ({
+    page,
+    request,
+  }) => {
+    const workerId = test.info().workerIndex.toString();
+
+    // "Asset 9" matches: Asset 9, Asset 90–99 = 11 results (single page)
+    // Inflate totalResults to 15 so the UI thinks there are more
+    const search = await createMismatchedSearch({
+      request,
+      workerId,
+      query: "Asset 9",
+      totalResultsOverride: 15,
+    });
+
+    await page.goto(`/defaultinstance/search/s/${search.searchId}`);
+
+    // Wait for results to render
+    await expect(page.locator(".search-result-card").first()).toBeVisible();
+
+    // The inflated totalResults makes the UI show "Load All" (showingCount < total)
+    const loadButton = page
+      .getByRole("button", { name: /Load All/i })
+      .first();
+    await expect(loadButton).toBeVisible();
+
+    // Click "Load All" and wait for the API response — should return 0 matches
+    // since all real results already fit on page 0
+    const loadAllResponsePromise = page.waitForResponse((res) =>
+      res.url().includes(`/searchResults/${search.searchId}/1/true`)
+    );
+    await loadButton.click();
+
+    const loadAllResponse = await loadAllResponsePromise;
+    const loadAllBody = await loadAllResponse.json();
+    expect(loadAllBody.matches).toHaveLength(0);
+
+    // No error notification should appear
+    await expect(
+      page.locator(".search-results-page__search-error-notification")
+    ).not.toBeVisible();
+
+    // After the empty page is detected, totalResults should be adjusted
+    // so the "Load All"/"Load More" button disappears (showingCount === total).
+    await expect(loadButton).not.toBeVisible();
+  });
+
+  test("paginated: adjusts totalResults when final page returns fewer results than expected", async ({
+    page,
+    request,
+  }) => {
+    const workerId = test.info().workerIndex.toString();
+
+    // Empty query matches all ~105 assets (4 pages).
+    // Inflate totalResults to 115 so the UI thinks there are 10 more.
+    const search = await createMismatchedSearch({
+      request,
+      workerId,
+      query: "",
+      totalResultsOverride: 115,
+    });
+
+    await page.goto(`/defaultinstance/search/s/${search.searchId}`);
+
+    // Wait for first page of results to render
+    await expect(page.locator(".search-result-card").first()).toBeVisible();
+
+    // Click "Load All" and wait for the loadAll API response to complete
+    const loadAllResponsePromise = page.waitForResponse((res) =>
+      res.url().includes(`/searchResults/${search.searchId}/1/true`)
+    );
+
+    const loadButton = page
+      .getByRole("button", { name: /Load All/i })
+      .first();
+    await expect(loadButton).toBeVisible();
+    await loadButton.click();
+
+    const loadAllResponse = await loadAllResponsePromise;
+    const loadAllBody = await loadAllResponse.json();
+    expect(loadAllBody.matches.length).toBeGreaterThan(0);
+
+    // No error notification should appear
+    await expect(
+      page.locator(".search-results-page__search-error-notification")
+    ).not.toBeVisible();
+
+    // The results count should show matching numbers.
+    // Both <b> tags inside the results-count <p> should contain the same number.
+    const countsText = await page
+      .locator(".results-count p")
+      .first()
+      .innerText();
+    const counts = countsText.match(/(\d+)/g);
+    expect(counts).not.toBeNull();
+    expect(counts!.length).toBeGreaterThanOrEqual(2);
+    expect(counts![0]).toEqual(counts![1]);
+  });
+});

--- a/tests/e2e/search-result-count.spec.ts
+++ b/tests/e2e/search-result-count.spec.ts
@@ -112,4 +112,61 @@ test.describe("Search Result Count Mismatch (#451)", () => {
     expect(counts!.length).toBeGreaterThanOrEqual(2);
     expect(counts![0]).toEqual(counts![1]);
   });
+
+  test("back navigation: does not duplicate results or reset adjusted totalResults", async ({
+    page,
+    request,
+  }) => {
+    const workerId = test.info().workerIndex.toString();
+
+    const search = await createMismatchedSearch({
+      request,
+      workerId,
+      query: "",
+      totalResultsOverride: 115,
+    });
+
+    await page.goto(`/defaultinstance/search/s/${search.searchId}`);
+
+    // Wait for first page, then load all
+    await expect(page.locator(".search-result-card").first()).toBeVisible();
+
+    const loadAllResponsePromise = page.waitForResponse((res) =>
+      res.url().includes(`/searchResults/${search.searchId}/1/true`)
+    );
+    await page.getByRole("button", { name: /Load All/i }).first().click();
+    await loadAllResponsePromise;
+
+    // Record the actual result count after loading
+    const countsTextBefore = await page
+      .locator(".results-count p")
+      .first()
+      .innerText();
+    const countsBefore = countsTextBefore.match(/(\d+)/g)!;
+    const resultCountBefore = countsBefore[0];
+
+    // Click a search result to navigate away
+    await page.locator(".search-result-card").first().click();
+    await expect(page).not.toHaveURL(/\/search\/s\//);
+
+    // Hit browser back
+    await page.goBack();
+    await expect(page).toHaveURL(/\/search\/s\//);
+    await expect(page.locator(".search-result-card").first()).toBeVisible();
+
+    // Wait for any post-navigation loading to settle
+    await page.waitForTimeout(1000);
+
+    // The result count should match what we had before navigating away
+    const countsTextAfter = await page
+      .locator(".results-count p")
+      .first()
+      .innerText();
+    const countsAfter = countsTextAfter.match(/(\d+)/g)!;
+
+    // Both numbers should match (no inflated total, no duplicates)
+    expect(countsAfter[0]).toEqual(countsAfter[1]);
+    // And the loaded count should be the same as before navigation
+    expect(countsAfter[0]).toEqual(resultCountBefore);
+  });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -100,6 +100,34 @@ export async function getAssetCount({
   return count;
 }
 
+export async function createMismatchedSearch({
+  request,
+  workerId,
+  query = "",
+  totalResultsOverride,
+}: {
+  request: APIRequestContext;
+  workerId: string;
+  query?: string;
+  totalResultsOverride: number;
+}) {
+  const response = await request.post(
+    `${MOCK_SERVER_BASE}/_tests/search/create`,
+    {
+      data: { query, totalResultsOverride },
+      headers: { "x-worker-id": workerId },
+    }
+  );
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to create mismatched search: ${response.status()} ${await response.text()}`
+    );
+  }
+
+  return await response.json();
+}
+
 export async function updateInstance({
   request,
   workerId,


### PR DESCRIPTION
Resolves #451.

- Fix 1: When searching, it's possible that the backend's `totalResults` is inaccurate. We shouldn't use `matches < totalResults` to determine if there are more matches. Instead, we treat this as a placeholder for totalResults and then if we fetch a page with empty results we know we're done and update the ui accordingly. 
- Fix 2: Back navigation now correctly prevents resetting currentPage to 0 if we have more than 1 page loaded. This was causing issues where duplicate results would be loaded, leading `matches.length` to exceed `totalResults`.
- Fix 3: Related. If matches exceed total results, it was possible for the number of skeleton cards in the `v-for` to be negative. We now guard against negative counts.
- Also:`hasMoreResults` is now sourced from the store, not computed independently in each component so that other pages with search results (embedded search) will benefit from these fixes.

On dev.

https://dev.elevator.umn.edu/defaultinstance/search/s/33e71528-35e0-43ea-bdfb-4594d90d5c44?resultsView=grid