### PR TITLE
Filter non-downloadable derivatives from download menu

### DIFF
--- a/bin/deploy-dev.sh
+++ b/bin/deploy-dev.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE_HOST="dev.elevator.umn.edu"
+REMOTE_DIR="/var/www/elevator/current/assets/elevator-ui"
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+echo "Deploying branch: $branch to $REMOTE_HOST"
+echo "Make sure you are connected to the VPN."
+echo ""
+
+ssh "$REMOTE_HOST" bash -s "$branch" "$REMOTE_DIR" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+BRANCH="$1"
+DIR="$2"
+
+cd "$DIR"
+echo "→ Fetching latest branches..."
+git fetch --all --prune
+
+echo "→ Checking out $BRANCH..."
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+
+echo "→ Installing dependencies..."
+yarn
+
+echo "→ Building (remotedev)..."
+yarn build:remotedev
+
+echo ""
+echo "✔ Deploy complete: $BRANCH on $(hostname)"
+REMOTE_SCRIPT
+
+echo ""
+echo "🔗 https://dev.elevator.umn.edu/defaultinstance"

--- a/mock-server/routes/assets.ts
+++ b/mock-server/routes/assets.ts
@@ -313,4 +313,50 @@ app.get("/compareTemplates/:templateId1/:templateId2", async (c) => {
   return isEmpty(differences) ? c.json([]) : c.json(differences);
 });
 
+// GET /asset/getEmbedAsJson/:fileId/:parentObjectId?
+// Returns download info for a file's derivatives in the shape the frontend expects.
+app.get("/getEmbedAsJson/:fileId/:parentObjectId?", async (c) => {
+  await delay(100);
+  const db = c.get("db");
+  const fileId = c.req.param("fileId");
+  const file = db.files.get(fileId);
+  const filename = file?.fileName ?? `file-${fileId}`;
+
+  const makeEntry = (
+    filetype: string,
+    {
+      ready = true,
+      downloadable = true,
+    }: { ready?: boolean; downloadable?: boolean } = {}
+  ) => ({
+    storageClass: "local",
+    originalFilename: filename,
+    path: `/files/${fileId}/${filetype}`,
+    derivativeType: filetype,
+    metadata: [],
+    basePath: "/files",
+    baseWebPath: "/files",
+    ready,
+    forcedMimeType: null,
+    localAsset: null,
+    storageKey: `${fileId}_${filetype}`,
+    downloadable,
+  });
+
+  const fileType = file?.fileType ?? "unknown";
+  const isNonDownloadable = ["dcm", "dicom"].includes(fileType);
+
+  return c.json({
+    original: makeEntry("original", { ready: true, downloadable: true }),
+    thumbnail: makeEntry("thumbnail", {
+      ready: true,
+      downloadable: !isNonDownloadable,
+    }),
+    screen: makeEntry("screen", {
+      ready: true,
+      downloadable: !isNonDownloadable,
+    }),
+  });
+});
+
 export default app;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "mock:install": "cd mock-server && npm install",
     "mock:serve": "cd mock-server && npm run serve:watch",
     "mock:serve:test": "yarn build:test && cd mock-server && npm run serve:watch",
-    "dev:mock": "VITE_API_PROXY_TARGET=http://localhost:3001 VITE_IS_USING_MOCK_SERVER=true concurrently \"npm run mock:serve\" \"npm run dev\""
+    "dev:mock": "VITE_API_PROXY_TARGET=http://localhost:3001 VITE_IS_USING_MOCK_SERVER=true concurrently \"npm run mock:serve\" \"npm run dev\"",
+    "deploy:dev": "./bin/deploy-dev.sh"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",

--- a/src/components/DownloadFileButton/DownloadFileButton.vue
+++ b/src/components/DownloadFileButton/DownloadFileButton.vue
@@ -16,7 +16,10 @@
       <ul v-else class="max-w-sm">
         <template v-for="download in downloadFileInfo" :key="download.filetype">
           <a
-            v-if="download.isReady || download.filetype === 'original'"
+            v-if="
+              (download.isReady && download.isDownloadable) ||
+              download.filetype === 'original'
+            "
             :href="download.url"
             class="py-2 hover:bg-outline-variant/50 border-t last:border-b block hover:no-underline group"
             :download="`${download.originalFilename}-${download.filetype}.${download.extension}`"

--- a/tests/e2e/dicom-download-filter.spec.ts
+++ b/tests/e2e/dicom-download-filter.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+
+const KNOWN_ASSET_ID = "6875871d4eb080a4880a0f44";
+// This is the firstFileHandlerId for the seed asset — the ID used in the
+// getEmbedAsJson API call when the download button is clicked.
+const KNOWN_FILE_HANDLER_ID = "687587494eb080a4880a0f46";
+
+/**
+ * Builds a mock FileDownloadResponse with a mix of downloadable
+ * and non-downloadable file types. This simulates a DICOM file
+ * whose derivatives are not downloadable.
+ */
+function makeMockDownloadResponse(filename: string) {
+  const makeEntry = (
+    filetype: string,
+    ready: boolean,
+    downloadable: boolean,
+  ) => ({
+    storageClass: "local",
+    originalFilename: filename,
+    path: `/files/${KNOWN_FILE_HANDLER_ID}/${filetype}`,
+    derivativeType: filetype,
+    metadata: [],
+    basePath: "/files",
+    baseWebPath: "/files",
+    ready,
+    forcedMimeType: null,
+    localAsset: null,
+    storageKey: `${KNOWN_FILE_HANDLER_ID}_${filetype}`,
+    downloadable,
+  });
+
+  return {
+    original: makeEntry("original", true, true),
+    thumbnail: makeEntry("thumbnail", true, true),
+    // DICOM-like: ready but NOT downloadable
+    dicom: makeEntry("dicom", true, false),
+    screen: makeEntry("screen", true, false),
+  };
+}
+
+test.describe("DownloadFileButton: non-downloadable file filter", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.route("**/arcgis.com/**", (route) => route.abort());
+    await page.route("**/basemaps-api.arcgis.com/**", (route) => route.abort());
+
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+  });
+
+  test("hides non-downloadable file types from the download menu", async ({
+    page,
+  }) => {
+    // Intercept the download info API to return a mix of downloadable / non-downloadable
+    await page.route(
+      `**/asset/getEmbedAsJson/${KNOWN_FILE_HANDLER_ID}/**`,
+      (route) => {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(makeMockDownloadResponse("scan.dcm")),
+        });
+      },
+    );
+
+    await page.goto(`/asset/viewAsset/${KNOWN_ASSET_ID}`);
+
+    // Click the download button to open the download modal
+    const downloadButton = page.getByRole("button", { name: "Download File" });
+    await expect(downloadButton).toBeVisible({ timeout: 10000 });
+    await downloadButton.click();
+
+    // Wait for the modal to appear (it doesn't have role="dialog", find by heading)
+    const modalHeading = page.getByRole("heading", { name: "File Downloads" });
+    await expect(modalHeading).toBeVisible({ timeout: 5000 });
+
+    // Scope assertions to the modal container
+    const modal = page.locator(".modal").filter({ has: modalHeading });
+
+    // Wait for download info to load (links appear)
+    await expect(modal.getByText("original")).toBeVisible({ timeout: 5000 });
+
+    // "thumbnail" is downloadable — should be visible
+    await expect(modal.getByText("thumbnail")).toBeVisible();
+
+    // "dicom" and "screen" are NOT downloadable — should be hidden
+    await expect(modal.getByText("dicom")).not.toBeVisible();
+    await expect(modal.getByText("screen")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
- Fixes #502 
- Adds `isDownloadable` guard to the download link condition so only actually-downloadable files appear
- Adds e2e test and mock server endpoint to verify the behavior