### PR TITLE
fix: search results map show NaN error when no results

### DIFF
--- a/src/components/SearchResultsMap/SearchResultsMap.vue
+++ b/src/components/SearchResultsMap/SearchResultsMap.vue
@@ -14,7 +14,7 @@
       </Button>
     </div>
     <Map
-      v-show="markers.length > 0"
+      v-else
       :zoom="10"
       mapStyle="light"
       :apiKey="config.arcgis.apiKey"


### PR DESCRIPTION
Resolves #560 

The issue occurred because v-show will render but not show the Map when there's no markers. `boundingBox` is lazily computed with `(Infinity, Infinity)` lnglats, and then computation of `center` becomes `(Infinity + Infinity)/2 = NaN`.

Changing to `v-else` so that the `<Map>` component isn't mounted if there are no markers resolves things.

(An alternative would be to change `getBoundingBox` to always return non-infinite values.)

on dev.

<img width="800" alt="CleanShot 2026-06-04 at 15 20 41@2x" src="https://github.com/user-attachments/assets/f36c455b-28ef-487b-8322-49b5a164c8ef" />


