### PR TITLE
Fix sidebar title overflow in template editor (#513)

### DIFF
--- a/src/components/DragDropList/DragDropListItem.vue
+++ b/src/components/DragDropList/DragDropListItem.vue
@@ -334,5 +334,6 @@ onMounted(() => {
 
 .drag-drop-list-item__content {
   flex: 1;
+  min-width: 0;
 }
 </style>


### PR DESCRIPTION
Add min-width: 0 to DragDropListItem content wrapper so flex children can shrink below their content width, allowing text truncation to work.

<img width="400"  alt="CleanShot 2026-04-09 at 10 05 51@2x" src="https://github.com/user-attachments/assets/445679ad-b843-4033-af07-47a46da9205c" />
