### PR TITLE
Fix preview image polling leak after leaving asset editor

### DIFF
--- a/src/helpers/usePreviewImage.ts
+++ b/src/helpers/usePreviewImage.ts
@@ -19,6 +19,9 @@ export const usePreviewImage = (
   const store = usePreviewImageStore();
   const fileId = computed(() => toValue(fileIdSource));
 
+  // watchEffect + onCleanup handles both fileId changes and component
+  // unmount in one place. onCleanup runs before each re-run AND on
+  // unmount, so we don't need a separate onUnmounted hook.
   watchEffect((onCleanup) => {
     const id = fileId.value;
     if (!id) return;

--- a/src/helpers/usePreviewImage.ts
+++ b/src/helpers/usePreviewImage.ts
@@ -2,7 +2,7 @@ import { usePreviewImageStore } from "@/stores/previewImageStore";
 import invariant from "tiny-invariant";
 import {
   computed,
-  watch,
+  watchEffect,
   toValue,
   type MaybeRefOrGetter,
   type ComputedRef,
@@ -19,14 +19,12 @@ export const usePreviewImage = (
   const store = usePreviewImageStore();
   const fileId = computed(() => toValue(fileIdSource));
 
-  watch(
-    fileId,
-    () => {
-      if (!fileId.value) return;
-      store.registerFileId(fileId.value);
-    },
-    { immediate: true }
-  );
+  watchEffect((onCleanup) => {
+    const id = fileId.value;
+    if (!id) return;
+    store.registerFileId(id);
+    onCleanup(() => store.unregisterFileId(id));
+  });
 
   const isReady = computed((): boolean => {
     return Boolean(fileId.value && store.isImageReady(fileId.value));

--- a/src/helpers/usePreviewImage.ts
+++ b/src/helpers/usePreviewImage.ts
@@ -2,7 +2,8 @@ import { usePreviewImageStore } from "@/stores/previewImageStore";
 import invariant from "tiny-invariant";
 import {
   computed,
-  watchEffect,
+  watch,
+  onBeforeUnmount,
   toValue,
   type MaybeRefOrGetter,
   type ComputedRef,
@@ -19,14 +20,20 @@ export const usePreviewImage = (
   const store = usePreviewImageStore();
   const fileId = computed(() => toValue(fileIdSource));
 
-  // watchEffect + onCleanup handles both fileId changes and component
-  // unmount in one place. onCleanup runs before each re-run AND on
-  // unmount, so we don't need a separate onUnmounted hook.
-  watchEffect((onCleanup) => {
-    const id = fileId.value;
-    if (!id) return;
-    store.registerFileId(id);
-    onCleanup(() => store.unregisterFileId(id));
+  // watch (not watchEffect) so we only track fileId — watchEffect would
+  // also track reactive reads inside registerFileId, causing an infinite
+  // loop when those same maps are mutated.
+  watch(
+    fileId,
+    (newId, oldId) => {
+      if (oldId) store.unregisterFileId(oldId);
+      if (newId) store.registerFileId(newId);
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    if (fileId.value) store.unregisterFileId(fileId.value);
   });
 
   const isReady = computed((): boolean => {

--- a/src/stores/previewImageStore.ts
+++ b/src/stores/previewImageStore.ts
@@ -51,10 +51,15 @@ export const usePreviewImageStore = defineStore("previewImages", () => {
     imageReadyMap.set(fileId, false);
   };
 
+  const unregisterFileId = (fileId: string) => {
+    imageReadyMap.delete(fileId);
+  };
+
   return {
     imageReadyMap,
     isImageReady,
     getPreviewImageUrl,
     registerFileId,
+    unregisterFileId,
   };
 });

--- a/src/stores/previewImageStore.ts
+++ b/src/stores/previewImageStore.ts
@@ -31,11 +31,15 @@ export const usePreviewImageStore = defineStore("previewImages", () => {
 
   const { data: previewResults } = usePreviewImagesQuery(imagesToCheck);
 
-  // Update imageReadyMap when query results change
+  // Update imageReadyMap when query results change. Guard against late
+  // responses arriving after a fileId has been unregistered — without
+  // this check, a stale response could re-add the fileId and restart polling.
   watchEffect(() => {
     if (previewResults.value) {
       previewResults.value.forEach(({ fileId, status }) => {
-        imageReadyMap.set(fileId, status === "true");
+        if (refCountMap.has(fileId)) {
+          imageReadyMap.set(fileId, status === "true");
+        }
       });
     }
   });
@@ -59,6 +63,7 @@ export const usePreviewImageStore = defineStore("previewImages", () => {
 
   return {
     imageReadyMap,
+    refCountMap,
     isImageReady,
     getPreviewImageUrl,
     registerFileId,

--- a/src/stores/previewImageStore.ts
+++ b/src/stores/previewImageStore.ts
@@ -2,22 +2,16 @@ import { defineStore } from "pinia";
 import * as Type from "@/types";
 import config from "@/config";
 import { computed, reactive, watchEffect } from "vue";
-import { isNotNil } from "ramda";
-import invariant from "tiny-invariant";
 import { usePreviewImagesQuery } from "@/queries/usePreviewImagesQuery";
 
 type FileId = Type.UploadWidgetContent["fileId"];
 
 export const usePreviewImageStore = defineStore("previewImages", () => {
   const imageReadyMap = reactive<Map<FileId, boolean>>(new Map());
+  const refCountMap = reactive<Map<FileId, number>>(new Map());
 
   const isImageReady = (fileId: FileId): boolean => {
-    const isReady = imageReadyMap.get(fileId);
-    invariant(
-      isNotNil(isReady),
-      `File ID ${fileId} is not registered in the preview image store.`
-    );
-    return isReady;
+    return imageReadyMap.get(fileId) ?? false;
   };
 
   const getPreviewImageUrl = (fileId: FileId): string => {
@@ -47,12 +41,20 @@ export const usePreviewImageStore = defineStore("previewImages", () => {
   });
 
   const registerFileId = (fileId: string) => {
-    if (imageReadyMap.has(fileId)) return;
-    imageReadyMap.set(fileId, false);
+    refCountMap.set(fileId, (refCountMap.get(fileId) ?? 0) + 1);
+    if (!imageReadyMap.has(fileId)) {
+      imageReadyMap.set(fileId, false);
+    }
   };
 
   const unregisterFileId = (fileId: string) => {
-    imageReadyMap.delete(fileId);
+    const count = refCountMap.get(fileId) ?? 0;
+    if (count <= 1) {
+      refCountMap.delete(fileId);
+      imageReadyMap.delete(fileId);
+    } else {
+      refCountMap.set(fileId, count - 1);
+    }
   };
 
   return {

--- a/src/stores/previewImageStore.ts
+++ b/src/stores/previewImageStore.ts
@@ -42,21 +42,24 @@ export const usePreviewImageStore = defineStore("previewImages", () => {
       });
   });
 
-  const registerFileId = (fileId: string) => {
+  const incrementRefCount = (fileId: FileId) =>
     refCountMap.set(fileId, (refCountMap.get(fileId) ?? 0) + 1);
-    if (!imageReadyMap.has(fileId)) {
-      imageReadyMap.set(fileId, false);
-    }
+
+  const decrementRefCount = (fileId: FileId) => {
+    const next = (refCountMap.get(fileId) ?? 1) - 1;
+    return next <= 0
+      ? refCountMap.delete(fileId)
+      : refCountMap.set(fileId, next);
+  };
+
+  const registerFileId = (fileId: string) => {
+    incrementRefCount(fileId);
+    imageReadyMap.set(fileId, imageReadyMap.get(fileId) ?? false);
   };
 
   const unregisterFileId = (fileId: string) => {
-    const count = refCountMap.get(fileId) ?? 0;
-    if (count <= 1) {
-      refCountMap.delete(fileId);
-      imageReadyMap.delete(fileId);
-    } else {
-      refCountMap.set(fileId, count - 1);
-    }
+    decrementRefCount(fileId);
+    if (!refCountMap.has(fileId)) imageReadyMap.delete(fileId);
   };
 
   return {

--- a/src/stores/previewImageStore.ts
+++ b/src/stores/previewImageStore.ts
@@ -31,17 +31,15 @@ export const usePreviewImageStore = defineStore("previewImages", () => {
 
   const { data: previewResults } = usePreviewImagesQuery(imagesToCheck);
 
-  // Update imageReadyMap when query results change. Guard against late
-  // responses arriving after a fileId has been unregistered — without
-  // this check, a stale response could re-add the fileId and restart polling.
+  // Update imageReadyMap when query results change. Filter out fileIds
+  // that were unregistered while the request was in flight — without
+  // this, a stale response could re-add the fileId and restart polling.
   watchEffect(() => {
-    if (previewResults.value) {
-      previewResults.value.forEach(({ fileId, status }) => {
-        if (refCountMap.has(fileId)) {
-          imageReadyMap.set(fileId, status === "true");
-        }
+    previewResults.value
+      ?.filter(({ fileId }) => refCountMap.has(fileId))
+      .forEach(({ fileId, status }) => {
+        imageReadyMap.set(fileId, status === "true");
       });
-    }
   });
 
   const registerFileId = (fileId: string) => {

--- a/tests/e2e/preview-polling-leak.spec.ts
+++ b/tests/e2e/preview-polling-leak.spec.ts
@@ -73,18 +73,12 @@ test.describe("Preview image polling cleanup", () => {
   test("polling stops after navigating away from asset editor", async ({
     page,
   }) => {
-    test.setTimeout(30_000);
+    test.setTimeout(60_000);
 
     await createAssetWithUploadAndWaitForPolling(page);
 
-    // SPA-navigate away via the logo RouterLink (not page.goto which
-    // does a full reload and destroys the Vue app — that would mask the
-    // bug since the Pinia store only survives SPA navigation).
-    await page.locator(".app-header__logo-link").click();
-    await expect(page).not.toHaveURL(/\/assetManager\/editAsset/);
-
-    // Count any previewImageAvailable requests that occur after navigation.
-    // Wait for 2 full polling cycles — if polling leaked, we'd see requests.
+    // Attach listener before navigation so we don't miss any requests
+    // that fire during or immediately after the route change.
     let postNavRequests = 0;
     page.on("request", (req) => {
       if (req.url().includes("previewImageAvailable")) {
@@ -92,6 +86,17 @@ test.describe("Preview image polling cleanup", () => {
       }
     });
 
+    // SPA-navigate away via the logo RouterLink (not page.goto which
+    // does a full reload and destroys the Vue app — that would mask the
+    // bug since the Pinia store only survives SPA navigation).
+    await page.locator(".app-header__logo-link").click();
+    await expect(page).not.toHaveURL(/\/assetManager\/editAsset/);
+
+    // Reset counter after navigation completes — any request during the
+    // route transition is acceptable; we care about requests after.
+    postNavRequests = 0;
+
+    // Wait for 2 full polling cycles — if polling leaked, we'd see requests.
     await page.waitForTimeout(POLLING_INTERVAL_MS * 2.5);
 
     expect(postNavRequests).toBe(0);
@@ -100,7 +105,7 @@ test.describe("Preview image polling cleanup", () => {
   test("polling resumes after navigating back to the asset", async ({
     page,
   }) => {
-    test.setTimeout(30_000);
+    test.setTimeout(60_000);
 
     const editUrl = await createAssetWithUploadAndWaitForPolling(page);
 

--- a/tests/e2e/preview-polling-leak.spec.ts
+++ b/tests/e2e/preview-polling-leak.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const testFilePath = path.join(testDir, "..", "fixtures", "test-image.jpg");
+
+const POLLING_INTERVAL_MS = 4000;
+
+/**
+ * Creates an asset with an uploaded file and waits until preview image
+ * polling is active. Returns the edit page URL so tests can navigate back.
+ */
+async function createAssetWithUploadAndWaitForPolling(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  const menuToggle = page.getByRole("button", { name: "Toggle main menu" });
+  await menuToggle.click();
+  await page.getByRole("button", { name: "Manage Assets" }).click();
+  await page.getByText("Add Asset").click();
+  await expect(page).toHaveURL(/\/assetManager\/addAsset/);
+
+  const templateSelect = page.getByLabel("Template");
+  await templateSelect.selectOption({ index: 1 });
+  const collectionSelect = page.getByLabel("Collection");
+  await collectionSelect.selectOption({ index: 1 });
+
+  const continueButton = page.getByRole("button", { name: "Continue" });
+  await expect(continueButton).toBeEnabled({ timeout: 5000 });
+  await continueButton.click();
+
+  await expect(
+    page.getByRole("heading", { name: "Create Asset" }),
+  ).toBeVisible();
+
+  await page.getByLabel("Title").first().fill("Polling Leak Test Asset");
+
+  // Start listening for the polling request before upload triggers it
+  const pollingStarted = page.waitForRequest(
+    (req) => req.url().includes("previewImageAvailable"),
+    { timeout: POLLING_INTERVAL_MS * 5 },
+  );
+
+  const fileInput = page.locator('input[type="file"]').first();
+  await fileInput.setInputFiles(testFilePath);
+
+  await expect(page.getByText("test-image.jpg")).toBeVisible({
+    timeout: 15000,
+  });
+
+  // Wait for auto-save redirect to edit page
+  await expect(page).toHaveURL(/\/assetManager\/editAsset\//);
+
+  // Wait for polling to actually start
+  await pollingStarted;
+
+  return page.url();
+}
+
+test.describe("Preview image polling cleanup", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.route("**/arcgis.com/**", (route) => route.abort());
+    await page.route("**/basemaps-api.arcgis.com/**", (route) => route.abort());
+
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+    await page.goto("/");
+  });
+
+  test("polling stops after navigating away from asset editor", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+
+    await createAssetWithUploadAndWaitForPolling(page);
+
+    // SPA-navigate away via the logo RouterLink (not page.goto which
+    // does a full reload and destroys the Vue app — that would mask the
+    // bug since the Pinia store only survives SPA navigation).
+    await page.locator(".app-header__logo-link").click();
+    await expect(page).not.toHaveURL(/\/assetManager\/editAsset/);
+
+    // Count any previewImageAvailable requests that occur after navigation.
+    // Wait for 2 full polling cycles — if polling leaked, we'd see requests.
+    let postNavRequests = 0;
+    page.on("request", (req) => {
+      if (req.url().includes("previewImageAvailable")) {
+        postNavRequests++;
+      }
+    });
+
+    await page.waitForTimeout(POLLING_INTERVAL_MS * 2.5);
+
+    expect(postNavRequests).toBe(0);
+  });
+
+  test("polling resumes after navigating back to the asset", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+
+    const editUrl = await createAssetWithUploadAndWaitForPolling(page);
+
+    // SPA-navigate away
+    await page.locator(".app-header__logo-link").click();
+    await expect(page).not.toHaveURL(/\/assetManager\/editAsset/);
+
+    // Navigate back to the same asset (full navigation is fine here —
+    // we just need to confirm polling starts fresh)
+    await page.goto(editUrl);
+    await expect(page).toHaveURL(/\/assetManager\/editAsset\//);
+
+    // Polling should restart — wait for a previewImageAvailable request
+    const pollingResumed = page.waitForRequest(
+      (req) => req.url().includes("previewImageAvailable"),
+      { timeout: POLLING_INTERVAL_MS * 3 },
+    );
+
+    await expect(pollingResumed).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
- Fixes #480
- Preview image polling now stops when navigating away from the asset editor, instead of continuing indefinitely
- Uses `watch` + `onBeforeUnmount` to unregister fileIds on unmount, with reference counting to handle shared fileIds safely