### PR TITLE
bump x size, add hover state

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditWidgetLayout.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditWidgetLayout.vue
@@ -162,14 +162,14 @@
                         widgetDef.type === Types.WIDGET_TYPES.UPLOAD
                       "
                       :class="[
-                        'text-on-surface-variant hover:text-error p-2 rounded-sm -mt-2 -mr-1',
+                        'text-on-surface-variant hover:text-error p-2 rounded-sm -mt-2 -mr-1 hover:bg-error-container duration-300 transition-colors',
                         {
                           'sr-only': !isOpen,
                         },
                       ]"
                       type="button"
                       @click="$emit('delete', item.id)">
-                      <XIcon class="!size-4" />
+                      <XIcon class="!size-5" />
                       <span class="sr-only">Delete</span>
                     </button>
                   </div>


### PR DESCRIPTION
Previously, the `X` to delete was a bit small and the hover effect was so subtle it could be missed. This bumps the icon size and changes hover to makes it clearer that the action is destructive.

If it's still too subtle, we could make the hover state the default state.

BEFORE
<img width="800"  alt="CleanShot 2026-06-18 at 15 20 33@2x" src="https://github.com/user-attachments/assets/b14e7ac9-0589-4af1-821e-fffb7c4b2c23" />

AFTER
<img width="800" alt="CleanShot 2026-06-18 at 15 20 12@2x" src="https://github.com/user-attachments/assets/758bd153-b300-45de-b17b-a68a57c60b6d" />

ON HOVER
<img width="800" alt="CleanShot 2026-06-18 at 15 24 26@2x" src="https://github.com/user-attachments/assets/26bc8614-4200-42dc-b1c7-e76a8a5e5b70" />

IN CONTEXT
<img width="1200"  alt="CleanShot 2026-06-18 at 15 19 21@2x" src="https://github.com/user-attachments/assets/6113e2c2-7dfc-4109-87d9-567f851f04ba" />

Closes #572 