### PR TITLE
Fix login redirect when deep-linking to a protected asset

### DIFF
--- a/mock-server/db/assets.ts
+++ b/mock-server/db/assets.ts
@@ -54,7 +54,7 @@ const baseAsset: WithMeta<Asset> = {
   titleObject: "title_1",
 };
 
-const generateMockAssets = (count = 100): Asset[] => {
+const generateMockAssets = (count = 100): WithMeta<Asset>[] => {
   const assets: Asset[] = [];
   const fileTypes = ["txt", "pdf", "docx", "jpg", "png", "mp4", "wav"];
 
@@ -114,7 +114,7 @@ const generateMockAssets = (count = 100): Asset[] => {
 };
 
 // Assets with location + date data for map/timeline/drawer share testing
-const locationAssetSeeds: Asset[] = [
+const locationAssetSeeds: WithMeta<Asset>[] = [
   {
     ...baseAsset,
     title_1: [

--- a/mock-server/db/assets.ts
+++ b/mock-server/db/assets.ts
@@ -3,8 +3,10 @@ import { assetToSearchResultMatch } from "../utils/index";
 import { createBaseTable } from "./baseTable";
 import type { CollectionsTable } from "./collections";
 import type { TemplatesTable } from "./templates";
+import type { WithMeta } from "../types";
 
-const baseAsset: Asset = {
+const baseAsset: WithMeta<Asset> = {
+  _meta: { visibility: "public" },
   title_1: [
     {
       isPrimary: false,
@@ -203,7 +205,7 @@ const locationAssetSeeds: Asset[] = [
 
 export const LOCATION_ASSET_IDS = locationAssetSeeds.map((a) => a.assetId);
 
-const assetSeeds: Asset[] = [
+const assetSeeds: WithMeta<Asset>[] = [
   ...locationAssetSeeds,
   baseAsset,
   // Asset with broken template for error boundary testing
@@ -306,6 +308,23 @@ const assetSeeds: Asset[] = [
       timezone: "UTC",
     },
   },
+  // Auth-required asset for testing 401 / login-redirect flows
+  {
+    ...baseAsset,
+    title_1: [{ isPrimary: false, fieldContents: "Protected Asset" }],
+    assetId: "protected_asset_001",
+    firstFileHandlerId: "handler_protected_001",
+    title: ["Protected Asset"],
+    templateId: 1,
+    collectionId: 1,
+    modifiedBy: 1,
+    modified: {
+      date: "2026-04-01 12:00:00.000000",
+      timezone_type: 3,
+      timezone: "UTC",
+    },
+    _meta: { visibility: "authenticated" },
+  },
   // Soft-deleted assets for trash tab testing
   {
     ...baseAsset,
@@ -375,7 +394,7 @@ export function createAssetsTable({
   templates: TemplatesTable;
 }) {
   const baseTable = createBaseTable(
-    (asset: Asset) => asset.assetId,
+    (asset: WithMeta<Asset>) => asset.assetId,
     assetSeeds
   );
 

--- a/mock-server/routes/assets.ts
+++ b/mock-server/routes/assets.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { parseFormData, delay } from "../utils/index";
+import { parseFormData, delay, stripMeta } from "../utils/index";
 import { MockServerContext, type AssetFormData } from "../types";
 import { Asset, TextWidgetContent, UploadWidgetContent } from "../../src/types";
 import type { DB } from "../db/index";
@@ -16,6 +16,11 @@ app.get("/viewAsset/:assetId/true", async (c) => {
   if (!asset) {
     return c.json({ error: "Asset not found" }, 404);
   }
+
+  if (asset._meta?.visibility === "authenticated" && !c.get("user")) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
   if (asset.deleted === true) {
     return c.json(
       {
@@ -28,7 +33,7 @@ app.get("/viewAsset/:assetId/true", async (c) => {
       { "Cache-Control": "no-store" }
     );
   }
-  return c.json(asset);
+  return c.json(stripMeta(asset));
 });
 
 // DELETE /assetManager/deleteAsset/:assetId/true

--- a/mock-server/routes/collections.ts
+++ b/mock-server/routes/collections.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono";
+import { delay } from "../utils/index";
+import { MockServerContext } from "../types";
+
+const app = new Hono<MockServerContext>();
+
+// GET /collections/collectionHeader/:collectionId/true
+app.get("/collectionHeader/:collectionId/true", async (c) => {
+  await delay(100);
+  const db = c.get("db");
+  const collectionId = Number(c.req.param("collectionId"));
+  const collection = db.collections.get(collectionId);
+
+  if (!collection) {
+    return c.json({ error: "Collection not found" }, 404);
+  }
+
+  return c.json({
+    collectionDescription: "",
+    collectionTitle: collection.title,
+  });
+});
+
+export default app;

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -8,6 +8,7 @@ import type { MockServerContext } from "./types";
 import { db, getOrCreateWorkerDb } from "./db/index";
 
 import assetRoutes from "./routes/assets";
+import collectionRoutes from "./routes/collections";
 import searchRoutes from "./routes/search";
 import drawerRoutes from "./routes/drawers";
 import authRoutes from "./routes/auth";
@@ -81,6 +82,7 @@ app.use("*", async (c, next) => {
 
 // Routes - defaultinstance prefix to match real API structure
 app.route("/defaultinstance/asset", assetRoutes);
+app.route("/defaultinstance/collections", collectionRoutes);
 app.route("/defaultinstance/search", searchRoutes);
 app.route("/defaultinstance/drawers", drawerRoutes);
 app.route("/defaultinstance/loginManager", authRoutes);

--- a/mock-server/types.ts
+++ b/mock-server/types.ts
@@ -38,6 +38,18 @@ export interface FileFormData {
   [key: string]: unknown;
 }
 
+/**
+ * Internal metadata attached to mock objects. Stripped before sending
+ * to the client — the frontend never sees this, mirroring how a real
+ * backend enforces permissions server-side.
+ */
+export interface MockMeta {
+  visibility: "public" | "authenticated";
+}
+
+/** Attach _meta to any mock object type. */
+export type WithMeta<T> = T & { _meta?: MockMeta };
+
 export interface MockServerContext {
   Variables: {
     user: MockUser | null;

--- a/mock-server/utils/index.ts
+++ b/mock-server/utils/index.ts
@@ -2,3 +2,4 @@ export { delay } from "./delay";
 export { parseFormData } from "./parseFormData";
 export { assetToSearchResultMatch } from "./assetToSearchResultMatch";
 export { makeSimpleSVG } from "./makeSimpleSVG";
+export { stripMeta } from "./stripMeta";

--- a/mock-server/utils/stripMeta.ts
+++ b/mock-server/utils/stripMeta.ts
@@ -1,0 +1,7 @@
+/** Remove `_meta` before sending mock objects to the client. */
+export function stripMeta<T extends Record<string, unknown>>(
+  obj: T
+): Omit<T, "_meta"> {
+  const { _meta, ...rest } = obj;
+  return rest as Omit<T, "_meta">;
+}

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -81,7 +81,11 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
     apiError = new ApiError(err.message, 0); // Use 0 as the status code to signal a network error.
   }
 
-  if (!customConfig.skipErrorNotifications && apiError.statusCode !== 410) {
+  if (
+    !customConfig.skipErrorNotifications &&
+    apiError.statusCode !== 401 &&
+    apiError.statusCode !== 410
+  ) {
     // Add the ApiError to the errorStore
     errorStore.setError(apiError);
   }

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -30,9 +30,6 @@ import SignInRequiredNotice from "@/pages/HomePage/SignInRequiredNotice.vue";
 const errorStore = useErrorStore();
 
 const error = computed(() => errorStore.error);
-const isCurrentUserUnauthenticated = computed(() => {
-  return error.value instanceof ApiError && error.value.statusCode === 401;
-});
 const errorTitle = computed(() => {
   if (!(error.value instanceof ApiError)) {
     return "Error";
@@ -43,6 +40,9 @@ const errorTitle = computed(() => {
   }
 
   return `Error: ${error.value.statusCode}`;
+});
+const isCurrentUserUnauthenticated = computed(() => {
+  return error.value instanceof ApiError && error.value.statusCode === 401;
 });
 
 const messages: Record<number | string, string> = {

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -30,6 +30,9 @@ import SignInRequiredNotice from "@/pages/HomePage/SignInRequiredNotice.vue";
 const errorStore = useErrorStore();
 
 const error = computed(() => errorStore.error);
+const isCurrentUserUnauthenticated = computed(() => {
+  return error.value instanceof ApiError && error.value.statusCode === 401;
+});
 const errorTitle = computed(() => {
   if (!(error.value instanceof ApiError)) {
     return "Error";
@@ -40,9 +43,6 @@ const errorTitle = computed(() => {
   }
 
   return `Error: ${error.value.statusCode}`;
-});
-const isCurrentUserUnauthenticated = computed(() => {
-  return error.value instanceof ApiError && error.value.statusCode === 401;
 });
 
 const messages: Record<number | string, string> = {

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -4,8 +4,9 @@
       <PrevNextSearchResultNav />
     </template>
     <template v-if="isPageLoaded">
+      <SignInRequiredNotice v-if="requiresAuth" />
       <DeletedAssetNotice
-        v-if="deletedAssetInfo"
+        v-else-if="deletedAssetInfo"
         :assetId="props.assetId"
         :deletedAt="deletedAssetInfo.deletedAt"
         @restored="handleRestored" />
@@ -30,13 +31,17 @@ import DeletedAssetNotice from "./DeletedAssetNotice.vue";
 import { getAssetTitle } from "@/helpers/displayUtils";
 import { usePageTitle } from "@/helpers/usePageTitle";
 import PrevNextSearchResultNav from "@/components/PrevNextSearchResultNav/PrevNextSearchResultNav.vue";
+import SignInRequiredNotice from "@/pages/HomePage/SignInRequiredNotice.vue";
 import { striptags } from "striptags";
 import { ApiError } from "@/api/ApiError";
+import { useErrorStore } from "@/stores/errorStore";
 import type { DeletedAssetInfo } from "@/types";
 
 const assetStore = useAssetStore();
+const errorStore = useErrorStore();
 const isMetaDataOnly = computed(() => !assetStore.activeFileObjectId);
 const isPageLoaded = ref(false);
+const requiresAuth = ref(false);
 const route = useRoute();
 const props = withDefaults(
   defineProps<{
@@ -61,6 +66,7 @@ async function onAssetIdChange() {
   // `metadata-only-page` or a `asset-with-viewer-page`
   isPageLoaded.value = false;
   deletedAssetInfo.value = null;
+  requiresAuth.value = false;
 
   try {
     const asset = await assetStore.setActiveAsset(
@@ -83,9 +89,11 @@ async function onAssetIdChange() {
       deletedAssetInfo.value = err.data as DeletedAssetInfo;
       pageTitle.value = "Deleted asset";
     } else if (err instanceof ApiError && err.statusCode === 401) {
-      // 401s are handled by the global error interceptor → ErrorModal →
-      // SignInRequiredNotice. Don't re-throw or ErrorBoundary will also
-      // catch it and replace the page with a generic error.
+      // Handle 401 inline instead of letting ErrorModal show a modal
+      // with the asset page visible behind a scrim.
+      requiresAuth.value = true;
+      errorStore.clearError();
+      assetStore.setActiveAsset(null);
       isPageLoaded.value = true;
       return;
     } else {

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -34,11 +34,9 @@ import PrevNextSearchResultNav from "@/components/PrevNextSearchResultNav/PrevNe
 import SignInRequiredNotice from "@/pages/HomePage/SignInRequiredNotice.vue";
 import { striptags } from "striptags";
 import { ApiError } from "@/api/ApiError";
-import { useErrorStore } from "@/stores/errorStore";
 import type { DeletedAssetInfo } from "@/types";
 
 const assetStore = useAssetStore();
-const errorStore = useErrorStore();
 const isMetaDataOnly = computed(() => !assetStore.activeFileObjectId);
 const isPageLoaded = ref(false);
 const requiresAuth = ref(false);
@@ -92,7 +90,6 @@ async function onAssetIdChange() {
       // Handle 401 inline instead of letting ErrorModal show a modal
       // with the asset page visible behind a scrim.
       requiresAuth.value = true;
-      errorStore.clearError();
       assetStore.setActiveAsset(null);
       isPageLoaded.value = true;
       return;

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -86,6 +86,7 @@ async function onAssetIdChange() {
       // 401s are handled by the global error interceptor → ErrorModal →
       // SignInRequiredNotice. Don't re-throw or ErrorBoundary will also
       // catch it and replace the page with a generic error.
+      isPageLoaded.value = true;
       return;
     } else {
       throw err;

--- a/src/pages/AssetViewPage/AssetViewPage.vue
+++ b/src/pages/AssetViewPage/AssetViewPage.vue
@@ -82,6 +82,11 @@ async function onAssetIdChange() {
     if (err instanceof ApiError && err.statusCode === 410) {
       deletedAssetInfo.value = err.data as DeletedAssetInfo;
       pageTitle.value = "Deleted asset";
+    } else if (err instanceof ApiError && err.statusCode === 401) {
+      // 401s are handled by the global error interceptor → ErrorModal →
+      // SignInRequiredNotice. Don't re-throw or ErrorBoundary will also
+      // catch it and replace the page with a generic error.
+      return;
     } else {
       throw err;
     }

--- a/src/pages/HomePage/SignInRequiredNotice.vue
+++ b/src/pages/HomePage/SignInRequiredNotice.vue
@@ -9,9 +9,9 @@
 
     <div class="flex gap-2">
       <Button
-        :to="`/loginManager/localLogin/?redirect=${$route.path}`"
         class="sign-in-required__local-login"
-        variant="primary">
+        variant="primary"
+        @click="goToLocalLogin">
         <span v-if="instance.useCentralAuth" class="guest-auth-label">
           <!--
           The label for the guest login option can be customized via the `--guest-auth-label` CSS variable. If not set, it will default to "Guest". Eventually, this could become an explicit instance setting.
@@ -31,18 +31,35 @@
 <script setup lang="ts">
 import { useBrowserLocation } from "@vueuse/core";
 import { useInstanceStore } from "@/stores/instanceStore";
+import { useErrorStore } from "@/stores/errorStore";
 import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import config from "@/config";
 import Notification from "@/components/Notification/Notification.vue";
 import Button from "@/components/Button/Button.vue";
 
 const instanceStore = useInstanceStore();
+const errorStore = useErrorStore();
+const router = useRouter();
+const route = useRoute();
 const instance = computed(() => instanceStore.instance);
 const browserLocation = useBrowserLocation();
 const encodedCallbackUrl = computed(() => {
   const callbackUrl = browserLocation.value?.href ?? config.instance.base.url;
   return encodeURIComponent(callbackUrl);
 });
+
+function goToLocalLogin() {
+  // Clear the error first so the ErrorModal unmounts cleanly,
+  // then navigate. Previously this was a RouterLink, but the
+  // router's beforeResolve guard cleared the error mid-navigation,
+  // destroying the modal (and its RouterLink) before navigation completed.
+  errorStore.clearError();
+  router.push({
+    path: "/loginManager/localLogin",
+    query: { redirect: route.path },
+  });
+}
 </script>
 <style scoped>
 .guest-auth-label::before {

--- a/src/pages/HomePage/SignInRequiredNotice.vue
+++ b/src/pages/HomePage/SignInRequiredNotice.vue
@@ -57,7 +57,7 @@ function goToLocalLogin() {
   errorStore.clearError();
   router.push({
     path: "/loginManager/localLogin",
-    query: { redirect: route.path },
+    query: { redirect: route.fullPath },
   });
 }
 </script>

--- a/tests/e2e/login-deep-link.spec.ts
+++ b/tests/e2e/login-deep-link.spec.ts
@@ -18,7 +18,9 @@ test.describe("Login deep link — protected asset", () => {
     await page.goto(`/asset/viewAsset/${PROTECTED_ASSET_ID}`);
 
     await expect(
-      page.getByRole("heading", { name: "Sign In Required" })
+      page
+        .locator(".asset-view-page")
+        .getByRole("heading", { name: "Sign In Required" })
     ).toBeVisible();
   });
 
@@ -30,11 +32,15 @@ test.describe("Login deep link — protected asset", () => {
 
     // 2. Sign-in notice appears
     await expect(
-      page.getByRole("heading", { name: "Sign In Required" })
+      page
+        .locator(".asset-view-page")
+        .getByRole("heading", { name: "Sign In Required" })
     ).toBeVisible();
 
     // 3. Click the guest Login button
-    await page.locator(".sign-in-required__local-login").click();
+    await page
+      .locator(".asset-view-page .sign-in-required__local-login")
+      .click();
 
     // 4. Should be on the local login page with redirect param
     await expect(page).toHaveURL(

--- a/tests/e2e/login-deep-link.spec.ts
+++ b/tests/e2e/login-deep-link.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase } from "../setup";
+
+const PROTECTED_ASSET_ID = "protected_asset_001";
+
+test.describe("Login deep link — protected asset", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+
+    // Deliberately NOT logging in — user is unauthenticated
+  });
+
+  test("navigating to a protected asset shows sign-in modal", async ({
+    page,
+  }) => {
+    await page.goto(`/asset/viewAsset/${PROTECTED_ASSET_ID}`);
+
+    await expect(
+      page.getByRole("heading", { name: "Sign In Required" })
+    ).toBeVisible();
+  });
+
+  test("guest login from deep link redirects to the protected asset", async ({
+    page,
+  }) => {
+    // 1. Navigate to protected asset while unauthenticated
+    await page.goto(`/asset/viewAsset/${PROTECTED_ASSET_ID}`);
+
+    // 2. Sign-in modal appears
+    await expect(
+      page.getByRole("heading", { name: "Sign In Required" })
+    ).toBeVisible();
+
+    // 3. Click the guest Login button in the modal
+    await page.locator(".sign-in-required__local-login").click();
+
+    // 4. Should be on the local login page with redirect param
+    await expect(page).toHaveURL(
+      /loginManager\/localLogin.*redirect.*protected_asset_001/
+    );
+
+    // 5. Fill in guest credentials and submit
+    await page.getByLabel("Username").fill("user");
+    await page.getByLabel("Password").fill("user");
+    await page.getByRole("button", { name: "Login" }).click();
+
+    // 6. Should redirect to the protected asset and render it
+    await expect(page).toHaveURL(
+      new RegExp(`asset/viewAsset/${PROTECTED_ASSET_ID}`)
+    );
+    await expect(page.getByText("Protected Asset")).toBeVisible();
+  });
+});

--- a/tests/e2e/login-deep-link.spec.ts
+++ b/tests/e2e/login-deep-link.spec.ts
@@ -12,7 +12,7 @@ test.describe("Login deep link — protected asset", () => {
     // Deliberately NOT logging in — user is unauthenticated
   });
 
-  test("navigating to a protected asset shows sign-in modal", async ({
+  test("navigating to a protected asset shows sign-in notice", async ({
     page,
   }) => {
     await page.goto(`/asset/viewAsset/${PROTECTED_ASSET_ID}`);
@@ -28,12 +28,12 @@ test.describe("Login deep link — protected asset", () => {
     // 1. Navigate to protected asset while unauthenticated
     await page.goto(`/asset/viewAsset/${PROTECTED_ASSET_ID}`);
 
-    // 2. Sign-in modal appears
+    // 2. Sign-in notice appears
     await expect(
       page.getByRole("heading", { name: "Sign In Required" })
     ).toBeVisible();
 
-    // 3. Click the guest Login button in the modal
+    // 3. Click the guest Login button
     await page.locator(".sign-in-required__local-login").click();
 
     // 4. Should be on the local login page with redirect param
@@ -44,7 +44,7 @@ test.describe("Login deep link — protected asset", () => {
     // 5. Fill in guest credentials and submit
     await page.getByLabel("Username").fill("user");
     await page.getByLabel("Password").fill("user");
-    await page.getByRole("button", { name: "Login" }).click();
+    await page.locator('button[type="submit"]').click();
 
     // 6. Should redirect to the protected asset and render it
     await expect(page).toHaveURL(


### PR DESCRIPTION
- Fixes #522
- Unauthenticated users visiting a protected asset can now log in and get redirected back to the asset.
- Login notifcation appears directly on page, not in modal.
- Removes background 401 error.
- Add tests for the permissions issue.

Tricky bug.

When a 401 would happen, the page would look something like this.

```
<Page>
  <ErrorModal>
      <LoginNotification>
           <RouterLink :to="/login">Login</RouterLink>
      </LoginNotification>           
   </ErrorModal>
</Page>
```

Notice that the `<RouterLink>` button is **inside** the `<ErrorModal>`.

Then:
1. user clicks <RouterLink>
2. vue router invokes `beforeResolve()` hook
3. **beforeResolve() runs `errorStore.clearError()`** This is done so that errors don't persist across page navigations.
4. Vue does a DOM update. Now that the error is clear `<ErrorModal>` is torn down... and with it the `<LoginNotification>` and `<RouterLink>`.
5. After RouterLink is torn down, the route never resolves to the correct page.


###  Fixes

- We change to render the login notifcation directly on the asset page, not in the error modal to avoid the tear down. That should fix _this_ particular issue.
- BUT, I'm pretty sure other pages rely on the 401 modal (e.g. a user's auth expires). So, we also change from  `<RouterLink :to="...">` to `<Button @click="goToLocalLogin">`. The`goToLocalLogin()` does a `router.push()` to the page. Vue doesn't update the DOM until functions complete, so we're guaranteed that the redirect will resolve correctly before the component is torn down. We could have also cleared the Error on `nextTick()` I think.


