### PR TITLE
Dark mode readability fixes

### DIFF
--- a/mock-server/db/instances.ts
+++ b/mock-server/db/instances.ts
@@ -37,6 +37,7 @@ const instanceSeeds: InstanceSettings[] = [
     domain: "example.edu",
     featuredAsset: "687969fd9c90c709c1021d01",
     featuredAssetText: "This is a featured asset",
+    enableTheming: true,
   }),
 ];
 

--- a/src/components/AppMenu/AppMenuItem.vue
+++ b/src/components/AppMenu/AppMenuItem.vue
@@ -41,6 +41,6 @@ withDefaults(
 
 .app-menu-item.is-current-page {
   background: var(--primary-container);
-  color: var(--primary);
+  color: var(--on-primary-container);
 }
 </style>

--- a/src/components/IconButton/IconButton.vue
+++ b/src/components/IconButton/IconButton.vue
@@ -5,6 +5,7 @@
       :href="resolvedHref"
       :type="type"
       :to="componentType === RouterLink ? to : undefined"
+      :aria-label="title"
       v-bind="$attrs"
       class="icon-button flex items-center justify-center aspect-square p-2 rounded-md transition-colors duration-150 text-primary hover:bg-primary-container hover:text-on-primary-container focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed"
       @click="($event) => $emit('click', $event)">

--- a/src/components/IconButton/IconButton.vue
+++ b/src/components/IconButton/IconButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <Popover :content="title">
+  <Tooltip :tip="title">
     <component
       :is="componentType"
       :href="resolvedHref"
@@ -7,14 +7,13 @@
       :to="componentType === RouterLink ? to : undefined"
       v-bind="$attrs"
       class="icon-button flex items-center justify-center aspect-square p-2 rounded-md transition-colors duration-150 text-primary hover:bg-primary-container hover:text-on-primary-container focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed"
-      :title="title"
       @click="($event) => $emit('click', $event)">
       <slot />
     </component>
-  </Popover>
+  </Tooltip>
 </template>
 <script setup lang="ts">
-import Popover from "../Popover/Popover.vue";
+import Tooltip from "../Tooltip/Tooltip.vue";
 
 import { computed } from "vue";
 import { RouterLink, type RouteLocationRaw, useRouter } from "vue-router";

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -4,7 +4,7 @@
       <TooltipTrigger asChild>
         <slot />
       </TooltipTrigger>
-      <TooltipContent>
+      <TooltipContent v-if="tip || $slots.content">
         <slot name="content">
           {{ tip }}
         </slot>

--- a/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
@@ -1,30 +1,32 @@
 <template>
-  <RouterLink
-    :title="title"
-    class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline hover:bg-primary-container hover:text-primary w-24 text-on-surface-variant"
-    :class="{
-      'opacity-80 hover:opacity-100 hover:border-primary': !isActiveObject,
-      'ring ring-offset-1 ring-primary hover:border-transparent opacity-100 bg-primary-container':
-        isActiveObject,
-    }"
-    :to="`#${assetId}`">
-    <ThumbnailImage
-      v-if="assetCacheItem?.primaryHandler"
-      :src="getTinyURL(assetCacheItem.primaryHandler)"
-      :alt="title"
-      class="thumbnail-related-asset-widget__image max-w-full" />
-    <ThumbnailGeneric v-else :isActive="isActiveObject" />
+  <Tooltip :tip="title">
+    <RouterLink
+      class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline hover:bg-primary-container hover:text-primary w-24 text-on-surface-variant"
+      :class="{
+        'opacity-80 hover:opacity-100 hover:border-primary': !isActiveObject,
+        'ring ring-offset-1 ring-primary hover:border-transparent opacity-100 bg-primary-container':
+          isActiveObject,
+      }"
+      :to="`#${assetId}`">
+      <ThumbnailImage
+        v-if="assetCacheItem?.primaryHandler"
+        :src="getTinyURL(assetCacheItem.primaryHandler)"
+        :alt="title"
+        class="thumbnail-related-asset-widget__image max-w-full" />
+      <ThumbnailGeneric v-else :isActive="isActiveObject" />
 
-    <SanitizedHTML
-      class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
-      :html="title" />
-  </RouterLink>
+      <SanitizedHTML
+        class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
+        :html="title" />
+    </RouterLink>
+  </Tooltip>
 </template>
 <script setup lang="ts">
 import { getTinyURL } from "@/helpers/displayUtils";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import ThumbnailGeneric from "@/components/ThumbnailGeneric/ThumbnailGeneric.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
+import Tooltip from "@/components/Tooltip/Tooltip.vue";
 import { RelatedAssetCacheItem } from "@/types";
 
 defineProps<{

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -43,27 +43,25 @@
       </DropDown>
     </template>
     <div class="upload-widget flex gap-2 flex-wrap mt-2">
-      <button
+      <Tooltip
         v-for="(content, key) in contents"
         :key="key"
-        :title="content.fileDescription"
-        class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline w-24"
-        :class="{
-          'opacity-80 hover:opacity-100': !isFileActive(content.fileId),
-          'ring ring-offset-1 is-active hover:border-transparent opacity-100':
-            isFileActive(content.fileId),
-        }"
-        @click="assetStore.activeFileObjectId = content.fileId">
-        <ThumbnailImage
-          :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
-          :alt="content.fileDescription"
-          :fileType="content.fileType"
-          class="thumbnail-related-asset-widget__image max-w-full" />
-        <SanitizedHTML
-          v-if="content.fileDescription"
-          class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
-          :html="content.fileDescription" />
-      </button>
+        :tip="content.fileDescription">
+        <button
+          class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline w-24"
+          :class="{
+            'opacity-80 hover:opacity-100': !isFileActive(content.fileId),
+            'ring ring-offset-1 is-active hover:border-transparent opacity-100':
+              isFileActive(content.fileId),
+          }"
+          @click="assetStore.activeFileObjectId = content.fileId">
+          <ThumbnailImage
+            :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
+            :alt="content.fileDescription"
+            :fileType="content.fileType"
+            class="thumbnail-related-asset-widget__image max-w-full" />
+        </button>
+      </Tooltip>
     </div>
   </Tuple>
 </template>
@@ -78,6 +76,7 @@ import config from "@/config";
 import { useAssetStore } from "@/stores/assetStore";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
+import Tooltip from "@/components/Tooltip/Tooltip.vue";
 import { computed, onMounted, onBeforeUnmount, ref } from "vue";
 import Tuple from "@/components/Tuple/Tuple.vue";
 import { SpinnerIcon, VerticalDotsIcon } from "@/icons";

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -75,7 +75,6 @@ import {
 import config from "@/config";
 import { useAssetStore } from "@/stores/assetStore";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
-import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import Tooltip from "@/components/Tooltip/Tooltip.vue";
 import { computed, onMounted, onBeforeUnmount, ref } from "vue";
 import Tuple from "@/components/Tuple/Tuple.vue";

--- a/src/components/ui/combobox/ComboboxList.vue
+++ b/src/components/ui/combobox/ComboboxList.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       v-bind="forwarded"
       :class="
         cn(
-          'z-50 min-w-sm w-sm rounded-md border bg-popover text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-50 min-w-sm w-sm rounded-md border bg-surface-bright text-on-surface shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           props.class
         )
       ">

--- a/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
+++ b/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
@@ -23,7 +23,7 @@
           <label class="sr-only">Add to Drawer</label>
           <select
             v-model="selectedDrawer"
-            class="border border-outline rounded w-full text-sm"
+            class="border border-outline rounded w-full text-sm bg-surface text-on-surface"
             :class="{
               'text-on-surface-variant': !selectedDrawer,
             }">

--- a/tests/e2e/instance-settings.spec.ts
+++ b/tests/e2e/instance-settings.spec.ts
@@ -287,10 +287,7 @@ test.describe("Instance Settings Page", () => {
       await page.getByLabel("Text Area Collapsed Height (px)").fill("200");
 
       // --- User Interface ---
-      // Interface version is already 1 (VueJS) — enable theming (starts off)
-      await page
-        .getByRole("switch", { name: "Enable Theme Selection" })
-        .click();
+      // Interface version is already 1 (VueJS) — theming starts on (seed default)
       await expect(
         page.getByRole("switch", { name: "Enable Theme Selection" })
       ).toHaveAttribute("aria-checked", "true");


### PR DESCRIPTION
Resolves a number of dark theme contrast issues. Additionally, #424 is resolved when changing from vue3-popper to reka-ui's tooltip (which portals to `<body>` so no scrollbar overflow.

- Fixes #505
- Fixes #446 
- Fixes #478 
- Fixes #424
- Fixes #507
- Fixes #472. Changes to tooltip.
- Fixes tooltip contrast by changing to reka-ui tooltip 
- Fixes active menu item contrast by using correct M3 color token
- Fixes combobox and select dark mode backgrounds by replacing undefined shadcn defaults with project tokens