### PR TITLE
Fix HTML editor modal button overflow

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -199,6 +199,7 @@ onMounted(() => {
     display: flex;
     flex-direction: column;
     flex: 1;
+    min-height: 0;
   }
 
   & .ql-html-textArea.ql-container {
@@ -210,6 +211,8 @@ onMounted(() => {
     height: auto;
     width: auto;
     flex: 1;
+    min-height: 0;
+    overflow: auto;
     border: 1px solid var(--outline);
 
     &:focus-within {


### PR DESCRIPTION
- Fixes #474
- Prevents Cancel and Submit buttons from extending below the HTML editor modal in Custom Pages
- Adds standard flex overflow fixes (`min-height: 0`, `overflow: auto`) to the modal's nested flex containers