### PR TITLE
Show default OS scroll at top level, but keep styled scroll for child components

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -63,22 +63,6 @@ body {
     clip-path: inset(50%);
     white-space: nowrap;
   }
-
-  ::-webkit-scrollbar {
-    width: 0.5rem;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: var(--surface-container);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: var(--outline);
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background: var(--on-surface-variant);
-  }
 }
 
 .prose {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -242,6 +242,32 @@ h6 {
   }
 }
 
+/**
+* We want to avoid users not realizing they can scroll down --
+* especially in the sidepanel on the asset view page. But, we also
+* want to respect OS-level settings to "hide scroll when not in use."
+* This is a compromise: keep page-level scroll as OS defaults,
+* but any child elements (e.g. asset panels, menus) will show
+* the scroll.
+*/
+html > * {
+  & ::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+
+  & ::-webkit-scrollbar-track {
+    background: var(--surface-container);
+  }
+
+  & ::-webkit-scrollbar-thumb {
+    background: var(--outline);
+  }
+
+  & ::-webkit-scrollbar-thumb:hover {
+    background: var(--on-surface-variant);
+  }
+}
+
 /* Unlayered, after @tailwind utilities — source order beats equal-specificity utility classes */
 :disabled,
 [disabled] {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -250,7 +250,7 @@ h6 {
 * but any child elements (e.g. asset panels, menus) will show
 * the scroll.
 */
-html > * {
+html * {
   & ::-webkit-scrollbar {
     width: 0.5rem;
   }


### PR DESCRIPTION
This removes scrollbar formatting so that Colin's scrollbars properly disappear when he's not using them. 😉

Whenever any `::webkit-scrollbar-*` styles are set in CSS, (some) browsers will disabled their own built-in styling and fall back to "classic" scrollbars. See: https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar

I _think_ the original design rationale was there's some features that may hide content unexpectedly if users have disappearing scrollbars. For example, the asset view side panel or search result cards with more content.

https://github.com/user-attachments/assets/61d83729-21da-403d-803e-6aa24acf606b

