### PR TITLE
Fix cascade select click-to-search filter not populating (#495)

### DIFF
--- a/mock-server/db/searches.ts
+++ b/mock-server/db/searches.ts
@@ -4,6 +4,7 @@ import {
   SearchEntry,
   SearchResultMatch,
   SearchSortOptions,
+  SpecificFieldSearchItem,
 } from "../../src/types";
 import { SORT_KEYS } from "../../src/constants/constants";
 import { assetToSearchResultMatch } from "../utils/assetToSearchResultMatch";
@@ -50,7 +51,13 @@ export function createSearchesTable({
     // Table-specific methods
     create: (
       query: string,
-      { totalResultsOverride }: { totalResultsOverride?: number } = {}
+      {
+        totalResultsOverride,
+        specificFieldSearch,
+      }: {
+        totalResultsOverride?: number;
+        specificFieldSearch?: SpecificFieldSearchItem[];
+      } = {}
     ): SearchResultsResponse => {
       const searchId = crypto.randomUUID();
 
@@ -72,9 +79,10 @@ export function createSearchesTable({
         return assetToSearchResultMatch({ asset, collection, template });
       });
 
-      const searchEntry = {
+      const searchEntry: SearchEntry = {
         searchText: query,
         combineSpecificSearches: "OR" as const,
+        ...(specificFieldSearch ? { specificFieldSearch } : {}),
       };
 
       const sortableWidgets = {

--- a/mock-server/routes/instance.ts
+++ b/mock-server/routes/instance.ts
@@ -4,6 +4,7 @@ import type { MockServerContext } from "../types.js";
 import {
   ApiInstanceNavResponse,
   Page,
+  RawSortableField,
   ShowCustomHeaderMode,
 } from "../../src/types";
 import type { MockCustomPage } from "../types";
@@ -59,7 +60,27 @@ app.get("/getInstanceNav", async (c) => {
     contact: instance.ownerHomepage ?? "",
     useCentralAuth: instance.useCentralAuth,
     centralAuthLabel: instance.centralAuthLabel,
-    sortableFields: {}, // not stored in InstanceSettings
+    sortableFields: db.templates
+      .getAll()
+      .flatMap((template) =>
+        template.widgetArray
+          .filter((w) => w.searchable || w.directSearch)
+          .map(
+            (w) =>
+              [
+                w.fieldTitle,
+                {
+                  label: w.label,
+                  template: template.templateId,
+                  type: w.type,
+                } satisfies RawSortableField,
+              ] as const
+          )
+      )
+      .reduce(
+        (acc, [id, field]) => ({ ...acc, [id]: field }),
+        {} as Record<string, RawSortableField>
+      ),
     customHeaderMode: instance.useCustomHeader as ShowCustomHeaderMode,
     customHeaderText: instance.customHeaderText,
     customFooterText: instance.customFooterText,

--- a/mock-server/routes/instance.ts
+++ b/mock-server/routes/instance.ts
@@ -60,27 +60,25 @@ app.get("/getInstanceNav", async (c) => {
     contact: instance.ownerHomepage ?? "",
     useCentralAuth: instance.useCentralAuth,
     centralAuthLabel: instance.centralAuthLabel,
-    sortableFields: db.templates
-      .getAll()
-      .flatMap((template) =>
-        template.widgetArray
-          .filter((w) => w.searchable || w.directSearch)
-          .map(
-            (w) =>
-              [
-                w.fieldTitle,
-                {
-                  label: w.label,
-                  template: template.templateId,
-                  type: w.type,
-                } satisfies RawSortableField,
-              ] as const
-          )
-      )
-      .reduce(
-        (acc, [id, field]) => ({ ...acc, [id]: field }),
-        {} as Record<string, RawSortableField>
-      ),
+    sortableFields: Object.fromEntries(
+      db.templates
+        .getAll()
+        .flatMap((template) =>
+          template.widgetArray
+            .filter((w) => w.searchable || w.directSearch)
+            .map(
+              (w) =>
+                [
+                  w.fieldTitle,
+                  {
+                    label: w.label,
+                    template: template.templateId,
+                    type: w.type,
+                  } satisfies RawSortableField,
+                ] as const
+            )
+        )
+    ) as Record<string, RawSortableField>,
     customHeaderMode: instance.useCustomHeader as ShowCustomHeaderMode,
     customHeaderText: instance.customHeaderText,
     customFooterText: instance.customFooterText,

--- a/mock-server/routes/search.ts
+++ b/mock-server/routes/search.ts
@@ -6,6 +6,7 @@ import {
   type SearchResultsResponse,
 } from "../../src/types";
 import type { MockServerContext } from "../types.js";
+import type { ApiGetMultiSelectFieldInfoResponse } from "../../src/types";
 
 const app = new Hono<MockServerContext>();
 
@@ -135,6 +136,72 @@ app.get("/searchResults/:searchId/:page/:loadAll", async (c) => {
   }
 
   return c.json<SearchResultsResponse>(results);
+});
+
+// GET /search/scopedQuerySearch/:fieldTitle/:value/:json
+app.get("/scopedQuerySearch/:fieldTitle/:value/:json", async (c) => {
+  await delay(200);
+  const db = c.get("db");
+  const fieldTitle = c.req.param("fieldTitle");
+  const value = decodeURIComponent(c.req.param("value"));
+
+  const resultsResponse = db.searches.create(value, {
+    specificFieldSearch: [
+      {
+        field: fieldTitle,
+        text: value,
+        fuzzy: false,
+      },
+    ],
+  });
+
+  return c.json({ searchId: resultsResponse.searchId });
+});
+
+// GET /search/querySearch/:value/:json
+app.get("/querySearch/:value/:json", async (c) => {
+  await delay(200);
+  const db = c.get("db");
+  const value = decodeURIComponent(c.req.param("value"));
+
+  const resultsResponse = db.searches.create(value);
+  return c.json({ searchId: resultsResponse.searchId });
+});
+
+// POST /search/getFieldInfo
+app.post("/getFieldInfo", async (c) => {
+  await delay(100);
+  const db = c.get("db");
+
+  const body = await c.req.formData();
+  const fieldTitle = body.get("fieldTitle") as string;
+  const templateId = Number(body.get("template"));
+
+  const template = db.templates.get(templateId);
+  if (!template) {
+    return c.json({ error: "Template not found" }, 404);
+  }
+
+  const widget = template.widgetArray.find(
+    (w) => w.fieldTitle === fieldTitle
+  );
+
+  if (!widget) {
+    return c.json({ error: "Widget not found" }, 404);
+  }
+
+  if (widget.type === "multiselect") {
+    return c.json<ApiGetMultiSelectFieldInfoResponse>({
+      type: "multiselect",
+      rawContent: widget.fieldData as ApiGetMultiSelectFieldInfoResponse["rawContent"],
+      values: {},
+    });
+  }
+
+  return c.json({
+    type: widget.type,
+    values: widget.fieldData,
+  });
 });
 
 // POST /search/getSuggestion

--- a/mock-server/routes/search.ts
+++ b/mock-server/routes/search.ts
@@ -190,7 +190,12 @@ app.post("/getFieldInfo", async (c) => {
     return c.json({ error: "Widget not found" }, 404);
   }
 
-  if (widget.type === "multiselect") {
+  if (
+    widget.type === "multiselect" &&
+    widget.fieldData &&
+    typeof widget.fieldData === "object" &&
+    !Array.isArray(widget.fieldData)
+  ) {
     return c.json<ApiGetMultiSelectFieldInfoResponse>({
       type: "multiselect",
       rawContent: widget.fieldData as ApiGetMultiSelectFieldInfoResponse["rawContent"],

--- a/mock-server/routes/search.ts
+++ b/mock-server/routes/search.ts
@@ -142,8 +142,11 @@ app.get("/searchResults/:searchId/:page/:loadAll", async (c) => {
 app.get("/scopedQuerySearch/:fieldTitle/:value/:json", async (c) => {
   await delay(200);
   const db = c.get("db");
+  const user = c.get("user");
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
   const fieldTitle = c.req.param("fieldTitle");
-  const value = decodeURIComponent(c.req.param("value"));
+  const value = c.req.param("value");
 
   const resultsResponse = db.searches.create(value, {
     specificFieldSearch: [
@@ -162,7 +165,10 @@ app.get("/scopedQuerySearch/:fieldTitle/:value/:json", async (c) => {
 app.get("/querySearch/:value/:json", async (c) => {
   await delay(200);
   const db = c.get("db");
-  const value = decodeURIComponent(c.req.param("value"));
+  const user = c.get("user");
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const value = c.req.param("value");
 
   const resultsResponse = db.searches.create(value);
   return c.json({ searchId: resultsResponse.searchId });
@@ -172,6 +178,8 @@ app.get("/querySearch/:value/:json", async (c) => {
 app.post("/getFieldInfo", async (c) => {
   await delay(100);
   const db = c.get("db");
+  const user = c.get("user");
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
 
   const body = await c.req.formData();
   const fieldTitle = body.get("fieldTitle") as string;

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -13,7 +13,13 @@
           {{ selected.label }}
         </label>
         <select
-          :class="['rounded-md text-sm', selectClass]"
+          :class="
+            cn([
+              'rounded-md text-sm bg-surface-container text-on-surface-container',
+              !selected.value && 'text-on-surface-variant',
+              selectClass,
+            ])
+          "
           :style="{ width: '100%' }"
           :value="selected.value"
           @change="
@@ -37,8 +43,9 @@
   </div>
 </template>
 <script setup lang="ts">
+import { cn } from "@/lib/utils";
 import { path } from "ramda";
-import { reactive, toRaw, watch } from "vue";
+import { reactive, watch } from "vue";
 
 export interface CascaderSelectOptions {
   [label: string]: string[] | CascaderSelectOptions;

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -227,13 +227,19 @@ const getters = (state: SearchStoreState) => ({
       state.filterBy.specificFieldsMap.values()
     );
 
-    // convert to SpecificFieldSearch shape
+    // convert to SpecificFieldSearch shape, normalizing multiselect
+    // values from internal format (",") back to API format (" : ")
+    const instanceStore = useInstanceStore();
     const specificFieldSearch: SpecificFieldSearchItem[] =
-      searchableFieldsArray.map((filter) => ({
-        field: filter.fieldId,
-        text: filter.value,
-        fuzzy: filter.isFuzzy,
-      }));
+      searchableFieldsArray.map((filter) => {
+        const field = instanceStore.getSearchableField(filter.fieldId);
+        const text =
+          field?.type === "multiselect"
+            ? filter.value.split(",").join(" : ")
+            : filter.value;
+
+        return { field: filter.fieldId, text, fuzzy: filter.isFuzzy };
+      });
 
     const startDateText =
       state.filterBy.globalDateRange?.startDate.toString() ?? "";
@@ -637,8 +643,17 @@ const actions = (state: SearchStoreState) => ({
         }
 
         console.log("adding search entry field", searchField.field);
+
+        // Normalize multiselect (cascade select) values from API format
+        // (" : " separated) to internal format ("," separated)
+        const field = instanceStore.getSearchableField(searchField.field);
+        const value =
+          field?.type === "multiselect"
+            ? searchField.text.split(" : ").join(",")
+            : searchField.text;
+
         actions(state).addSearchableFieldFilter(searchField.field, {
-          value: searchField.text,
+          value,
           isFuzzy: searchField.fuzzy,
         });
       });

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -642,8 +642,6 @@ const actions = (state: SearchStoreState) => ({
           return;
         }
 
-        console.log("adding search entry field", searchField.field);
-
         // Normalize multiselect (cascade select) values from API format
         // (" : " separated) to internal format ("," separated)
         const field = instanceStore.getSearchableField(searchField.field);

--- a/tests/e2e/click-to-search-cascade.spec.ts
+++ b/tests/e2e/click-to-search-cascade.spec.ts
@@ -12,8 +12,8 @@ test.describe("Click-to-Search Cascade Select Filter (#495)", () => {
   test("field-specific click-to-search populates advanced filter cascade dropdowns", async ({
     page,
   }) => {
-    // Navigate to the pre-seeded "All Fields Asset" which has cascade select data:
-    // { country: "usa", stateorprovince: "minnesota", city: "St. Paul", neighborhood: "Summit Hill" }
+    // Pre-seeded "All Fields Asset" from mock-server/db/assets.ts
+    // Has cascade select data: { country: "usa", stateorprovince: "minnesota", city: "St. Paul", neighborhood: "Summit Hill" }
     const existingAssetId = "687969fd9c90c709c1021d01";
     await page.goto(`/asset/viewAsset/${existingAssetId}`);
     await page.waitForLoadState("networkidle");

--- a/tests/e2e/click-to-search-cascade.spec.ts
+++ b/tests/e2e/click-to-search-cascade.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
+
+test.describe("Click-to-Search Cascade Select Filter (#495)", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+  });
+
+  test("field-specific click-to-search populates advanced filter cascade dropdowns", async ({
+    page,
+  }) => {
+    // Navigate to the pre-seeded "All Fields Asset" which has cascade select data:
+    // { country: "usa", stateorprovince: "minnesota", city: "St. Paul", neighborhood: "Summit Hill" }
+    const existingAssetId = "687969fd9c90c709c1021d01";
+    await page.goto(`/asset/viewAsset/${existingAssetId}`);
+    await page.waitForLoadState("networkidle");
+
+    // The cascade select widget (fieldTitle: cascadeselect_1, clickToSearchType: 1)
+    // renders values as clickable links: usa : minnesota : St. Paul : Summit Hill
+    // Click "minnesota" which should trigger a scoped search for "usa : minnesota"
+    const minnesotaLink = page.getByRole("link", { name: "minnesota" });
+    await expect(minnesotaLink).toBeVisible();
+    await minnesotaLink.click();
+
+    // Should navigate to search results page
+    await expect(page).toHaveURL(/\/search\/s\//);
+
+    // Open the advanced search panel
+    const advancedSearchTrigger = page.getByRole("button", {
+      name: /advanced/i,
+    });
+
+    // The filter badge or advanced search should indicate a filter is active
+    // Open the advanced search form to inspect the filter
+    const advancedForm = page.locator(".advanced-search-form");
+    if (!(await advancedForm.isVisible())) {
+      await advancedSearchTrigger.click();
+      await expect(advancedForm).toBeVisible();
+    }
+
+    // The cascade select field should be selected in the filter row
+    const filterFieldSelect = advancedForm.locator(
+      ".filter-row__name"
+    );
+    await expect(filterFieldSelect).toBeVisible();
+
+    // Verify the cascade select dropdowns are populated with correct values
+    // The clicked value was "minnesota" which sends "usa : minnesota" as the search text
+    // After normalization, the dropdowns should show: country=usa, State or Province=minnesota
+    const cascadeSelect = advancedForm.locator(".cascade-select");
+    await expect(cascadeSelect).toBeVisible();
+
+    // First dropdown (Country) should have "usa" selected
+    const countrySelect = cascadeSelect.getByLabel("country");
+    await expect(countrySelect).toBeVisible();
+    await expect(countrySelect).toHaveValue("usa");
+
+    // Second dropdown (State or Province) should have "minnesota" selected
+    const stateSelect = cascadeSelect.getByLabel("State or Province");
+    await expect(stateSelect).toBeVisible();
+    await expect(stateSelect).toHaveValue("minnesota");
+  });
+});

--- a/tests/e2e/click-to-search-cascade.spec.ts
+++ b/tests/e2e/click-to-search-cascade.spec.ts
@@ -43,9 +43,10 @@ test.describe("Click-to-Search Cascade Select Filter (#495)", () => {
 
     // The cascade select field should be selected in the filter row
     const filterFieldSelect = advancedForm.locator(
-      ".filter-row__name"
+      "select.filter-row__name"
     );
     await expect(filterFieldSelect).toBeVisible();
+    await expect(filterFieldSelect).toHaveValue("cascadeselect_1");
 
     // Verify the cascade select dropdowns are populated with correct values
     // The clicked value was "minnesota" which sends "usa : minnesota" as the search text
@@ -53,14 +54,13 @@ test.describe("Click-to-Search Cascade Select Filter (#495)", () => {
     const cascadeSelect = advancedForm.locator(".cascade-select");
     await expect(cascadeSelect).toBeVisible();
 
+    // The cascade dropdowns render with sr-only labels, so locate by role
+    const cascadeDropdowns = cascadeSelect.locator("select");
+
     // First dropdown (Country) should have "usa" selected
-    const countrySelect = cascadeSelect.getByLabel("country");
-    await expect(countrySelect).toBeVisible();
-    await expect(countrySelect).toHaveValue("usa");
+    await expect(cascadeDropdowns.nth(0)).toHaveValue("usa");
 
     // Second dropdown (State or Province) should have "minnesota" selected
-    const stateSelect = cascadeSelect.getByLabel("State or Province");
-    await expect(stateSelect).toBeVisible();
-    await expect(stateSelect).toHaveValue("minnesota");
+    await expect(cascadeDropdowns.nth(1)).toHaveValue("minnesota");
   });
 });

--- a/tests/e2e/click-to-search-cascade.spec.ts
+++ b/tests/e2e/click-to-search-cascade.spec.ts
@@ -28,13 +28,12 @@ test.describe("Click-to-Search Cascade Select Filter (#495)", () => {
     // Should navigate to search results page
     await expect(page).toHaveURL(/\/search\/s\//);
 
-    // Open the advanced search panel
+    // Open the advanced search panel. When filters are active, the
+    // "Advanced Search" button is replaced by a filter-count button.
     const advancedSearchTrigger = page.getByRole("button", {
-      name: /advanced/i,
+      name: /advanced|\d+\s+filters?/i,
     });
 
-    // The filter badge or advanced search should indicate a filter is active
-    // Open the advanced search form to inspect the filter
     const advancedForm = page.locator(".advanced-search-form");
     if (!(await advancedForm.isVisible())) {
       await advancedSearchTrigger.click();


### PR DESCRIPTION
- Fixes #495
- Normalizes cascade select filter values between API format (` : ` separated) and internal format (`,` separated) at the store boundary
- Adds mock server infrastructure: `sortableFields`, `scopedQuerySearch`, `querySearch`, and `getFieldInfo` endpoints