### PR TITLE
Hide date on unsaved new assets

### DIFF
--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/utils.test.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { makeLocalAsset } from "./utils";
+import type { Template } from "@/types";
+
+const emptyTemplate = {
+  templateId: 1,
+  widgetArray: [],
+} as unknown as Template;
+
+describe("makeLocalAsset", () => {
+  it("returns null modified date for a new unsaved asset", () => {
+    const asset = makeLocalAsset({
+      template: emptyTemplate,
+      collectionId: 42,
+      savedAsset: null,
+    });
+
+    expect(asset.modified).toBeNull();
+  });
+});

--- a/src/pages/CreateOrEditAssetPage/useAssetEditor/utils.ts
+++ b/src/pages/CreateOrEditAssetPage/useAssetEditor/utils.ts
@@ -138,11 +138,7 @@ function makeNewLocalAsset({
     readyForDisplay: true,
     collectionId,
     availableAfter: null,
-    modified: {
-      date: new Date().toISOString(),
-      timezone_type: 3,
-      timezone: "UTC",
-    },
+    modified: null,
     modifiedBy: 0,
     createdBy: 0,
     deletedBy: null,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -513,8 +513,9 @@ interface AssetWidgetFields {
 
 export type Asset = BaseAsset & AssetWidgetFields;
 
-export type UnsavedAsset = Omit<BaseAsset, "assetId"> & {
+export type UnsavedAsset = Omit<BaseAsset, "assetId" | "modified"> & {
   assetId: null;
+  modified: PHPDateTime | null;
 } & AssetWidgetFields;
 
 export type TemplateShowPropertyPosition =


### PR DESCRIPTION
- Fixes #461
- New assets no longer show a misleading date below the save button before they've been saved
- Sets `modified` to `null` in `makeNewLocalAsset` instead of the current timestamp