### PR TITLE
bump chunk size to 200MB

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -61,6 +61,9 @@ const uppy = new Uppy({
 }).use(umnAwsS3, {
   endpoint: config.instance.base.url,
   shouldUseMultipart: true,
+  // AWS S3 allows up to 10k parts per multipart upload.
+  // support up to 2TB file size w/200MB part size (200MB * 10k = 2TB)
+  getChunkSize: () => 200 * 1024 * 1024, // 200MB
   async createMultipartUpload(file): Promise<{
     uploadId: string;
     key: string;


### PR DESCRIPTION
Resolves #573 

Smoke tested 600MB file. Now it's divided into three 200MB parts:

<img width="800" alt="CleanShot 2026-06-18 at 12 58 13@2x" src="https://github.com/user-attachments/assets/cfc6fc29-1a08-4278-b3fb-e834445e1ff4" />
