### PR TITLE
add more error boundaries

### DIFF
--- a/src/components/AssetDetailsPanel/AssetDetailsPanel.vue
+++ b/src/components/AssetDetailsPanel/AssetDetailsPanel.vue
@@ -32,7 +32,9 @@
         <Tuple v-if="showTemplateTop" label="Template">
           {{ template.templateName }}
         </Tuple>
-        <WidgetList :assetId="assetId" class="py-4 md:py-0" />
+        <ErrorBoundary>
+          <WidgetList :assetId="assetId" class="py-4 md:py-0" />
+        </ErrorBoundary>
         <CollectionTuple
           v-if="showCollectionBottom"
           :collectionId="asset.collectionId"
@@ -65,6 +67,7 @@ import { useInstanceStore } from "@/stores/instanceStore";
 import { PencilIcon } from "lucide-vue-next";
 import IconButton from "../IconButton/IconButton.vue";
 import Link from "../Link/Link.vue";
+import ErrorBoundary from "../ErrorBoundary/ErrorBoundary.vue";
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/Widget/Widget.vue
+++ b/src/components/Widget/Widget.vue
@@ -1,18 +1,37 @@
 <template>
-  <component
-    :is="getWidgetComponentByType(widget.type)"
-    v-if="['upload'].includes(widget.type)"
-    :widget="widget"
-    :contents="widgetContents"
-    :asset="asset"></component>
-  <Tuple v-else :label="widget.label" class="widget">
+  <ErrorBoundary>
+    <template #fallback>
+      <div class="p-4 bg-error-container border border-error rounded-md">
+        <h3 class="text-sm text-error font-bold mb-2">Widget Error</h3>
+        <p class="text-sm text-error/90">
+          An error occurred while rendering this widget.
+          <a
+            :href="`${
+              instanceStore.instance.contact || 'mailto:latistecharch@umn.edu'
+            }`"
+            target="_blank"
+            rel="noopener noreferrer">
+            Contact your administrator
+          </a>
+          for assistance.
+        </p>
+      </div>
+    </template>
     <component
       :is="getWidgetComponentByType(widget.type)"
-      v-if="getWidgetComponentByType(widget.type)"
+      v-if="['upload'].includes(widget.type)"
       :widget="widget"
       :contents="widgetContents"
       :asset="asset"></component>
-  </Tuple>
+    <Tuple v-else :label="widget.label" class="widget">
+      <component
+        :is="getWidgetComponentByType(widget.type)"
+        v-if="getWidgetComponentByType(widget.type)"
+        :widget="widget"
+        :contents="widgetContents"
+        :asset="asset"></component>
+    </Tuple>
+  </ErrorBoundary>
 </template>
 <script setup lang="ts">
 import { type Component, computed } from "vue";
@@ -30,11 +49,15 @@ import UploadWidget from "@/components/Widget/UploadWidget/UploadWidget.vue";
 import TagWidget from "@/components/Widget/TagWidget/TagWidget.vue";
 import RelatedAssetWidget from "@/components/Widget/RelatedAssetWidget/RelatedAssetWidget.vue";
 import { getWidgetContents } from "@/helpers/displayUtils";
+import ErrorBoundary from "../ErrorBoundary/ErrorBoundary.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
 
 const props = defineProps<{
   widget: WidgetDef;
   asset: Asset | UnsavedAsset;
 }>();
+
+const instanceStore = useInstanceStore();
 
 const widgetContents = computed(() =>
   getWidgetContents({ asset: props.asset, widget: props.widget })

--- a/src/pages/AssetViewPage/AssetView.vue
+++ b/src/pages/AssetViewPage/AssetView.vue
@@ -1,21 +1,23 @@
 <template>
   <div class="asset-view-page__asset-view md:h-full relative pb-16 md:pb-0">
-    <ObjectViewer
-      class="asset-view__object-viewer min-h-[50dvh] md:min-h-0 md:absolute md:top-0 border-t-0 border-b-asset-view"
-      :class="{
-        'md:top-0 md:bottom-1/2 md:left-sm md:right-0 border-l-asset-view':
-          isAssetDetailsOpen && isObjectDetailsOpen, // both open
-        'md:top-0 md:bottom-16 md:left-sm md:right-0 border-l-asset-view':
-          isAssetDetailsOpen && !isObjectDetailsOpen, // just asset details
+    <ErrorBoundary>
+      <ObjectViewer
+        class="asset-view__object-viewer min-h-[50dvh] md:min-h-0 md:absolute md:top-0 border-t-0 border-b-asset-view"
+        :class="{
+          'md:top-0 md:bottom-1/2 md:left-sm md:right-0 border-l-asset-view':
+            isAssetDetailsOpen && isObjectDetailsOpen, // both open
+          'md:top-0 md:bottom-16 md:left-sm md:right-0 border-l-asset-view':
+            isAssetDetailsOpen && !isObjectDetailsOpen, // just asset details
 
-        'md:top-0 md:bottom-16 md:left-0 md:right-sm border-r-asset-view':
-          !isAssetDetailsOpen && isObjectDetailsOpen, // just object details
-        'md:top-0 md:bottom-16 md:left-0 md:right-0':
-          !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
-      }"
-      :fileHandlerId="assetStore.activeFileObjectId"
-      :parentAssetId="assetStore.activeAssetId"
-      :title="iframeTitle" />
+          'md:top-0 md:bottom-16 md:left-0 md:right-sm border-r-asset-view':
+            !isAssetDetailsOpen && isObjectDetailsOpen, // just object details
+          'md:top-0 md:bottom-16 md:left-0 md:right-0':
+            !isAssetDetailsOpen && !isObjectDetailsOpen, // neither open
+        }"
+        :fileHandlerId="assetStore.activeFileObjectId"
+        :parentAssetId="assetStore.activeAssetId"
+        :title="iframeTitle" />
+    </ErrorBoundary>
     <!-- render file view toolbar here for mobile
        so it appears below the object viewer. Otherwise it goes
        with the object details panel
@@ -25,41 +27,45 @@
         :fileHandlerId="assetStore.activeFileObjectId"
         :assetId="assetStore.activeObjectId ?? assetId" />
     </div>
-    <AssetDetailsPanel
-      class="asset-view__asset-panel md:absolute"
-      :class="{
-        'asset-view__asset-panel--open': isAssetDetailsOpen,
-        'md:bottom-0 md:left-0 md:top-0 md:w-sm': isAssetDetailsOpen, // both open + asset details open
-        'md:bottom-0 md:left-0 md:h-16 md:right-sm border-r-asset-view':
-          !isAssetDetailsOpen && isObjectDetailsOpen, // just obj panel
-        'md:bottom-0 md:left-0 md:h-16 md:w-1/2':
-          !isAssetDetailsOpen && !isObjectDetailsOpen, //neither open
-      }"
-      :showToggle="permitPanelToggle"
-      :assetId="assetStore.activeAssetId"
-      :parentAssetId="assetStore.activeAssetId"
-      :isOpen="permitPanelToggle ? isAssetDetailsOpen : true"
-      @toggle="isAssetDetailsOpen = !isAssetDetailsOpen" />
-    <ObjectDetailsPanel
-      class="asset-view__details-panel md:absolute"
-      :class="{
-        'asset-view__details-panel--open': isObjectDetailsOpen,
-        'border-l-asset-view': !isObjectDetailsOpen,
-        'md:bottom-0 md:right-0 md:h-16 md:left-sm':
-          !isObjectDetailsOpen && isAssetDetailsOpen, // just asset open
-        'md:bottom-0 md:right-0 md:h-1/2 md:left-sm border-l-asset-view':
-          isObjectDetailsOpen && isAssetDetailsOpen, // both panels open
-        'md:bottom-0 md:right-0 md:top-0 md:w-sm':
-          isObjectDetailsOpen && !isAssetDetailsOpen, // just object open
-        'md:bottom-0 md:right-0 md:h-16 md:w-1/2':
-          !isObjectDetailsOpen && !isAssetDetailsOpen, // neither panels open
-      }"
-      :showToggle="permitPanelToggle"
-      :assetId="assetStore.activeAssetId"
-      :objectId="assetStore.activeObjectId"
-      :fileHandlerId="assetStore.activeFileObjectId"
-      :isOpen="permitPanelToggle ? isObjectDetailsOpen : true"
-      @toggle="isObjectDetailsOpen = !isObjectDetailsOpen" />
+    <ErrorBoundary>
+      <AssetDetailsPanel
+        class="asset-view__asset-panel md:absolute"
+        :class="{
+          'asset-view__asset-panel--open': isAssetDetailsOpen,
+          'md:bottom-0 md:left-0 md:top-0 md:w-sm': isAssetDetailsOpen, // both open + asset details open
+          'md:bottom-0 md:left-0 md:h-16 md:right-sm border-r-asset-view':
+            !isAssetDetailsOpen && isObjectDetailsOpen, // just obj panel
+          'md:bottom-0 md:left-0 md:h-16 md:w-1/2':
+            !isAssetDetailsOpen && !isObjectDetailsOpen, //neither open
+        }"
+        :showToggle="permitPanelToggle"
+        :assetId="assetStore.activeAssetId"
+        :parentAssetId="assetStore.activeAssetId"
+        :isOpen="permitPanelToggle ? isAssetDetailsOpen : true"
+        @toggle="isAssetDetailsOpen = !isAssetDetailsOpen" />
+    </ErrorBoundary>
+    <ErrorBoundary>
+      <ObjectDetailsPanel
+        class="asset-view__details-panel md:absolute"
+        :class="{
+          'asset-view__details-panel--open': isObjectDetailsOpen,
+          'border-l-asset-view': !isObjectDetailsOpen,
+          'md:bottom-0 md:right-0 md:h-16 md:left-sm':
+            !isObjectDetailsOpen && isAssetDetailsOpen, // just asset open
+          'md:bottom-0 md:right-0 md:h-1/2 md:left-sm border-l-asset-view':
+            isObjectDetailsOpen && isAssetDetailsOpen, // both panels open
+          'md:bottom-0 md:right-0 md:top-0 md:w-sm':
+            isObjectDetailsOpen && !isAssetDetailsOpen, // just object open
+          'md:bottom-0 md:right-0 md:h-16 md:w-1/2':
+            !isObjectDetailsOpen && !isAssetDetailsOpen, // neither panels open
+        }"
+        :showToggle="permitPanelToggle"
+        :assetId="assetStore.activeAssetId"
+        :objectId="assetStore.activeObjectId"
+        :fileHandlerId="assetStore.activeFileObjectId"
+        :isOpen="permitPanelToggle ? isObjectDetailsOpen : true"
+        @toggle="isObjectDetailsOpen = !isObjectDetailsOpen" />
+    </ErrorBoundary>
   </div>
 </template>
 <script setup lang="ts">
@@ -70,6 +76,7 @@ import ObjectDetailsPanel from "@/components/ObjectDetailsPanel/ObjectDetailsPan
 import AssetDetailsPanel from "@/components/AssetDetailsPanel/AssetDetailsPanel.vue";
 import ActiveFileViewToolbar from "@/components/ActiveFileViewToolbar/ActiveFileViewToolbar.vue";
 import { useMediaQuery } from "@vueuse/core";
+import ErrorBoundary from "@/components/ErrorBoundary/ErrorBoundary.vue";
 
 defineProps<{
   assetId: string | null;
@@ -84,9 +91,7 @@ const permitPanelToggle = useMediaQuery("(min-width: 768px)");
 
 const iframeTitle = computed(
   () =>
-    assetStore.activeFileDescription ||
-    assetStore.activeTitle ||
-    "Asset viewer"
+    assetStore.activeFileDescription || assetStore.activeTitle || "Asset viewer"
 );
 </script>
 <style scoped lang="postcss">


### PR DESCRIPTION
Adding some more boundaries to contain any errors in widgets/templates:

Before /  After: Note the login bar and title render, but the select widget (which has a template error) renders the fallback message.

<img width="400" alt="ScreenShot 2026-04-08 at 14 57 21" src="https://github.com/user-attachments/assets/cdc693b7-fae5-41e7-9471-2cd6973b2b5b" /> <img width="400" alt="ScreenShot 2026-04-08 at 14 56 59" src="https://github.com/user-attachments/assets/50e4dfa9-e5d4-430f-9ec3-ca2764521b6b" />
