### PR TITLE
fix(StaticContentPage): centers page title when no Edit Page btn

### DIFF
--- a/src/pages/StaticContentPage/StaticContentPage.vue
+++ b/src/pages/StaticContentPage/StaticContentPage.vue
@@ -8,16 +8,16 @@
       v-if="page"
       class="static-content-page__content p-4 lg:p-8 mx-auto flex-1 w-full max-w-screen-xl">
       <article class="mx-auto">
-        <header class="flex items-center gap-4 justify-between mb-8">
-          <div />
+        <header class="grid grid-cols-[1fr_auto_1fr] items-center gap-4 mb-8">
           <h1
-            class="static-content-page__page-title text-4xl font-bold text-center">
+            class="static-content-page__page-title col-start-2 text-4xl font-bold text-center">
             {{ page.title || "Untitled" }}
           </h1>
           <Button
             v-if="canCurrentUserEdit"
             :to="`/instances/editPage/${pageId}`"
-            variant="tertiary">
+            variant="tertiary"
+            class="col-start-3 justify-self-end">
             Edit Page
           </Button>
         </header>


### PR DESCRIPTION
This fixes an issue where the page title wouldn't properly center on a static content page. The issue only appeared when the user had no "Edit Page" button.

The problem was that we used `justify-between` to center the page title:
`<div> <PageTitle> <EditButton>`

However, when there's no EditButton, that splits the space between the `<div>` and `<PageTitle>` making it look right justfied.

A better fix is using CSS grid with `grid-template-columns: 1fr auto 1fr`, and start the page title on the second column.

Before:
<img width="400" alt="CleanShot 2026-04-29 at 16 18 25@2x" src="https://github.com/user-attachments/assets/ef19e777-7809-4f7c-938a-ea183097bceb" />

After:
<img width="400" alt="CleanShot 2026-04-29 at 16 17 47@2x" src="https://github.com/user-attachments/assets/3b487f04-7724-4b3d-8609-47ff62a3de70" />
