### PR TITLE
Suppress location info when extractLocation is false

### DIFF
--- a/src/components/ActiveFileViewToolbar/ActiveFileViewToolbar.vue
+++ b/src/components/ActiveFileViewToolbar/ActiveFileViewToolbar.vue
@@ -4,7 +4,8 @@
       <div class="flex gap-1 items-center leading-none">
         <MoreFileInfoButton
           v-if="fileHandlerId"
-          :fileObjectId="fileHandlerId" />
+          :fileObjectId="fileHandlerId"
+          :assetId="assetId" />
         <DownloadFileButton
           v-if="assetId && fileHandlerId"
           :assetId="assetId"

--- a/src/components/MoreFileInfoButton/MoreFileInfoButton.vue
+++ b/src/components/MoreFileInfoButton/MoreFileInfoButton.vue
@@ -70,7 +70,7 @@ import Tuple from "../Tuple/Tuple.vue";
 import config from "@/config";
 import InfoIcon from "@/icons/InfoIcon.vue";
 import {
-  getExtractLocation,
+  shouldExtractLocation,
   filterGpsFromExif,
 } from "@/helpers/templateHelpers";
 
@@ -101,7 +101,7 @@ async function handleInfoButtonClick() {
 
   if (props.assetId) {
     const { template } = await api.getAssetWithTemplate(props.assetId);
-    shouldShowLocation.value = getExtractLocation(template);
+    shouldShowLocation.value = shouldExtractLocation(template);
   }
 
   fileMetaData.value = await api.getFileMetaData(props.fileObjectId);

--- a/src/components/MoreFileInfoButton/MoreFileInfoButton.vue
+++ b/src/components/MoreFileInfoButton/MoreFileInfoButton.vue
@@ -27,7 +27,7 @@
           </Tuple>
           <Tuple label="Image Size">
             {{ fileMetaData.width ?? "Unknown" }} x
-            {{ fileMetaData.height ?? "Unknonwn" }}
+            {{ fileMetaData.height ?? "Unknown" }}
           </Tuple>
           <Tuple
             v-if="shouldShowLocation && fileMetaData.coordinates"
@@ -54,7 +54,7 @@
           <pre>{{ displayExif }}</pre>
         </section>
         <section v-else>
-          <pre>{{ fileMetaData }}</pre>
+          <pre>{{ displayFileMetaData }}</pre>
         </section>
       </div>
     </Transition>
@@ -95,9 +95,22 @@ const displayExif = computed(() => {
   return shouldShowLocation.value ? exif : filterGpsFromExif(exif);
 });
 
+const displayFileMetaData = computed(() => {
+  if (!fileMetaData.value || shouldShowLocation.value) return fileMetaData.value;
+  const { coordinates: _coordinates, exif, ...rest } = fileMetaData.value;
+  return {
+    ...rest,
+    ...(exif ? { exif: filterGpsFromExif(exif) } : {}),
+  };
+});
+
 async function handleInfoButtonClick() {
   isFileInfoOpen.value = !isFileInfoOpen.value;
+
+  if (!isFileInfoOpen.value) return;
+
   fileMetaData.value = undefined;
+  shouldShowLocation.value = true;
 
   if (props.assetId) {
     const { template } = await api.getAssetWithTemplate(props.assetId);

--- a/src/components/MoreFileInfoButton/MoreFileInfoButton.vue
+++ b/src/components/MoreFileInfoButton/MoreFileInfoButton.vue
@@ -29,7 +29,9 @@
             {{ fileMetaData.width ?? "Unknown" }} x
             {{ fileMetaData.height ?? "Unknonwn" }}
           </Tuple>
-          <Tuple v-if="fileMetaData.coordinates" label="Location">
+          <Tuple
+            v-if="shouldShowLocation && fileMetaData.coordinates"
+            label="Location">
             <div class="bg-surface-container p-4 rounded-xl">
               <Map
                 :center="{
@@ -49,7 +51,7 @@
           </Tuple>
 
           <h2 class="text-xl font-bold mt-6 border-t pt-6">EXIF Details</h2>
-          <pre>{{ fileMetaData.exif }}</pre>
+          <pre>{{ displayExif }}</pre>
         </section>
         <section v-else>
           <pre>{{ fileMetaData }}</pre>
@@ -59,18 +61,22 @@
   </Modal>
 </template>
 <script setup lang="ts">
-import { ref, defineAsyncComponent } from "vue";
+import { ref, computed, defineAsyncComponent } from "vue";
 import IconButton from "@/components/IconButton/IconButton.vue";
 import Modal from "../Modal/Modal.vue";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import api from "@/api";
-import { computed } from "vue";
 import Tuple from "../Tuple/Tuple.vue";
 import config from "@/config";
 import InfoIcon from "@/icons/InfoIcon.vue";
+import {
+  getExtractLocation,
+  filterGpsFromExif,
+} from "@/helpers/templateHelpers";
 
 const props = defineProps<{
   fileObjectId: string;
+  assetId?: string | null;
 }>();
 
 const Map = defineAsyncComponent(() => import("@/components/Map/Map.vue"));
@@ -80,11 +86,24 @@ const MapMarker = defineAsyncComponent(
 
 const isFileInfoOpen = ref(false);
 const fileMetaData = ref<FileMetaData | null | undefined>(undefined);
+const shouldShowLocation = ref(true);
 const isFileMetaDataReady = computed(() => fileMetaData.value !== undefined);
+
+const displayExif = computed(() => {
+  const exif = fileMetaData.value?.exif;
+  if (!exif) return undefined;
+  return shouldShowLocation.value ? exif : filterGpsFromExif(exif);
+});
 
 async function handleInfoButtonClick() {
   isFileInfoOpen.value = !isFileInfoOpen.value;
   fileMetaData.value = undefined;
+
+  if (props.assetId) {
+    const { template } = await api.getAssetWithTemplate(props.assetId);
+    shouldShowLocation.value = getExtractLocation(template);
+  }
+
   fileMetaData.value = await api.getFileMetaData(props.fileObjectId);
 }
 </script>

--- a/src/helpers/templateHelpers.test.ts
+++ b/src/helpers/templateHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getExtractLocation, filterGpsFromExif } from "./templateHelpers";
+import { shouldExtractLocation, filterGpsFromExif } from "./templateHelpers";
 import type { Template } from "@/types";
 import type { Exif } from "@/types/FileMetaDataTypes";
 
@@ -71,25 +71,25 @@ function makeTemplateWithoutUpload(): Template {
   };
 }
 
-describe("getExtractLocation", () => {
+describe("shouldExtractLocation", () => {
   it("returns false when extractLocation is false", () => {
-    expect(getExtractLocation(makeTemplate(false))).toBe(false);
+    expect(shouldExtractLocation(makeTemplate(false))).toBe(false);
   });
 
   it("returns true when extractLocation is true", () => {
-    expect(getExtractLocation(makeTemplate(true))).toBe(true);
+    expect(shouldExtractLocation(makeTemplate(true))).toBe(true);
   });
 
   it("defaults to true when extractLocation is undefined", () => {
-    expect(getExtractLocation(makeTemplate(undefined))).toBe(true);
+    expect(shouldExtractLocation(makeTemplate(undefined))).toBe(true);
   });
 
   it("defaults to true when template has no upload widget", () => {
-    expect(getExtractLocation(makeTemplateWithoutUpload())).toBe(true);
+    expect(shouldExtractLocation(makeTemplateWithoutUpload())).toBe(true);
   });
 
   it("defaults to true when template is null", () => {
-    expect(getExtractLocation(null)).toBe(true);
+    expect(shouldExtractLocation(null)).toBe(true);
   });
 });
 

--- a/src/helpers/templateHelpers.test.ts
+++ b/src/helpers/templateHelpers.test.ts
@@ -10,9 +10,9 @@ function makeTemplate(
     templateId: 1,
     templateName: "Test Template",
     showCollection: false,
-    showCollectionPosition: "top",
+    showCollectionPosition: 1,
     showTemplate: false,
-    showTemplatePosition: "top",
+    showTemplatePosition: 1,
     widgetArray: [
       {
         widgetId: 1,
@@ -44,9 +44,9 @@ function makeTemplateWithoutUpload(): Template {
     templateId: 2,
     templateName: "No Upload Template",
     showCollection: false,
-    showCollectionPosition: "top",
+    showCollectionPosition: 1,
     showTemplate: false,
-    showTemplatePosition: "top",
+    showTemplatePosition: 1,
     widgetArray: [
       {
         widgetId: 1,

--- a/src/helpers/templateHelpers.test.ts
+++ b/src/helpers/templateHelpers.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { getExtractLocation, filterGpsFromExif } from "./templateHelpers";
+import type { Template } from "@/types";
+import type { Exif } from "@/types/FileMetaDataTypes";
+
+function makeTemplate(
+  extractLocation?: boolean
+): Template {
+  return {
+    templateId: 1,
+    templateName: "Test Template",
+    showCollection: false,
+    showCollectionPosition: "top",
+    showTemplate: false,
+    showTemplatePosition: "top",
+    widgetArray: [
+      {
+        widgetId: 1,
+        type: "upload",
+        fieldTitle: "upload_1",
+        label: "Photo",
+        tooltip: "",
+        fieldData: {
+          extractLocation,
+        },
+        allowMultiple: false,
+        attemptAutocomplete: false,
+        display: true,
+        displayInPreview: false,
+        required: false,
+        searchable: false,
+        directSearch: false,
+        clickToSearch: false,
+        clickToSearchType: 0,
+        viewOrder: 0,
+        templateOrder: 0,
+      },
+    ],
+  };
+}
+
+function makeTemplateWithoutUpload(): Template {
+  return {
+    templateId: 2,
+    templateName: "No Upload Template",
+    showCollection: false,
+    showCollectionPosition: "top",
+    showTemplate: false,
+    showTemplatePosition: "top",
+    widgetArray: [
+      {
+        widgetId: 1,
+        type: "text",
+        fieldTitle: "text_1",
+        label: "Title",
+        tooltip: "",
+        fieldData: null,
+        allowMultiple: false,
+        attemptAutocomplete: false,
+        display: true,
+        displayInPreview: false,
+        required: false,
+        searchable: false,
+        directSearch: false,
+        clickToSearch: false,
+        clickToSearchType: 0,
+        viewOrder: 0,
+        templateOrder: 0,
+      },
+    ],
+  };
+}
+
+describe("getExtractLocation", () => {
+  it("returns false when extractLocation is false", () => {
+    expect(getExtractLocation(makeTemplate(false))).toBe(false);
+  });
+
+  it("returns true when extractLocation is true", () => {
+    expect(getExtractLocation(makeTemplate(true))).toBe(true);
+  });
+
+  it("defaults to true when extractLocation is undefined", () => {
+    expect(getExtractLocation(makeTemplate(undefined))).toBe(true);
+  });
+
+  it("defaults to true when template has no upload widget", () => {
+    expect(getExtractLocation(makeTemplateWithoutUpload())).toBe(true);
+  });
+
+  it("defaults to true when template is null", () => {
+    expect(getExtractLocation(null)).toBe(true);
+  });
+});
+
+describe("filterGpsFromExif", () => {
+  it("removes GPS fields from Composite", () => {
+    const exif: Exif = {
+      Composite: {
+        GPSLatitude: "44 deg 58' 12.34\"",
+        GPSLongitude: "-93 deg 15' 45.67\"",
+        GPSAltitude: "300 m",
+        GPSPosition: "44.97, -93.26",
+        ImageSize: "4032x3024",
+        Megapixels: 12.2,
+      },
+    };
+    const filtered = filterGpsFromExif(exif);
+    expect(filtered.Composite).not.toHaveProperty("GPSLatitude");
+    expect(filtered.Composite).not.toHaveProperty("GPSLongitude");
+    expect(filtered.Composite).not.toHaveProperty("GPSAltitude");
+    expect(filtered.Composite).not.toHaveProperty("GPSPosition");
+    expect(filtered.Composite).toHaveProperty("ImageSize", "4032x3024");
+    expect(filtered.Composite).toHaveProperty("Megapixels", 12.2);
+  });
+
+  it("removes GPS fields from EXIF section", () => {
+    const exif: Exif = {
+      EXIF: {
+        GPSLatitude: "44 deg 58' 12.34\"",
+        GPSLongitude: "-93 deg 15' 45.67\"",
+        GPSSpeed: 0,
+        GPSSpeedRef: "km/h",
+        GPSAltitude: "300 m",
+        GPSAltitudeRef: "Above Sea Level",
+        GPSDestBearing: 180,
+        GPSDestBearingRef: "True North",
+        GPSImgDirection: 90,
+        GPSImgDirectionRef: "True North",
+        GPSLatitudeRef: "North",
+        GPSLongitudeRef: "West",
+        GPSHPositioningError: "5 m",
+        Make: "Apple",
+        Model: "iPhone 14 Pro",
+      },
+    };
+    const filtered = filterGpsFromExif(exif);
+    expect(filtered.EXIF).not.toHaveProperty("GPSLatitude");
+    expect(filtered.EXIF).not.toHaveProperty("GPSLongitude");
+    expect(filtered.EXIF).not.toHaveProperty("GPSSpeed");
+    expect(filtered.EXIF).not.toHaveProperty("GPSAltitude");
+    expect(filtered.EXIF).not.toHaveProperty("GPSImgDirection");
+    expect(filtered.EXIF).toHaveProperty("Make", "Apple");
+    expect(filtered.EXIF).toHaveProperty("Model", "iPhone 14 Pro");
+  });
+
+  it("does not mutate the original exif object", () => {
+    const exif: Exif = {
+      Composite: {
+        GPSLatitude: "44 deg",
+        ImageSize: "4032x3024",
+      },
+    };
+    filterGpsFromExif(exif);
+    expect(exif.Composite).toHaveProperty("GPSLatitude");
+  });
+
+  it("handles exif with no GPS fields gracefully", () => {
+    const exif: Exif = {
+      File: {
+        FileSize: "3.2 MB",
+        FileType: "JPEG",
+      },
+    };
+    const filtered = filterGpsFromExif(exif);
+    expect(filtered.File).toHaveProperty("FileSize", "3.2 MB");
+    expect(filtered.File).toHaveProperty("FileType", "JPEG");
+  });
+
+  it("handles undefined exif sections gracefully", () => {
+    const exif: Exif = {};
+    const filtered = filterGpsFromExif(exif);
+    expect(filtered).toEqual({});
+  });
+});

--- a/src/helpers/templateHelpers.ts
+++ b/src/helpers/templateHelpers.ts
@@ -1,0 +1,45 @@
+import type { Template, UploadWidgetDef } from "@/types";
+import type { Exif } from "@/types/FileMetaDataTypes";
+
+/**
+ * Returns the `extractLocation` flag from the template's upload widget.
+ * Defaults to true (show location) when the flag is absent, the template
+ * has no upload widget, or the template itself is null.
+ */
+export function getExtractLocation(template: Template | null): boolean {
+  if (!template) return true;
+
+  const uploadWidget = template.widgetArray.find(
+    (w): w is UploadWidgetDef => w.type === "upload"
+  );
+
+  return uploadWidget?.fieldData.extractLocation ?? true;
+}
+
+const GPS_KEY_PREFIX = "GPS";
+
+function omitGpsKeys<T extends Record<string, unknown>>(
+  section: Partial<T>
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(section).filter(([key]) => !key.startsWith(GPS_KEY_PREFIX))
+  ) as Partial<T>;
+}
+
+/**
+ * Returns a shallow copy of the EXIF object with all GPS-prefixed fields
+ * removed from every section. Does not mutate the original.
+ */
+export function filterGpsFromExif(exif: Exif): Exif {
+  const filtered: Exif = {};
+
+  for (const [sectionKey, sectionValue] of Object.entries(exif)) {
+    if (sectionValue && typeof sectionValue === "object") {
+      filtered[sectionKey as keyof Exif] = omitGpsKeys(
+        sectionValue as Record<string, unknown>
+      ) as Exif[keyof Exif];
+    }
+  }
+
+  return filtered;
+}

--- a/src/helpers/templateHelpers.ts
+++ b/src/helpers/templateHelpers.ts
@@ -1,4 +1,4 @@
-import type { Template, UploadWidgetDef } from "@/types";
+import { WIDGET_TYPES, type Template, type UploadWidgetDef } from "@/types";
 import type { Exif } from "@/types/FileMetaDataTypes";
 
 /**
@@ -6,16 +6,19 @@ import type { Exif } from "@/types/FileMetaDataTypes";
  * Defaults to true (show location) when the flag is absent, the template
  * has no upload widget, or the template itself is null.
  */
-export function getExtractLocation(template: Template | null): boolean {
+export function shouldExtractLocation(template: Template | null): boolean {
   if (!template) return true;
 
-  const uploadWidget = template.widgetArray.find(
-    (w): w is UploadWidgetDef => w.type === "upload"
+  const uploadWidgetDef = template.widgetArray.find(
+    (w): w is UploadWidgetDef => w.type === WIDGET_TYPES.UPLOAD
   );
 
-  return uploadWidget?.fieldData.extractLocation ?? true;
+  return uploadWidgetDef?.fieldData.extractLocation ?? true;
 }
 
+// EXIF GPS fields all share a "GPS" prefix (GPSLatitude, GPSLongitude,
+// GPSAltitude, GPSSpeed, etc.) across every EXIF section (EXIF, Composite).
+// Filtering by prefix strips all location data from the raw EXIF dump.
 const GPS_KEY_PREFIX = "GPS";
 
 function omitGpsKeys<T extends Record<string, unknown>>(
@@ -31,15 +34,14 @@ function omitGpsKeys<T extends Record<string, unknown>>(
  * removed from every section. Does not mutate the original.
  */
 export function filterGpsFromExif(exif: Exif): Exif {
-  const filtered: Exif = {};
-
-  for (const [sectionKey, sectionValue] of Object.entries(exif)) {
-    if (sectionValue && typeof sectionValue === "object") {
-      filtered[sectionKey as keyof Exif] = omitGpsKeys(
-        sectionValue as Record<string, unknown>
-      ) as Exif[keyof Exif];
-    }
-  }
-
-  return filtered;
+  // Each EXIF section (EXIF, Composite, File, etc.) is an object whose keys
+  // we can filter. Non-object values are preserved as-is.
+  return Object.fromEntries(
+    Object.entries(exif).map(([key, section]) => [
+      key,
+      section && typeof section === "object"
+        ? omitGpsKeys(section as Record<string, unknown>)
+        : section,
+    ])
+  ) as Exif;
 }

--- a/src/pages/ExcerptViewPage/ExcerptViewPage.vue
+++ b/src/pages/ExcerptViewPage/ExcerptViewPage.vue
@@ -31,7 +31,9 @@
             </span>
           </div>
           <div>
-            <MoreFileInfoButton :fileObjectId="excerpt.fileObjectId" />
+            <MoreFileInfoButton
+              :fileObjectId="excerpt.fileObjectId"
+              :assetId="excerpt.assetId" />
             <DownloadFileButton
               :assetId="excerpt.assetId"
               :fileObjectId="excerpt.fileObjectId" />


### PR DESCRIPTION
- Fixes #417
- Hides the map, coordinates, and GPS EXIF fields in the File Info popup when the template's upload widget has `extractLocation: false`
- Uses the already-cached template to check the flag — no extra network requests in the normal flow

Example asset: https://dev.elevator.umn.edu/defaultinstance/assetManager/editAsset/623dee393392272653676222

Before (extractLocation: true) -- shows map and gps data
<img width="500"  alt="ScreenShot 2026-04-02 at 18 35 14@2x" src="https://github.com/user-attachments/assets/42788e25-22b5-4e61-83f1-fc1beaa8507e" />


After (extractLocation: false) -- map and gps data suppressed
<img width="500" alt="ScreenShot 2026-04-02 at 18 34 50@2x" src="https://github.com/user-attachments/assets/b1c6b0e9-226b-4e67-9847-243b9c060d54" />
