### PR TITLE
add tab for admin group mangement

### DIFF
--- a/bin/deploy-dev.sh
+++ b/bin/deploy-dev.sh
@@ -24,6 +24,14 @@ echo "→ Checking out $BRANCH..."
 git checkout "$BRANCH"
 git pull origin "$BRANCH"
 
+if [ ! -f .env ]; then
+  echo "→ Creating .env from .env.example..."
+  cp .env.example .env
+
+  echo "→ enabling admin permissions feature flag in .env..."
+  echo "VITE_FEATURE_ADMIN_PERMISSIONS=true" >> .env
+fi
+
 echo "→ Installing dependencies..."
 yarn
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
     </div>
     <Teleport to="body">
       <ErrorModal />
-      <ToastRoot />
+      <ToastRoot class="z-[60]" />
     </Teleport>
     <ErrorBoundary>
       <RouterView v-if="instanceStore.hasData && drawerStore.isReady" />

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1134,3 +1134,28 @@ export async function updateTemplate(
   );
   return res.data;
 }
+
+const PERMISSIONS_GROUP_TYPES = {
+  ALL: "All",
+  AUTHED: "Authed",
+  SSO: "Authed_remote", // SSO
+  USER: "User",
+} as const;
+
+type PermissionsGroupTypeKeys = keyof typeof PERMISSIONS_GROUP_TYPES;
+type PermissionsGroupTypeValues =
+  (typeof PERMISSIONS_GROUP_TYPES)[PermissionsGroupTypeKeys];
+
+interface PermissionsGroupType {
+  type: PermissionsGroupTypeValues;
+  label: string;
+  description: string;
+}
+
+export async function fetchGroupTypes() {
+  const res = await axios.get<{ groupTypes: PermissionsGroupType[] }>(
+    `${BASE_URL}/adminPermissions/groupTypes`
+  );
+
+  return res.data.groupTypes;
+}

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1178,7 +1178,7 @@ export async function createGroup(
   const params = new URLSearchParams();
   params.append("label", payload.label);
   params.append("type", payload.type);
-  for (const value of payload.values ?? []) {
+  for (const value of payload.values) {
     params.append("values[]", value);
   }
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1230,3 +1230,12 @@ export async function addGroupMember(
 
   return res.data.member;
 }
+
+export async function removeGroupMember(
+  groupId: number,
+  userId: number
+): Promise<void> {
+  await axios.delete(
+    `${BASE_URL}/adminPermissions/groups/${groupId}/members/${userId}`
+  );
+}

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1158,9 +1158,16 @@ export async function fetchGroups(): Promise<PermissionsGroup[]> {
 export async function createGroup(
   payload: CreateGroupPayload
 ): Promise<PermissionsGroup> {
+  const params = new URLSearchParams();
+  params.append("label", payload.label);
+  params.append("type", payload.type);
+  for (const value of payload.values ?? []) {
+    params.append("values[]", value);
+  }
+
   const res = await axios.post<{ group: PermissionsGroup }>(
     `${BASE_URL}/adminPermissions/groups`,
-    payload
+    params
   );
 
   return res.data.group;

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -49,6 +49,7 @@ import {
   type LabelledGroupType,
   type PermissionsGroup,
   type CreateGroupPayload,
+  type UpdateGroupPayload,
   type UserAutocompleteMatch,
   GROUP_TYPES,
 } from "@/types";
@@ -1182,6 +1183,22 @@ export async function createGroup(
 
   const res = await axios.post<{ group: PermissionsGroup }>(
     `${BASE_URL}/adminPermissions/groups`,
+    params
+  );
+
+  return res.data.group;
+}
+
+export async function updateGroup(
+  groupId: number,
+  payload: UpdateGroupPayload
+): Promise<PermissionsGroup> {
+  const params = new URLSearchParams();
+  params.append("label", payload.label);
+  params.append("type", payload.type);
+
+  const res = await axios.put<{ group: PermissionsGroup }>(
+    `${BASE_URL}/adminPermissions/groups/${groupId}`,
     params
   );
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1248,3 +1248,7 @@ export async function removeGroupMember(
     `${BASE_URL}/adminPermissions/groups/${groupId}/members/${userId}`
   );
 }
+
+export async function deleteGroup(groupId: number): Promise<void> {
+  await axios.delete(`${BASE_URL}/adminPermissions/groups/${groupId}`);
+}

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -51,6 +51,7 @@ import {
   type CreateGroupPayload,
   type UpdateGroupPayload,
   type UserAutocompleteMatch,
+  type GroupMember,
   GROUP_TYPES,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
@@ -1203,4 +1204,29 @@ export async function updateGroup(
   );
 
   return res.data.group;
+}
+
+export async function fetchGroupMembers(
+  groupId: number
+): Promise<GroupMember[]> {
+  const res = await axios.get<{ members: GroupMember[] }>(
+    `${BASE_URL}/adminPermissions/groups/${groupId}/members`
+  );
+
+  return res.data.members;
+}
+
+export async function addGroupMember(
+  groupId: number,
+  userId: number
+): Promise<GroupMember> {
+  const params = new URLSearchParams();
+  params.append("userId", String(userId));
+
+  const res = await axios.post<{ member: GroupMember }>(
+    `${BASE_URL}/adminPermissions/groups/${groupId}/members`,
+    params
+  );
+
+  return res.data.member;
 }

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -46,6 +46,11 @@ import {
   type AdminTemplate,
   type TemplatePayload,
   type FieldType,
+  type PermissionsGroupType,
+  type PermissionsGroup,
+  type CreateGroupPayload,
+  type GroupUserMatch,
+  PERMISSIONS_GROUP_TYPES,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -1135,23 +1140,6 @@ export async function updateTemplate(
   return res.data;
 }
 
-const PERMISSIONS_GROUP_TYPES = {
-  ALL: "All",
-  AUTHED: "Authed",
-  SSO: "Authed_remote", // SSO
-  USER: "User",
-} as const;
-
-type PermissionsGroupTypeKeys = keyof typeof PERMISSIONS_GROUP_TYPES;
-type PermissionsGroupTypeValues =
-  (typeof PERMISSIONS_GROUP_TYPES)[PermissionsGroupTypeKeys];
-
-interface PermissionsGroupType {
-  type: PermissionsGroupTypeValues;
-  label: string;
-  description: string;
-}
-
 export async function fetchGroupTypes() {
   const res = await axios.get<{ groupTypes: PermissionsGroupType[] }>(
     `${BASE_URL}/adminPermissions/groupTypes`
@@ -1159,3 +1147,23 @@ export async function fetchGroupTypes() {
 
   return res.data.groupTypes;
 }
+
+export async function fetchGroups(): Promise<PermissionsGroup[]> {
+  const res = await axios.get<{ groups: PermissionsGroup[] }>(
+    `${BASE_URL}/adminPermissions/groups`
+  );
+
+  return res.data.groups;
+}
+
+export async function createGroup(
+  payload: CreateGroupPayload
+): Promise<PermissionsGroup> {
+  const res = await axios.post<{ group: PermissionsGroup }>(
+    `${BASE_URL}/adminPermissions/groups`,
+    payload
+  );
+
+  return res.data.group;
+}
+

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -46,11 +46,10 @@ import {
   type AdminTemplate,
   type TemplatePayload,
   type FieldType,
-  type PermissionsGroupType,
+  type LabelledGroupType,
   type PermissionsGroup,
   type CreateGroupPayload,
-  type GroupUserMatch,
-  PERMISSIONS_GROUP_TYPES,
+  GROUP_TYPES,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
@@ -1141,7 +1140,7 @@ export async function updateTemplate(
 }
 
 export async function fetchGroupTypes() {
-  const res = await axios.get<{ groupTypes: PermissionsGroupType[] }>(
+  const res = await axios.get<{ groupTypes: LabelledGroupType[] }>(
     `${BASE_URL}/adminPermissions/groupTypes`
   );
 
@@ -1166,4 +1165,3 @@ export async function createGroup(
 
   return res.data.group;
 }
-

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1156,10 +1156,8 @@ export async function fetchGroups(): Promise<PermissionsGroup[]> {
   return res.data.groups;
 }
 
-// Suggest people for a "Specific People" group member field. What comes
-// back depends on the institution: local rows everywhere, plus a live
-// directory at API schools. The query is passed through verbatim; the
-// backend short-circuits to [] for trivial input.
+// Fetch user suggestions for a group's member field. The backend returns
+// [] for trivial queries, so keystrokes can be passed straight through.
 export async function fetchUserAutocomplete(
   query: string,
   options?: { signal?: AbortSignal }

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -69,6 +69,14 @@ axios.defaults.withCredentials = true;
 // convert them into API errors and store them in the error store
 // so that they're displayed to the user
 axios.interceptors.response.use(undefined, async (err: AxiosError) => {
+  // A request aborted via AbortSignal (e.g. TanStack Query superseding a
+  // stale autocomplete fetch) isn't a failure. Reject quietly so it never
+  // reaches the global error store, while still letting the query revert.
+  // Pass as unknown so the guard doesn't narrow `err` to never below.
+  if (axios.isCancel(err as unknown)) {
+    return Promise.reject(err);
+  }
+
   const customConfig = err.config as CustomAxiosRequestConfig;
 
   const errorStore = useErrorStore();

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1216,15 +1216,24 @@ export async function fetchGroupMembers(
   return res.data.members;
 }
 
+// Add by localUserId for someone who already has a local row, or by
+// remoteUserId (a netid/username) for someone we provision on add.
+export type AddGroupMemberInput =
+  | { groupId: number; localUserId: number }
+  | { groupId: number; remoteUserId: string };
+
 export async function addGroupMember(
-  groupId: number,
-  userId: number
+  input: AddGroupMemberInput
 ): Promise<GroupMember> {
   const params = new URLSearchParams();
-  params.append("userId", String(userId));
+  if ("localUserId" in input) {
+    params.append("localUserId", String(input.localUserId));
+  } else {
+    params.append("remoteUserId", input.remoteUserId);
+  }
 
   const res = await axios.post<{ member: GroupMember }>(
-    `${BASE_URL}/adminPermissions/groups/${groupId}/members`,
+    `${BASE_URL}/adminPermissions/groups/${input.groupId}/members`,
     params
   );
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -49,6 +49,7 @@ import {
   type LabelledGroupType,
   type PermissionsGroup,
   type CreateGroupPayload,
+  type UserAutocompleteMatch,
   GROUP_TYPES,
 } from "@/types";
 import { FileMetaData } from "@/types/FileMetaDataTypes";
@@ -1153,6 +1154,22 @@ export async function fetchGroups(): Promise<PermissionsGroup[]> {
   );
 
   return res.data.groups;
+}
+
+// Suggest people for a "Specific People" group member field. What comes
+// back depends on the institution: local rows everywhere, plus a live
+// directory at API schools. The query is passed through verbatim; the
+// backend short-circuits to [] for trivial input.
+export async function fetchUserAutocomplete(
+  query: string,
+  options?: { signal?: AbortSignal }
+): Promise<UserAutocompleteMatch[]> {
+  const res = await axios.get<{ matches: UserAutocompleteMatch[] }>(
+    `${BASE_URL}/adminPermissions/userAutocomplete`,
+    { params: { q: query }, signal: options?.signal }
+  );
+
+  return res.data.matches;
 }
 
 export async function createGroup(

--- a/src/components/AutoCompleteInput/AutoCompleteInput.vue
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.vue
@@ -58,6 +58,7 @@
               'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-primary-container hover:text-on-primary-container',
               index === highlightedIndex && 'bg-primary text-on-primary',
               isDisabled(item) && 'cursor-not-allowed opacity-50',
+              itemClass?.(item),
             ]"
             @mousedown.prevent="commitSelection(item)">
             <slot
@@ -99,6 +100,8 @@ const props = withDefaults(
     id?: string;
     blurOnSelect?: boolean;
     isItemDisabled?: (item: T) => boolean;
+    // extra classes per option wrapper, e.g. to set a pinned row apart
+    itemClass?: (item: T) => CSSClass;
   }>(),
   {
     id: "",
@@ -107,6 +110,7 @@ const props = withDefaults(
     isLoading: false,
     blurOnSelect: true,
     isItemDisabled: undefined,
+    itemClass: undefined,
   }
 );
 

--- a/src/components/AutoCompleteInput/AutoCompleteInput.vue
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.vue
@@ -22,12 +22,7 @@
         @keydown.up="handleKeydownUp"
         @keydown.down="handleKeydownDown"
         @keydown.esc="handleKeydownEsc"
-        @keydown="
-          $emit('keydown', $event, {
-            highlightedSuggestion: highlightedSuggestion,
-            modelValue: modelValue,
-          })
-        "
+        @keydown="$emit('keydown', $event, { highlightedItem, modelValue })"
         @blur="$emit('blur')" />
     </PopoverAnchor>
 
@@ -38,40 +33,40 @@
         :aria-labelledby="id"
         align="start"
         :sideOffset="4">
-        <!-- Loading state -->
         <div
-          v-if="isLoadingSuggestions"
+          v-if="isLoading"
           class="flex items-center justify-center gap-2 p-4">
           <SpinnerIcon class="size-4" />
           <span class="text-sm">Loading suggestions...</span>
         </div>
 
-        <!-- Empty state -->
         <div
           v-else-if="showEmptyState"
           class="p-4 text-sm text-muted-foreground text-center">
           No suggestions found.
         </div>
 
-        <!-- Suggestions -->
         <div v-else class="max-h-[33dvh] overflow-y-auto">
           <div
-            v-for="(suggestion, index) in suggestions"
+            v-for="(item, index) in items"
             :id="`${id}-option-${index}`"
-            :key="suggestion"
+            :key="index"
             role="option"
-            :aria-selected="suggestion === modelValue"
+            :aria-selected="index === highlightedIndex"
+            :aria-disabled="isDisabled(item)"
             :class="[
               'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-primary-container hover:text-on-primary-container',
               index === highlightedIndex && 'bg-primary text-on-primary',
+              isDisabled(item) && 'cursor-not-allowed opacity-50',
             ]"
-            @mousedown.prevent="
-              // use mousedown to prevent race condition with input blur
-              // mousedown will commit the suggestion, and blur
-              // won't try to commit searchTerm
-              commitSelection(suggestion)
-            ">
-            <span>{{ suggestion }}</span>
+            @mousedown.prevent="commitSelection(item)">
+            <slot
+              name="option"
+              :item="item"
+              :highlighted="index === highlightedIndex"
+              :disabled="isDisabled(item)">
+              {{ item }}
+            </slot>
           </div>
         </div>
       </PopoverContent>
@@ -79,9 +74,8 @@
   </PopoverRoot>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 import { computed, ref, useTemplateRef } from "vue";
-import { useDebounce } from "@vueuse/core";
 import {
   PopoverRoot,
   PopoverContent,
@@ -90,25 +84,29 @@ import {
 } from "reka-ui";
 import { Input } from "@/components/ui/input";
 import { SpinnerIcon } from "@/icons";
-import { useAutocompleteQuery } from "@/queries/useAutocompleteQuery";
 import { CSSClass } from "@/types";
 
+// Presentational autocomplete. The parent owns the data: it passes `items`
+// and `isLoading`, renders each item with the #option slot, and reacts to
+// `select`. A disabled item can be shown but not chosen.
 const props = withDefaults(
   defineProps<{
     modelValue: string;
+    items: T[];
+    isLoading?: boolean;
     placeholder?: string;
-    fieldTitle: string;
-    templateId?: number | null;
     inputClass?: CSSClass;
-    id: string;
+    id?: string;
     blurOnSelect?: boolean;
+    isItemDisabled?: (item: T) => boolean;
   }>(),
   {
     id: "",
     placeholder: "",
     inputClass: "",
-    templateId: undefined,
+    isLoading: false,
     blurOnSelect: true,
+    isItemDisabled: undefined,
   }
 );
 
@@ -116,133 +114,83 @@ const emit = defineEmits<{
   "update:modelValue": [value: string];
   keydown: [
     event: KeyboardEvent,
-    {
-      highlightedSuggestion: string | null;
-      modelValue: string;
-    }
+    context: { highlightedItem: T | null; modelValue: string }
   ];
   blur: [];
-  select: [selection: string];
+  select: [item: T];
 }>();
 
-// Component refs
 const inputRef = useTemplateRef("inputRef");
 
 const isOpen = ref(false);
 const highlightedIndex = ref(-1);
 
-const highlightedSuggestion = computed((): string | null => {
-  if (!suggestions.value.length || highlightedIndex.value < 0) return null;
-  return suggestions.value[highlightedIndex.value] ?? null;
+const highlightedItem = computed((): T | null => {
+  if (!props.items.length || highlightedIndex.value < 0) return null;
+  return props.items[highlightedIndex.value] ?? null;
 });
 
-// Debounced search for API calls
-const debouncedSearchTerm = useDebounce(
-  computed(() => props.modelValue),
-  300
-);
-
-// Query for autocomplete suggestions
-const { data: suggestionsData, isFetching } = useAutocompleteQuery(
-  props.fieldTitle,
-  debouncedSearchTerm,
-  props.templateId || ""
-);
-const suggestions = computed(() => suggestionsData.value ?? []);
-
-const isTyping = computed(() => {
-  const hasActiveInput = props.modelValue.trim().length >= 1;
-  return hasActiveInput && props.modelValue !== debouncedSearchTerm.value;
-});
-
-const isLoadingSuggestions = computed(() => {
-  return isTyping.value || isFetching.value;
-});
+function isDisabled(item: T): boolean {
+  return props.isItemDisabled?.(item) ?? false;
+}
 
 const showEmptyState = computed(() => {
   return (
     props.modelValue.trim().length >= 1 &&
-    !isLoadingSuggestions.value &&
-    suggestions.value.length === 0
+    !props.isLoading &&
+    props.items.length === 0
   );
 });
 
 function handleUpdateSearchTerm(value: string) {
   emit("update:modelValue", value);
+  highlightedIndex.value = -1;
 
-  highlightedIndex.value = -1; // Reset highlighting on new input
-
-  // If the input is empty, close the dropdown
   if (value.trim().length === 0) {
     isOpen.value = false;
     return;
   }
-
-  // Open dropdown when user is actively typing
   isOpen.value = true;
 }
 
 function handleKeydownDown(event: KeyboardEvent) {
-  const trimmedTerm = props.modelValue.trim();
-  // if no searchTerm or suggestions, we're done
-  if (!trimmedTerm.length || !suggestions.value.length) {
-    return;
-  }
-
+  if (!props.modelValue.trim().length || !props.items.length) return;
   event.preventDefault();
-
-  // make sure dropdown is open
   isOpen.value = true;
-
-  // advance highlight if possible
   highlightedIndex.value = Math.min(
     highlightedIndex.value + 1,
-    suggestions.value.length - 1
+    props.items.length - 1
   );
 }
 
 function handleKeydownUp(event: KeyboardEvent) {
-  const trimmedTerm = props.modelValue.trim();
-  // if no searchTerm or suggestions, we're done
-  if (!trimmedTerm.length || !suggestions.value.length) {
-    return;
-  }
-
+  if (!props.modelValue.trim().length || !props.items.length) return;
   event.preventDefault();
-
-  // move highlight up if possible
   highlightedIndex.value = Math.max(highlightedIndex.value - 1, -1);
 }
 
 function handleKeydownEnter(event: KeyboardEvent) {
-  const trimmedTerm = props.modelValue.trim();
-  // if no searchTerm or suggestions, we're done
-  if (!trimmedTerm.length) {
-    return;
-  }
-
+  const item = highlightedItem.value;
+  if (item === null) return;
   event.preventDefault();
-
-  // commit the highlighted suggestion or the current term
-  commitSelection(highlightedSuggestion.value ?? trimmedTerm);
+  commitSelection(item);
 }
 
 function handleKeydownEsc(event: KeyboardEvent) {
-  // Close the dropdown and reset highlighting
   event.preventDefault();
   isOpen.value = false;
   highlightedIndex.value = -1;
 }
 
-async function commitSelection(selection: string) {
-  // reset state
+function commitSelection(item: T) {
+  if (isDisabled(item)) return;
+
   isOpen.value = false;
   highlightedIndex.value = -1;
-
-  emit("select", selection);
+  emit("select", item);
 
   if (props.blurOnSelect) {
-    inputRef.value?.$el.blur(); // Remove focus from input
+    inputRef.value?.$el.blur();
   }
 }
 </script>

--- a/src/components/AutoCompleteInput/FieldAutoComplete.vue
+++ b/src/components/AutoCompleteInput/FieldAutoComplete.vue
@@ -1,0 +1,62 @@
+<template>
+  <AutoCompleteInput
+    :id="id"
+    :modelValue="modelValue"
+    :items="suggestions"
+    :isLoading="isFetching"
+    :placeholder="placeholder"
+    :inputClass="inputClass"
+    :blurOnSelect="blurOnSelect"
+    @update:modelValue="$emit('update:modelValue', $event)"
+    @select="$emit('select', $event)"
+    @blur="$emit('blur')"
+    @keydown="(event) => $emit('keydown', event)" />
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useDebounce } from "@vueuse/core";
+import AutoCompleteInput from "./AutoCompleteInput.vue";
+import { useAutocompleteQuery } from "@/queries/useAutocompleteQuery";
+import { CSSClass } from "@/types";
+
+// Autocomplete for a template field's existing values. Wraps the
+// presentational AutoCompleteInput with the field-value query, debounced.
+const props = withDefaults(
+  defineProps<{
+    modelValue: string;
+    fieldTitle: string;
+    templateId?: number | null;
+    placeholder?: string;
+    inputClass?: CSSClass;
+    id?: string;
+    blurOnSelect?: boolean;
+  }>(),
+  {
+    id: "",
+    placeholder: "",
+    inputClass: "",
+    templateId: undefined,
+    blurOnSelect: true,
+  }
+);
+
+defineEmits<{
+  "update:modelValue": [value: string];
+  select: [value: string];
+  blur: [];
+  keydown: [event: KeyboardEvent];
+}>();
+
+const debouncedTerm = useDebounce(
+  computed(() => props.modelValue),
+  300
+);
+
+const { data, isFetching } = useAutocompleteQuery(
+  () => props.fieldTitle,
+  debouncedTerm,
+  () => props.templateId ?? ""
+);
+const suggestions = computed(() => data.value ?? []);
+</script>

--- a/src/components/AutoCompleteInput/index.ts
+++ b/src/components/AutoCompleteInput/index.ts
@@ -1,1 +1,2 @@
 export { default as AutoCompleteInput } from "./AutoCompleteInput.vue";
+export { default as FieldAutoComplete } from "./FieldAutoComplete.vue";

--- a/src/components/Chip/Chip.vue
+++ b/src/components/Chip/Chip.vue
@@ -1,10 +1,15 @@
 <template>
   <span
-    class="chip inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-surface-container text-on-surface"
-    :class="{
-      'chip--is-clickable border cursor-pointer transition-colors ease-in-out':
-        clickable,
-    }">
+    :class="
+      cn([
+        'chip inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-surface-container text-on-surface',
+        {
+          'chip--is-clickable border cursor-pointer transition-colors ease-in-out':
+            clickable,
+        },
+        $attrs.class,
+      ])
+    ">
     <slot />
     <ArrowUpRight
       v-if="clickable"
@@ -14,6 +19,7 @@
   </span>
 </template>
 <script setup lang="ts">
+import { cn } from "@/lib/utils";
 import { ArrowUpRight } from "lucide-vue-next";
 
 withDefaults(

--- a/src/components/DropDown/DropDownItem.vue
+++ b/src/components/DropDown/DropDownItem.vue
@@ -5,7 +5,7 @@
     :disabled="disabled">
     <component
       :is="is || ($attrs.disabled ? 'div' : Link)"
-      class="block px-4 py-2 text-sm !no-underline"
+      class="block w-full text-left px-4 py-2 text-sm !no-underline"
       :class="{
         'bg-surface-container-high': active,
         'text-on-surface': active || current,

--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -39,6 +39,7 @@
         <slot name="append" />
       </div>
     </div>
+    <p v-if="error" class="text-error my-2 text-xs">{{ error }}</p>
   </div>
 </template>
 <script setup lang="ts" generic="TModelValue = string | number | null">
@@ -55,12 +56,14 @@ withDefaults(
     inputClass?: CSSClass;
     labelClass?: CSSClass;
     required?: boolean;
+    error?: string | null;
   }>(),
   {
     id: () => useId(),
     labelHidden: false,
     type: "text",
     required: false,
+    error: "",
     inputClass: () => ({}),
     labelClass: () => ({}),
   }

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -9,7 +9,7 @@
       }"
       @click.self="$emit('close')">
       <div
-        class="modal-contents shadow-lg relative rounded-2xl flex flex-col overflow-hidden max-w-[60rem] max-h-[90vh] m-auto w-full p-4 md:p-8 gap-4 md:gap-6 bg-surface-container text-on-surface"
+        class="modal-contents shadow-lg relative rounded-2xl flex flex-col overflow-hidden max-w-[60rem] max-h-[90vh] m-auto w-full p-4 md:p-8 gap-4 md:gap-6 bg-surface text-on-surface"
         v-bind="$attrs">
         <XButton
           class="absolute top-4 right-4 md:top-8 md:right-8"

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -32,7 +32,7 @@ defineProps<{
   labelsClass?: string;
 }>();
 
-// change to defineModel so we can take a prop or `tactiveTabId`
+// change to defineModel so we can take a prop or `activeTabId`
 // can exist on its own as a ref
 const activeTabId = defineModel<string>("activeTabId");
 

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -28,10 +28,13 @@ import { ref, provide } from "vue";
 import { TabsInjectionKey } from "@/constants/constants";
 import type { Tab, TabsContext } from "@/types";
 
-const props = defineProps<{
+defineProps<{
   labelsClass?: string;
-  activeTabId: string;
 }>();
+
+// change to defineModel so we can take a prop or `tactiveTabId`
+// can exist on its own as a ref
+const activeTabId = defineModel<string>("activeTabId");
 
 const emit = defineEmits<{
   (event: "tabChange", tab: Tab): void;
@@ -41,6 +44,10 @@ const tabs = ref<Tab[]>([]);
 
 const addTab = (tab: Tab) => {
   tabs.value.push(tab);
+  // Seed the default selection (first tab) when used without a v-model.
+  if (activeTabId.value === undefined) {
+    activeTabId.value = tab.id;
+  }
 };
 
 const removeTab = (tab: Tab) => {
@@ -54,11 +61,12 @@ const setActiveTab = (tabId: string) => {
   if (!newActiveTab) {
     throw new Error(`Tab with id ${tabId} not found`);
   }
+  activeTabId.value = newActiveTab.id;
   emit("tabChange", newActiveTab);
 };
 
 const isActiveTab = (tabId: string) => {
-  return tabId === props.activeTabId;
+  return tabId === activeTabId.value;
 };
 
 provide<TabsContext>(TabsInjectionKey, {

--- a/src/helpers/tryFocus.ts
+++ b/src/helpers/tryFocus.ts
@@ -1,0 +1,50 @@
+// Resolve the element to focus: a CSS selector or a function returning one.
+type FocusTarget = string | (() => HTMLElement | null | undefined);
+
+type TryFocusOptions = {
+  // How many animation frames to keep retrying before giving up.
+  maxAttempts?: number;
+};
+
+// Focus an element that may not be ready the instant we ask. A freshly
+// rendered element can mount a few frames late (async data, open
+// transitions) and isn't always focusable the moment it appears, so retry on
+// animation frames until focus actually lands. Resolves with the focused
+// element; rejects if it never takes — a rejection is a real signal worth
+// surfacing, not a silent no-op.
+export function tryFocus(
+  target: FocusTarget,
+  { maxAttempts = 10 }: TryFocusOptions = {}
+): Promise<HTMLElement> {
+  const resolveTarget = (): HTMLElement | null =>
+    typeof target === "string"
+      ? document.querySelector<HTMLElement>(target)
+      : (target() ?? null);
+
+  return new Promise((resolve, reject) => {
+    let attemptsLeft = maxAttempts;
+
+    const attempt = () => {
+      const element = resolveTarget();
+      if (element) {
+        element.focus();
+        // focus() no-ops on an element that isn't focusable yet, so confirm
+        // it landed before we call it done
+        if (document.activeElement === element) {
+          resolve(element);
+          return;
+        }
+      }
+
+      if (attemptsLeft > 0) {
+        attemptsLeft -= 1;
+        requestAnimationFrame(attempt);
+      } else {
+        const label = typeof target === "string" ? target : "element";
+        reject(new Error(`tryFocus: gave up on "${label}" after ${maxAttempts} frames`));
+      }
+    };
+
+    attempt();
+  });
+}

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -4,7 +4,7 @@
       <slot name="custom-header" />
     </template>
     <div class="flex flex-1 min-h-0">
-      <AdminSidebar class="shrink-0" />
+      <AdminSidebar class="hidden lg:block shrink-0" />
       <div class="flex-1 min-w-0">
         <slot />
       </div>

--- a/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
+++ b/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
@@ -13,37 +13,7 @@
           </div>
         </Tab>
         <Tab id="groups" label="Groups">
-          <div class="flex items-center justify-between">
-            <p>Help text goes here about groups and how they work.</p>
-            <Button variant="primary">Create Group</Button>
-          </div>
-
-          <AccordionRoot type="multiple" class="mt-4 flex flex-col gap-2">
-            <AccordionItem
-              value="group-everyone"
-              class="rounded-md border border-outline-variant bg-surface-container">
-              <AccordionHeader>
-                <AccordionTrigger
-                  class="group flex w-full items-center gap-4 p-4 text-left">
-                  <ChevronRightIcon
-                    class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90" />
-                  <span class="text-lg font-bold">Everyone</span>
-                  <span
-                    class="ml-auto flex items-center gap-4 text-sm text-on-surface-variant">
-                    <span>Anyone — even signed-out visitors</span>
-                    <span>1 grant</span>
-                  </span>
-                </AccordionTrigger>
-              </AccordionHeader>
-              <AccordionContent
-                class="border-t border-outline-variant p-4 bg-surface-container-lowest">
-                <p class="mb-4 text-sm text-on-surface-variant">
-                  Matches everyone, including signed-out visitors.
-                </p>
-                <Button variant="danger">Delete Group</Button>
-              </AccordionContent>
-            </AccordionItem>
-          </AccordionRoot>
+          <GroupsTabContent />
         </Tab>
       </Tabs>
     </PageContent>
@@ -57,16 +27,8 @@ import PageHeader from "@/components/PageHeader/PageHeader.vue";
 import Tabs from "@/components/Tabs/Tabs.vue";
 import Tab from "@/components/Tabs/Tab.vue";
 import { computed } from "vue";
-import Button from "@/components/Button/Button.vue";
 import { useRoute, useRouter } from "vue-router";
-import {
-  AccordionRoot,
-  AccordionTrigger,
-  AccordionContent,
-  AccordionHeader,
-  AccordionItem,
-} from "reka-ui";
-import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
+import GroupsTabContent from "./GroupsTabContent.vue";
 
 const VALID_TABS = ["rules", "groups"] as const;
 type ValidTab = (typeof VALID_TABS)[number];

--- a/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
+++ b/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
@@ -1,11 +1,13 @@
 <template>
   <AdminLayout>
-    <PageContent>
+    <PageContent class="max-w-screen-lg">
       <PageHeader
         title="Permissions"
         description="Grant access to any collection in this instance" />
 
-      <Tabs v-model:activeTabId="activeTabId">
+      <Tabs
+        v-model:activeTabId="activeTabId"
+        labelsClass="border-b border-outline-variant">
         <Tab id="rules" label="Rules">
           <div
             class="border border-dashed border-outline-variant rounded-md p-10 text-center text-sm text-on-surface-variant">

--- a/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
+++ b/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
@@ -5,10 +5,47 @@
         title="Permissions"
         description="Baseline access across this Elevator instance. Rules are additive — a user gets the highest grant that matches them." />
 
-      <div
-        class="border border-dashed border-outline-variant rounded-md p-10 text-center text-sm text-on-surface-variant">
-        Permissions admin coming soon.
-      </div>
+      <Tabs v-model:activeTabId="activeTabId">
+        <Tab id="rules" label="Rules">
+          <div
+            class="border border-dashed border-outline-variant rounded-md p-10 text-center text-sm text-on-surface-variant">
+            Rules
+          </div>
+        </Tab>
+        <Tab id="groups" label="Groups">
+          <div class="flex items-center justify-between">
+            <p>Help text goes here about groups and how they work.</p>
+            <Button variant="primary">Create Group</Button>
+          </div>
+
+          <AccordionRoot type="multiple" class="mt-4 flex flex-col gap-2">
+            <AccordionItem
+              value="group-everyone"
+              class="rounded-md border border-outline-variant bg-surface-container">
+              <AccordionHeader>
+                <AccordionTrigger
+                  class="group flex w-full items-center gap-4 p-4 text-left">
+                  <ChevronRightIcon
+                    class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90" />
+                  <span class="text-lg font-bold">Everyone</span>
+                  <span
+                    class="ml-auto flex items-center gap-4 text-sm text-on-surface-variant">
+                    <span>Anyone — even signed-out visitors</span>
+                    <span>1 grant</span>
+                  </span>
+                </AccordionTrigger>
+              </AccordionHeader>
+              <AccordionContent
+                class="border-t border-outline-variant p-4 bg-surface-container-lowest">
+                <p class="mb-4 text-sm text-on-surface-variant">
+                  Matches everyone, including signed-out visitors.
+                </p>
+                <Button variant="danger">Delete Group</Button>
+              </AccordionContent>
+            </AccordionItem>
+          </AccordionRoot>
+        </Tab>
+      </Tabs>
     </PageContent>
   </AdminLayout>
 </template>
@@ -17,4 +54,44 @@
 import AdminLayout from "@/layouts/AdminLayout.vue";
 import PageContent from "@/components/PageContent/PageContent.vue";
 import PageHeader from "@/components/PageHeader/PageHeader.vue";
+import Tabs from "@/components/Tabs/Tabs.vue";
+import Tab from "@/components/Tabs/Tab.vue";
+import { computed } from "vue";
+import Button from "@/components/Button/Button.vue";
+import { useRoute, useRouter } from "vue-router";
+import {
+  AccordionRoot,
+  AccordionTrigger,
+  AccordionContent,
+  AccordionHeader,
+  AccordionItem,
+} from "reka-ui";
+import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
+
+const VALID_TABS = ["rules", "groups"] as const;
+type ValidTab = (typeof VALID_TABS)[number];
+
+const route = useRoute();
+const router = useRouter();
+
+// helper for TS since route.query.tab could be array
+const isValidTab = (x: unknown): x is ValidTab =>
+  VALID_TABS.some((tab) => tab === x);
+
+// let route be the source of truth for the active tab.
+const activeTabId = computed<ValidTab>({
+  get() {
+    const tab = route.query.tab;
+    return isValidTab(tab) ? tab : VALID_TABS[0];
+  },
+  set(tabId) {
+    router.replace({
+      query: {
+        ...route.query,
+        // only include tabId in query if it's not the default (first tab)
+        tab: tabId === VALID_TABS[0] ? undefined : tabId,
+      },
+    });
+  },
+});
 </script>

--- a/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
+++ b/src/pages/AdminPermissionsPage/AdminPermissionsPage.vue
@@ -3,13 +3,13 @@
     <PageContent>
       <PageHeader
         title="Permissions"
-        description="Baseline access across this Elevator instance. Rules are additive — a user gets the highest grant that matches them." />
+        description="Grant access to any collection in this instance" />
 
       <Tabs v-model:activeTabId="activeTabId">
         <Tab id="rules" label="Rules">
           <div
             class="border border-dashed border-outline-variant rounded-md p-10 text-center text-sm text-on-surface-variant">
-            Rules
+            Permission Rules (Not Implemented Yet)
           </div>
         </Tab>
         <Tab id="groups" label="Groups">

--- a/src/pages/AdminPermissionsPage/CreateGroupModal.vue
+++ b/src/pages/AdminPermissionsPage/CreateGroupModal.vue
@@ -1,0 +1,95 @@
+<template>
+  <Modal
+    :isOpen="isOpen"
+    label="New group"
+    class="max-w-md"
+    @close="handleClose">
+    <form class="flex flex-col gap-6" @submit.prevent="handleSubmit">
+      <p class="-mt-2 text-sm text-on-surface-variant">
+        Add a group to this instance.
+      </p>
+
+      <InputGroup v-model="form.name" label="Group name" />
+
+      <SelectGroup
+        v-model="form.type"
+        label="Type"
+        placeholder="Select a type…"
+        :options="typeOptions" />
+
+      <div class="flex items-center justify-end gap-2">
+        <Button variant="tertiary" type="button" @click="handleClose">
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          type="submit"
+          :disabled="!isValid || mutation.isPending.value">
+          Create Group
+        </Button>
+      </div>
+    </form>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive } from "vue";
+import Modal from "@/components/Modal/Modal.vue";
+import InputGroup from "@/components/InputGroup/InputGroup.vue";
+import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
+import Button from "@/components/Button/Button.vue";
+import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
+import { useCreateGroupMutation } from "@/queries/useCreateGroupMutation";
+import { PERMISSIONS_GROUP_TYPES } from "@/types";
+import type { CreateGroupPayload, PermissionsGroupTypeValues } from "@/types";
+
+defineProps<{ isOpen: boolean }>();
+const emit = defineEmits<{ (e: "close"): void }>();
+
+const { data: groupTypes } = useGroupTypesQuery();
+const mutation = useCreateGroupMutation();
+
+const form = reactive({
+  name: "",
+  type: "" as PermissionsGroupTypeValues | "",
+});
+
+const typeOptions = computed(() =>
+  (groupTypes.value ?? []).map((groupType) => ({
+    id: groupType.type,
+    label: groupType.label,
+    description: groupType.description,
+  }))
+);
+
+const isValid = computed(() => {
+  if (!form.name.trim() || !form.type) return false;
+  return true;
+});
+
+function resetForm() {
+  form.name = "";
+  form.type = "";
+}
+
+function handleClose() {
+  resetForm();
+  emit("close");
+}
+
+function handleSubmit() {
+  if (!isValid.value || form.type === "") return;
+
+  const payload: CreateGroupPayload = {
+    type: form.type,
+    label: form.name.trim(),
+  };
+
+  mutation.mutate(payload, {
+    onSuccess: () => {
+      resetForm();
+      emit("close");
+    },
+  });
+}
+</script>

--- a/src/pages/AdminPermissionsPage/CreateGroupModal.vue
+++ b/src/pages/AdminPermissionsPage/CreateGroupModal.vue
@@ -1,21 +1,29 @@
 <template>
   <Modal
     :isOpen="isOpen"
-    label="New group"
+    label="Create Group"
     class="max-w-md"
     @close="handleClose">
     <form class="flex flex-col gap-6" @submit.prevent="handleSubmit">
-      <p class="-mt-2 text-sm text-on-surface-variant">
-        Add a group to this instance.
+      <InputGroup
+        v-model="form.label"
+        label="Name"
+        placeholder="e.g. Library Staff"
+        required
+        @blur="wasTouched.label = true" />
+      <p v-if="wasTouched.label && errors.label" class="text-error">
+        {{ errors.label }}
       </p>
-
-      <InputGroup v-model="form.name" label="Group name" />
 
       <SelectGroup
         v-model="form.type"
         label="Type"
         placeholder="Select a type…"
-        :options="typeOptions" />
+        :options="typeOptions"
+        @update:modelValue="wasTouched.type = true" />
+      <p v-if="wasTouched.type && errors.type" class="text-error">
+        {{ errors.type }}
+      </p>
 
       <div class="flex items-center justify-end gap-2">
         <Button variant="tertiary" type="button" @click="handleClose">
@@ -24,7 +32,7 @@
         <Button
           variant="primary"
           type="submit"
-          :disabled="!isValid || mutation.isPending.value">
+          :disabled="!canSubmit || mutation.isPending.value">
           Create Group
         </Button>
       </div>
@@ -33,43 +41,68 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from "vue";
+import { computed, reactive, ref } from "vue";
 import Modal from "@/components/Modal/Modal.vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
 import Button from "@/components/Button/Button.vue";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
 import { useCreateGroupMutation } from "@/queries/useCreateGroupMutation";
-import { PERMISSIONS_GROUP_TYPES } from "@/types";
-import type { CreateGroupPayload, PermissionsGroupTypeValues } from "@/types";
+import { GroupTypeValues, SelectOption } from "@/types";
 
 defineProps<{ isOpen: boolean }>();
 const emit = defineEmits<{ (e: "close"): void }>();
 
-const { data: groupTypes } = useGroupTypesQuery();
+const { data: labelledGroupTypes } = useGroupTypesQuery();
 const mutation = useCreateGroupMutation();
 
-const form = reactive({
-  name: "",
-  type: "" as PermissionsGroupTypeValues | "",
+type CreateGroupForm = {
+  label: string;
+  type: GroupTypeValues | "";
+  values: string[]; // todo GroupMembers array
+};
+
+const form = ref<CreateGroupForm>({
+  label: "",
+  type: "",
+  values: [],
 });
 
-const typeOptions = computed(() =>
-  (groupTypes.value ?? []).map((groupType) => ({
+const errors = computed(() => {
+  const f = form.value;
+  return {
+    label: f.label.trim() === "" ? "Group name is required" : null,
+    type: f.type === "" ? "Type is required" : null,
+  };
+});
+
+function isSubmittable(
+  form: CreateGroupForm
+): form is CreateGroupForm & { type: GroupTypeValues } {
+  return form.type !== "" && form.label.trim() !== "";
+}
+
+const canSubmit = computed((): boolean => isSubmittable(form.value));
+
+const wasTouched = reactive({
+  label: false,
+  type: false,
+});
+
+const typeOptions = computed((): SelectOption[] =>
+  (labelledGroupTypes.value ?? []).map((groupType) => ({
     id: groupType.type,
     label: groupType.label,
     description: groupType.description,
   }))
 );
 
-const isValid = computed(() => {
-  if (!form.name.trim() || !form.type) return false;
-  return true;
-});
-
 function resetForm() {
-  form.name = "";
-  form.type = "";
+  form.value = {
+    label: "",
+    type: "",
+    values: [],
+  };
 }
 
 function handleClose() {
@@ -78,14 +111,13 @@ function handleClose() {
 }
 
 function handleSubmit() {
-  if (!isValid.value || form.type === "") return;
+  form.value.label = form.value.label.trim();
 
-  const payload: CreateGroupPayload = {
-    type: form.type,
-    label: form.name.trim(),
-  };
+  if (!isSubmittable(form.value)) {
+    return;
+  }
 
-  mutation.mutate(payload, {
+  mutation.mutate(form.value, {
     onSuccess: () => {
       resetForm();
       emit("close");

--- a/src/pages/AdminPermissionsPage/GroupFormModal.vue
+++ b/src/pages/AdminPermissionsPage/GroupFormModal.vue
@@ -107,12 +107,26 @@ function isSubmittable(
 
 const canSubmit = computed((): boolean => isSubmittable(form.value));
 
+// implemented types
+const ENABLED_GROUP_TYPES: GroupTypeValues[] = [
+  "All",
+  "Authed",
+  "Authed_remote",
+  "User",
+];
+
 const typeOptions = computed((): SelectOption[] =>
-  (labelledGroupTypes.value ?? []).map((groupType) => ({
-    id: groupType.type,
-    label: groupType.label,
-    description: groupType.description,
-  }))
+  (labelledGroupTypes.value ?? []).map((groupType) => {
+    const isEnabled = ENABLED_GROUP_TYPES.includes(groupType.type);
+    return {
+      id: groupType.type,
+      label: isEnabled
+        ? groupType.label
+        : `${groupType.label} (not implemented)`,
+      description: groupType.description,
+      disabled: !isEnabled,
+    };
+  })
 );
 
 function handleClose() {

--- a/src/pages/AdminPermissionsPage/GroupFormModal.vue
+++ b/src/pages/AdminPermissionsPage/GroupFormModal.vue
@@ -56,7 +56,10 @@ const props = defineProps<{
   // when present the modal edits this group, otherwise it creates one
   group?: PermissionsGroup | null;
 }>();
-const emit = defineEmits<{ (e: "close"): void }>();
+const emit = defineEmits<{
+  (e: "close"): void;
+  (e: "created", group: PermissionsGroup): void;
+}>();
 
 const { data: labelledGroupTypes } = useGroupTypesQuery();
 const createMutation = useCreateGroupMutation();
@@ -140,16 +143,23 @@ function handleSubmit() {
     return;
   }
 
-  const onSuccess = () => emit("close");
   const { type, label } = form.value;
 
   if (props.group) {
     updateMutation.mutate(
       { id: props.group.id, payload: { type, label } },
-      { onSuccess }
+      { onSuccess: () => emit("close") }
     );
   } else {
-    createMutation.mutate({ type, label, values: [] }, { onSuccess });
+    createMutation.mutate(
+      { type, label, values: [] },
+      {
+        onSuccess: (group) => {
+          emit("created", group);
+          emit("close");
+        },
+      }
+    );
   }
 }
 </script>

--- a/src/pages/AdminPermissionsPage/GroupFormModal.vue
+++ b/src/pages/AdminPermissionsPage/GroupFormModal.vue
@@ -4,26 +4,23 @@
     :label="isEditing ? 'Edit Group' : 'Create Group'"
     class="max-w-md"
     @close="handleClose">
-    <form class="flex flex-col gap-6" @submit.prevent="handleSubmit">
+    <form @submit.prevent="handleSubmit">
       <InputGroup
         v-model="form.label"
         label="Name"
         placeholder="e.g. Library Staff"
+        :error="wasTouched.label ? errors.label : null"
         required
         @blur="wasTouched.label = true" />
-      <p v-if="wasTouched.label && errors.label" class="text-error">
-        {{ errors.label }}
-      </p>
 
       <SelectGroup
         v-model="form.type"
         label="Type"
         placeholder="Select a type…"
+        class="my-4"
+        :error="wasTouched.type ? errors.type : null"
         :options="typeOptions"
         @update:modelValue="wasTouched.type = true" />
-      <p v-if="wasTouched.type && errors.type" class="text-error">
-        {{ errors.type }}
-      </p>
 
       <div class="flex items-center justify-end gap-2">
         <Button variant="tertiary" type="button" @click="handleClose">

--- a/src/pages/AdminPermissionsPage/GroupFormModal.vue
+++ b/src/pages/AdminPermissionsPage/GroupFormModal.vue
@@ -1,0 +1,141 @@
+<template>
+  <Modal
+    :isOpen="isOpen"
+    :label="isEditing ? 'Edit Group' : 'Create Group'"
+    class="max-w-md"
+    @close="handleClose">
+    <form class="flex flex-col gap-6" @submit.prevent="handleSubmit">
+      <InputGroup
+        v-model="form.label"
+        label="Name"
+        placeholder="e.g. Library Staff"
+        required
+        @blur="wasTouched.label = true" />
+      <p v-if="wasTouched.label && errors.label" class="text-error">
+        {{ errors.label }}
+      </p>
+
+      <SelectGroup
+        v-model="form.type"
+        label="Type"
+        placeholder="Select a type…"
+        :options="typeOptions"
+        @update:modelValue="wasTouched.type = true" />
+      <p v-if="wasTouched.type && errors.type" class="text-error">
+        {{ errors.type }}
+      </p>
+
+      <div class="flex items-center justify-end gap-2">
+        <Button variant="tertiary" type="button" @click="handleClose">
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          type="submit"
+          :disabled="!canSubmit || isPending">
+          {{ isEditing ? "Save Changes" : "Create Group" }}
+        </Button>
+      </div>
+    </form>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from "vue";
+import Modal from "@/components/Modal/Modal.vue";
+import InputGroup from "@/components/InputGroup/InputGroup.vue";
+import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
+import Button from "@/components/Button/Button.vue";
+import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
+import { useCreateGroupMutation } from "@/queries/useCreateGroupMutation";
+import { useUpdateGroupMutation } from "@/queries/useUpdateGroupMutation";
+import { GroupTypeValues, PermissionsGroup, SelectOption } from "@/types";
+
+const props = defineProps<{
+  isOpen: boolean;
+  // when present the modal edits this group, otherwise it creates one
+  group?: PermissionsGroup | null;
+}>();
+const emit = defineEmits<{ (e: "close"): void }>();
+
+const { data: labelledGroupTypes } = useGroupTypesQuery();
+const createMutation = useCreateGroupMutation();
+const updateMutation = useUpdateGroupMutation();
+
+const isEditing = computed(() => Boolean(props.group));
+const isPending = computed(
+  () => createMutation.isPending.value || updateMutation.isPending.value
+);
+
+type GroupForm = {
+  label: string;
+  type: GroupTypeValues | "";
+};
+
+const form = ref<GroupForm>({ label: "", type: "" });
+const wasTouched = reactive({ label: false, type: false });
+
+// fill the form each time the modal opens, prefilling from the group in edit
+// mode and starting blank in create mode
+watch(
+  () => [props.isOpen, props.group] as const,
+  ([isOpen]) => {
+    if (!isOpen) return;
+    form.value = {
+      label: props.group?.label ?? "",
+      type: props.group?.type ?? "",
+    };
+    wasTouched.label = false;
+    wasTouched.type = false;
+  },
+  { immediate: true }
+);
+
+const errors = computed(() => {
+  const f = form.value;
+  return {
+    label: f.label.trim() === "" ? "Group name is required" : null,
+    type: f.type === "" ? "Type is required" : null,
+  };
+});
+
+function isSubmittable(
+  form: GroupForm
+): form is GroupForm & { type: GroupTypeValues } {
+  return form.type !== "" && form.label.trim() !== "";
+}
+
+const canSubmit = computed((): boolean => isSubmittable(form.value));
+
+const typeOptions = computed((): SelectOption[] =>
+  (labelledGroupTypes.value ?? []).map((groupType) => ({
+    id: groupType.type,
+    label: groupType.label,
+    description: groupType.description,
+  }))
+);
+
+function handleClose() {
+  emit("close");
+}
+
+function handleSubmit() {
+  form.value.label = form.value.label.trim();
+
+  if (!isSubmittable(form.value)) {
+    return;
+  }
+
+  const onSuccess = () => emit("close");
+  const { type, label } = form.value;
+
+  if (props.group) {
+    updateMutation.mutate(
+      { id: props.group.id, payload: { type, label } },
+      { onSuccess }
+    );
+  } else {
+    createMutation.mutate({ type, label, values: [] }, { onSuccess });
+  }
+}
+</script>

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -49,7 +49,11 @@
         </template>
       </AutoCompleteInput>
     </div>
-    <GroupMembersTable :columns="columns" :data="memberList" class="mb-2" />
+    <GroupMembersTable
+      :columns="columns"
+      :data="memberList"
+      :isLoading="isLoadingMembers"
+      class="mb-2" />
 
     <ConfirmModal
       :isOpen="memberToRemove !== null"
@@ -96,10 +100,21 @@ const props = defineProps<{
   isOpen: boolean;
 }>();
 
-const { data: members } = useGroupMembersQuery(() => props.group.id, {
+const {
+  data: members,
+  isFetching: isFetchingMembers,
+  isPlaceholderData: isMembersPlaceholder,
+} = useGroupMembersQuery(() => props.group.id, {
   enabled: () => props.isOpen,
 });
 const memberList = computed(() => members.value ?? []);
+
+// Only the very first load — the query starts on the placeholder list and a
+// fetch is in flight. Cache patches on add/remove never refetch, so this
+// stays false for them.
+const isLoadingMembers = computed(
+  () => isFetchingMembers.value && isMembersPlaceholder.value
+);
 
 const search = ref("");
 const debouncedSearch = useDebounce(search, 300);

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -16,40 +16,39 @@
     </div>
 
     <div>
-      <InputGroup
+      <label
+        :for="`group-${group.id}-add-member`"
+        class="text-sm font-bold text-on-surface-variant">
+        Add member
+      </label>
+      <AutoCompleteInput
+        :id="`group-${group.id}-add-member`"
         v-model="search"
-        label="Add member"
-        placeholder="Search by name or email…" />
-
-      <ul v-if="search.trim().length >= 2" class="mt-2 flex flex-col gap-1">
-        <li
-          v-if="matchList.length === 0"
-          class="p-2 text-sm text-on-surface-variant">
-          No matches.
-        </li>
-        <li v-for="match in matchList" :key="match.username">
-          <button
-            type="button"
-            class="flex w-full items-center gap-2 rounded p-2 text-left text-sm hover:bg-surface-container disabled:cursor-not-allowed disabled:opacity-50"
-            :disabled="!isAddable(match) || isAdding"
-            @click="add(match)">
-            <span>{{ match.name }}</span>
-            <span class="text-on-surface-variant">{{ match.email }}</span>
-            <span
-              v-if="reasonNotAddable(match)"
-              class="ml-auto text-xs italic text-on-surface-variant">
-              {{ reasonNotAddable(match) }}
-            </span>
-          </button>
-        </li>
-      </ul>
+        :items="matchList"
+        :isLoading="isSearching"
+        :isItemDisabled="(match: UserAutocompleteMatch) => !isAddable(match)"
+        :blurOnSelect="false"
+        placeholder="Search by name or email…"
+        inputClass="mt-1 w-full bg-surface-container rounded-md px-3 py-2 text-sm"
+        @select="add">
+        <template #option="{ item }">
+          <span>{{ item.name }}</span>
+          <span class="text-inverse-on-surface/70">{{ item.email }}</span>
+          <span
+            v-if="reasonNotAddable(item)"
+            class="ml-auto text-xs italic text-inverse-on-surface/70">
+            {{ reasonNotAddable(item) }}
+          </span>
+        </template>
+      </AutoCompleteInput>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import InputGroup from "@/components/InputGroup/InputGroup.vue";
+import { useDebounce } from "@vueuse/core";
+import { AutoCompleteInput } from "@/components/AutoCompleteInput";
 import { useUserAutocompleteQuery } from "@/queries/useUserAutocompleteQuery";
 import { useGroupMembersQuery } from "@/queries/useGroupMembersQuery";
 import { useAddGroupMemberMutation } from "@/queries/useAddGroupMemberMutation";
@@ -66,11 +65,12 @@ const { data: members } = useGroupMembersQuery(() => props.group.id, {
 const memberList = computed(() => members.value ?? []);
 
 const search = ref("");
-const { data: matches } = useUserAutocompleteQuery(search);
+const debouncedSearch = useDebounce(search, 300);
+const { data: matches, isFetching: isSearching } =
+  useUserAutocompleteQuery(debouncedSearch);
 const matchList = computed(() => matches.value ?? []);
 
 const addMutation = useAddGroupMemberMutation();
-const isAdding = computed(() => addMutation.isPending.value);
 
 const memberIds = computed(
   () => new Set(memberList.value.map((member) => member.userId))
@@ -93,5 +93,6 @@ function reasonNotAddable(match: UserAutocompleteMatch): string | null {
 function add(match: UserAutocompleteMatch) {
   if (match.localUserId === null) return;
   addMutation.mutate({ groupId: props.group.id, userId: match.localUserId });
+  search.value = "";
 }
 </script>

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -1,21 +1,6 @@
 <template>
   <div class="flex flex-col gap-4">
     <div>
-      <h4 class="text-sm font-bold text-on-surface-variant">Members</h4>
-      <p
-        v-if="memberList.length === 0"
-        class="mt-1 text-sm text-on-surface-variant">
-        No members yet.
-      </p>
-      <ul v-else class="mt-2 flex flex-col gap-1">
-        <li v-for="member in memberList" :key="member.userId" class="text-sm">
-          {{ member.name }}
-          <span class="text-on-surface-variant">{{ member.email }}</span>
-        </li>
-      </ul>
-    </div>
-
-    <div>
       <label
         :for="`group-${group.id}-add-member`"
         class="text-sm font-bold text-on-surface-variant">
@@ -42,6 +27,25 @@
         </template>
       </AutoCompleteInput>
     </div>
+    <div>
+      <h4 class="text-sm font-bold text-on-surface-variant">Members</h4>
+      <GroupMembersTable
+        :columns="columns"
+        :data="memberList"
+        class="mt-2" />
+    </div>
+
+    <ConfirmModal
+      :isOpen="memberToRemove !== null"
+      title="Remove member?"
+      type="danger"
+      confirmLabel="Remove"
+      @confirm="confirmRemove"
+      @close="memberToRemove = null">
+      <p v-if="memberToRemove">
+        Remove <strong>{{ memberToRemove.name }}</strong> from this group?
+      </p>
+    </ConfirmModal>
   </div>
 </template>
 
@@ -49,10 +53,18 @@
 import { computed, ref } from "vue";
 import { useDebounce } from "@vueuse/core";
 import { AutoCompleteInput } from "@/components/AutoCompleteInput";
+import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
+import GroupMembersTable from "./GroupMembersTable.vue";
+import { createGroupMemberColumns } from "./GroupMembersTableColumns";
 import { useUserAutocompleteQuery } from "@/queries/useUserAutocompleteQuery";
 import { useGroupMembersQuery } from "@/queries/useGroupMembersQuery";
 import { useAddGroupMemberMutation } from "@/queries/useAddGroupMemberMutation";
-import type { PermissionsGroup, UserAutocompleteMatch } from "@/types";
+import { useRemoveGroupMemberMutation } from "@/queries/useRemoveGroupMemberMutation";
+import type {
+  GroupMember,
+  PermissionsGroup,
+  UserAutocompleteMatch,
+} from "@/types";
 
 const props = defineProps<{
   group: PermissionsGroup;
@@ -71,6 +83,24 @@ const { data: matches, isFetching: isSearching } =
 const matchList = computed(() => matches.value ?? []);
 
 const addMutation = useAddGroupMemberMutation();
+const removeMutation = useRemoveGroupMemberMutation();
+
+const memberToRemove = ref<GroupMember | null>(null);
+
+function remove(member: GroupMember) {
+  memberToRemove.value = member;
+}
+
+function confirmRemove() {
+  if (memberToRemove.value) {
+    removeMutation.mutate({
+      groupId: props.group.id,
+      userId: memberToRemove.value.userId,
+    });
+  }
+}
+
+const columns = createGroupMemberColumns(remove);
 
 const memberIds = computed(
   () => new Set(memberList.value.map((member) => member.userId))

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <div>
+      <h4 class="text-sm font-bold text-on-surface-variant">Members</h4>
+      <p
+        v-if="memberList.length === 0"
+        class="mt-1 text-sm text-on-surface-variant">
+        No members yet.
+      </p>
+      <ul v-else class="mt-2 flex flex-col gap-1">
+        <li v-for="member in memberList" :key="member.userId" class="text-sm">
+          {{ member.name }}
+          <span class="text-on-surface-variant">{{ member.email }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <div>
+      <InputGroup
+        v-model="search"
+        label="Add member"
+        placeholder="Search by name or email…" />
+
+      <ul v-if="search.trim().length >= 2" class="mt-2 flex flex-col gap-1">
+        <li
+          v-if="matchList.length === 0"
+          class="p-2 text-sm text-on-surface-variant">
+          No matches.
+        </li>
+        <li v-for="match in matchList" :key="match.username">
+          <button
+            type="button"
+            class="flex w-full items-center gap-2 rounded p-2 text-left text-sm hover:bg-surface-container disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="!isAddable(match) || isAdding"
+            @click="add(match)">
+            <span>{{ match.name }}</span>
+            <span class="text-on-surface-variant">{{ match.email }}</span>
+            <span
+              v-if="reasonNotAddable(match)"
+              class="ml-auto text-xs italic text-on-surface-variant">
+              {{ reasonNotAddable(match) }}
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import InputGroup from "@/components/InputGroup/InputGroup.vue";
+import { useUserAutocompleteQuery } from "@/queries/useUserAutocompleteQuery";
+import { useGroupMembersQuery } from "@/queries/useGroupMembersQuery";
+import { useAddGroupMemberMutation } from "@/queries/useAddGroupMemberMutation";
+import type { PermissionsGroup, UserAutocompleteMatch } from "@/types";
+
+const props = defineProps<{
+  group: PermissionsGroup;
+  isOpen: boolean;
+}>();
+
+const { data: members } = useGroupMembersQuery(() => props.group.id, {
+  enabled: () => props.isOpen,
+});
+const memberList = computed(() => members.value ?? []);
+
+const search = ref("");
+const { data: matches } = useUserAutocompleteQuery(search);
+const matchList = computed(() => matches.value ?? []);
+
+const addMutation = useAddGroupMemberMutation();
+const isAdding = computed(() => addMutation.isPending.value);
+
+const memberIds = computed(
+  () => new Set(memberList.value.map((member) => member.userId))
+);
+
+function isAlreadyMember(match: UserAutocompleteMatch): boolean {
+  return match.localUserId !== null && memberIds.value.has(match.localUserId);
+}
+
+function isAddable(match: UserAutocompleteMatch): boolean {
+  return match.localUserId !== null && !isAlreadyMember(match);
+}
+
+function reasonNotAddable(match: UserAutocompleteMatch): string | null {
+  if (match.localUserId === null) return "not in the system yet";
+  if (isAlreadyMember(match)) return "already a member";
+  return null;
+}
+
+function add(match: UserAutocompleteMatch) {
+  if (match.localUserId === null) return;
+  addMutation.mutate({ groupId: props.group.id, userId: match.localUserId });
+}
+</script>

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="flex flex-col gap-4">
     <div>
-      <label
-        :for="`group-${group.id}-add-member`"
-        class="text-sm font-bold text-on-surface-variant">
+      <label :for="`group-${group.id}-add-member`" class="sr-only">
         Add member
       </label>
       <AutoCompleteInput
@@ -13,7 +11,7 @@
         :isLoading="isSearching"
         :isItemDisabled="(match: UserAutocompleteMatch) => !isAddable(match)"
         :blurOnSelect="false"
-        placeholder="Search by name or email…"
+        placeholder="Add member by name or email…"
         inputClass="mt-1 w-full bg-surface-container rounded-md px-3 py-2 text-sm"
         @select="add">
         <template #option="{ item }">
@@ -27,13 +25,7 @@
         </template>
       </AutoCompleteInput>
     </div>
-    <div>
-      <h4 class="text-sm font-bold text-on-surface-variant">Members</h4>
-      <GroupMembersTable
-        :columns="columns"
-        :data="memberList"
-        class="mt-2" />
-    </div>
+    <GroupMembersTable :columns="columns" :data="memberList" class="mb-2" />
 
     <ConfirmModal
       :isOpen="memberToRemove !== null"
@@ -43,7 +35,9 @@
       @confirm="confirmRemove"
       @close="memberToRemove = null">
       <p v-if="memberToRemove">
-        Remove <strong>{{ memberToRemove.name }}</strong> from this group?
+        Remove
+        <strong>{{ memberToRemove.name }}</strong>
+        from this group?
       </p>
     </ConfirmModal>
   </div>

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -10,46 +10,41 @@
         :items="options"
         :isLoading="isSearching"
         :isItemDisabled="isOptionDisabled"
-        :itemClass="optionClass"
         :blurOnSelect="false"
         placeholder="Add member by name, email, or username…"
         inputClass="mt-1 w-full bg-surface-container rounded-md px-3 py-2 text-sm"
         @select="add">
         <template #option="{ item }">
           <template v-if="item.kind === 'match'">
-            <span
-              class="flex size-8 flex-none items-center justify-center rounded-full bg-primary-container text-xs font-semibold text-on-primary-container">
+            <div
+              class="border border-current rounded-full size-8 flex items-center justify-center">
               {{ initials(item.match.name) }}
-            </span>
-            <span class="min-w-0 flex-1">
+            </div>
+            <div>
               <span class="block truncate font-medium">
                 {{ item.match.name }}
               </span>
-              <span class="block truncate text-xs text-inverse-on-surface/70">
+              <span class="block truncate text-xs">
                 {{ secondaryLine(item.match) }}
               </span>
-            </span>
-            <span
-              v-if="isAlreadyMember(item.match)"
-              class="ml-auto flex-none text-xs italic text-inverse-on-surface/70">
-              already a member
-            </span>
+              <em v-if="isAlreadyMember(item.match)" class="text-xs italic">
+                already a member
+              </em>
+            </div>
           </template>
           <template v-else>
-            <span
-              class="flex size-8 flex-none items-center justify-center rounded-lg bg-primary-container text-on-primary-container">
+            <div
+              class="border border-current rounded-md size-8 flex items-center justify-center">
               <PlusIcon class="size-4" />
-            </span>
-            <span class="min-w-0 flex-1">
+            </div>
+            <div>
               <span class="block truncate font-medium">
-                Create new user “{{ item.query }}”
+                Provision and add remote user
               </span>
-              <span class="block truncate text-xs text-inverse-on-surface/70">
-                Provision an account for someone not in the directory
+              <span class="block truncate text-xs">
+                with username: "{{ item.query }}"
               </span>
-            </span>
-            <ChevronRightIcon
-              class="ml-auto size-4 flex-none text-inverse-on-surface/50" />
+            </div>
           </template>
         </template>
       </AutoCompleteInput>
@@ -158,13 +153,6 @@ function isAlreadyMember(match: UserAutocompleteMatch): boolean {
 // only an existing member is unpickable; the create row is always actionable
 function isOptionDisabled(option: MemberOption): boolean {
   return option.kind === "match" && isAlreadyMember(option.match);
-}
-
-// set the pinned create row apart from the match rows above it
-function optionClass(option: MemberOption): string {
-  return option.kind === "create"
-    ? "border-t border-inverse-on-surface/15 bg-inverse-on-surface/5"
-    : "";
 }
 
 function add(option: MemberOption) {

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col gap-4">
-    <div>
+    <div :data-group-add-member="group.id">
       <label :for="`group-${group.id}-add-member`" class="sr-only">
         Add member
       </label>
@@ -78,7 +78,7 @@ import { AutoCompleteInput } from "@/components/AutoCompleteInput";
 import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import GroupMembersTable from "./GroupMembersTable.vue";
 import { createGroupMemberColumns } from "./GroupMembersTableColumns";
-import { ChevronRightIcon, PlusIcon } from "@/icons";
+import { PlusIcon } from "@/icons";
 import { useUserAutocompleteQuery } from "@/queries/useUserAutocompleteQuery";
 import { useGroupMembersQuery } from "@/queries/useGroupMembersQuery";
 import { useAddGroupMemberMutation } from "@/queries/useAddGroupMemberMutation";

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -7,21 +7,50 @@
       <AutoCompleteInput
         :id="`group-${group.id}-add-member`"
         v-model="search"
-        :items="matchList"
+        :items="options"
         :isLoading="isSearching"
-        :isItemDisabled="(match: UserAutocompleteMatch) => !isAddable(match)"
+        :isItemDisabled="isOptionDisabled"
+        :itemClass="optionClass"
         :blurOnSelect="false"
-        placeholder="Add member by name or email…"
+        placeholder="Add member by name, email, or username…"
         inputClass="mt-1 w-full bg-surface-container rounded-md px-3 py-2 text-sm"
         @select="add">
         <template #option="{ item }">
-          <span>{{ item.name }}</span>
-          <span class="text-inverse-on-surface/70">{{ item.email }}</span>
-          <span
-            v-if="reasonNotAddable(item)"
-            class="ml-auto text-xs italic text-inverse-on-surface/70">
-            {{ reasonNotAddable(item) }}
-          </span>
+          <template v-if="item.kind === 'match'">
+            <span
+              class="flex size-8 flex-none items-center justify-center rounded-full bg-primary-container text-xs font-semibold text-on-primary-container">
+              {{ initials(item.match.name) }}
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate font-medium">
+                {{ item.match.name }}
+              </span>
+              <span class="block truncate text-xs text-inverse-on-surface/70">
+                {{ secondaryLine(item.match) }}
+              </span>
+            </span>
+            <span
+              v-if="isAlreadyMember(item.match)"
+              class="ml-auto flex-none text-xs italic text-inverse-on-surface/70">
+              already a member
+            </span>
+          </template>
+          <template v-else>
+            <span
+              class="flex size-8 flex-none items-center justify-center rounded-lg bg-primary-container text-on-primary-container">
+              <PlusIcon class="size-4" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate font-medium">
+                Create new user “{{ item.query }}”
+              </span>
+              <span class="block truncate text-xs text-inverse-on-surface/70">
+                Provision an account for someone not in the directory
+              </span>
+            </span>
+            <ChevronRightIcon
+              class="ml-auto size-4 flex-none text-inverse-on-surface/50" />
+          </template>
         </template>
       </AutoCompleteInput>
     </div>
@@ -50,6 +79,7 @@ import { AutoCompleteInput } from "@/components/AutoCompleteInput";
 import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import GroupMembersTable from "./GroupMembersTable.vue";
 import { createGroupMemberColumns } from "./GroupMembersTableColumns";
+import { ChevronRightIcon, PlusIcon } from "@/icons";
 import { useUserAutocompleteQuery } from "@/queries/useUserAutocompleteQuery";
 import { useGroupMembersQuery } from "@/queries/useGroupMembersQuery";
 import { useAddGroupMemberMutation } from "@/queries/useAddGroupMemberMutation";
@@ -59,6 +89,12 @@ import type {
   PermissionsGroup,
   UserAutocompleteMatch,
 } from "@/types";
+
+// A row in the add-member dropdown: a person to pick, or the pinned action
+// that provisions a brand-new account from whatever was typed.
+type MemberOption =
+  | { kind: "match"; match: UserAutocompleteMatch }
+  | { kind: "create"; query: string };
 
 const props = defineProps<{
   group: PermissionsGroup;
@@ -75,6 +111,21 @@ const debouncedSearch = useDebounce(search, 300);
 const { data: matches, isFetching: isSearching } =
   useUserAutocompleteQuery(debouncedSearch);
 const matchList = computed(() => matches.value ?? []);
+
+// matches first, then a create row pinned to the bottom whenever there is
+// text to provision — present even when matches exist, so creating someone
+// not in the directory is always one click away
+const options = computed<MemberOption[]>(() => {
+  const rows: MemberOption[] = matchList.value.map((match) => ({
+    kind: "match",
+    match,
+  }));
+  const query = search.value.trim();
+  if (query.length > 0) {
+    rows.push({ kind: "create", query });
+  }
+  return rows;
+});
 
 const addMutation = useAddGroupMemberMutation();
 const removeMutation = useRemoveGroupMemberMutation();
@@ -104,19 +155,57 @@ function isAlreadyMember(match: UserAutocompleteMatch): boolean {
   return match.localUserId !== null && memberIds.value.has(match.localUserId);
 }
 
-function isAddable(match: UserAutocompleteMatch): boolean {
-  return match.localUserId !== null && !isAlreadyMember(match);
+// only an existing member is unpickable; the create row is always actionable
+function isOptionDisabled(option: MemberOption): boolean {
+  return option.kind === "match" && isAlreadyMember(option.match);
 }
 
-function reasonNotAddable(match: UserAutocompleteMatch): string | null {
-  if (match.localUserId === null) return "not in the system yet";
-  if (isAlreadyMember(match)) return "already a member";
-  return null;
+// set the pinned create row apart from the match rows above it
+function optionClass(option: MemberOption): string {
+  return option.kind === "create"
+    ? "border-t border-inverse-on-surface/15 bg-inverse-on-surface/5"
+    : "";
 }
 
-function add(match: UserAutocompleteMatch) {
-  if (match.localUserId === null) return;
-  addMutation.mutate({ groupId: props.group.id, userId: match.localUserId });
+function add(option: MemberOption) {
+  if (option.kind === "create") {
+    provision(option.query);
+    return;
+  }
+
+  const { match } = option;
+  if (isAlreadyMember(match)) return;
+
+  // a local match adds by id; a directory match with no local row yet
+  // provisions through its remote username
+  addMutation.mutate(
+    match.localUserId !== null
+      ? { groupId: props.group.id, localUserId: match.localUserId }
+      : { groupId: props.group.id, remoteUserId: match.username }
+  );
   search.value = "";
+}
+
+// the create row's text is the remote id to provision — a netid the admin
+// typed at a school whose directory the search can't reach
+function provision(query: string) {
+  const remoteUserId = query.trim();
+  if (remoteUserId === "") return;
+  addMutation.mutate({ groupId: props.group.id, remoteUserId });
+  search.value = "";
+}
+
+// username, plus email when the directory gave us one
+function secondaryLine(match: UserAutocompleteMatch): string {
+  return match.email ? `${match.username} · ${match.email}` : match.username;
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
 }
 </script>

--- a/src/pages/AdminPermissionsPage/GroupMemberManager.vue
+++ b/src/pages/AdminPermissionsPage/GroupMemberManager.vue
@@ -147,12 +147,14 @@ function remove(member: GroupMember) {
 }
 
 function confirmRemove() {
-  if (memberToRemove.value) {
-    removeMutation.mutate({
-      groupId: props.group.id,
-      userId: memberToRemove.value.userId,
-    });
-  }
+  if (!memberToRemove.value) return;
+  removeMutation.mutate({
+    groupId: props.group.id,
+    userId: memberToRemove.value.userId,
+  });
+  // Close the confirm modal now
+  // removal is optimistic, no need to wait for mutation
+  memberToRemove.value = null;
 }
 
 const columns = createGroupMemberColumns(remove);

--- a/src/pages/AdminPermissionsPage/GroupMembersTable.vue
+++ b/src/pages/AdminPermissionsPage/GroupMembersTable.vue
@@ -8,7 +8,7 @@
           <TableHead
             v-for="header in headerGroup.headers"
             :key="header.id"
-            class="bg-surface-container-lowest"
+            class="bg-surface-container-low"
             :class="{
               'cursor-pointer select-none': header.column.getCanSort(),
             }"
@@ -21,11 +21,11 @@
               <template v-if="header.column.getCanSort()">
                 <ArrowUpDown
                   v-if="!header.column.getIsSorted()"
-                  class="h-4 w-4 text-muted-foreground/50" />
+                  class="h-4 w-4 text-on-surface-muted" />
                 <ArrowUp
                   v-else-if="header.column.getIsSorted() === 'asc'"
-                  class="h-4 w-4" />
-                <ArrowDown v-else class="h-4 w-4" />
+                  class="h-4 w-4 text-primary" />
+                <ArrowDown v-else class="h-4 w-4 text-primary" />
               </template>
             </div>
           </TableHead>
@@ -33,9 +33,7 @@
       </TableHeader>
       <TableBody>
         <template v-if="table.getRowModel().rows?.length">
-          <TableRow
-            v-for="row in table.getRowModel().rows"
-            :key="row.id">
+          <TableRow v-for="row in table.getRowModel().rows" :key="row.id">
             <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id">
               <FlexRender
                 :render="cell.column.columnDef.cell"

--- a/src/pages/AdminPermissionsPage/GroupMembersTable.vue
+++ b/src/pages/AdminPermissionsPage/GroupMembersTable.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="border border-outline-variant rounded-md">
+    <Table class="w-full">
+      <TableHeader>
+        <TableRow
+          v-for="headerGroup in table.getHeaderGroups()"
+          :key="headerGroup.id">
+          <TableHead
+            v-for="header in headerGroup.headers"
+            :key="header.id"
+            class="bg-surface-container-lowest"
+            :class="{
+              'cursor-pointer select-none': header.column.getCanSort(),
+            }"
+            @click="header.column.getToggleSortingHandler()?.($event)">
+            <div class="flex items-center gap-2">
+              <FlexRender
+                v-if="!header.isPlaceholder"
+                :render="header.column.columnDef.header"
+                :props="header.getContext()" />
+              <template v-if="header.column.getCanSort()">
+                <ArrowUpDown
+                  v-if="!header.column.getIsSorted()"
+                  class="h-4 w-4 text-muted-foreground/50" />
+                <ArrowUp
+                  v-else-if="header.column.getIsSorted() === 'asc'"
+                  class="h-4 w-4" />
+                <ArrowDown v-else class="h-4 w-4" />
+              </template>
+            </div>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <template v-if="table.getRowModel().rows?.length">
+          <TableRow
+            v-for="row in table.getRowModel().rows"
+            :key="row.id">
+            <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id">
+              <FlexRender
+                :render="cell.column.columnDef.cell"
+                :props="cell.getContext()" />
+            </TableCell>
+          </TableRow>
+        </template>
+        <template v-else>
+          <TableRow>
+            <TableCell
+              :colspan="columns.length"
+              class="h-16 text-center text-sm text-on-surface-variant">
+              No members yet.
+            </TableCell>
+          </TableRow>
+        </template>
+      </TableBody>
+    </Table>
+  </div>
+</template>
+
+<script setup lang="ts" generic="TData">
+import { ref } from "vue";
+import type { ColumnDef, SortingState } from "@tanstack/vue-table";
+import {
+  FlexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useVueTable,
+} from "@tanstack/vue-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-vue-next";
+
+const props = defineProps<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columns: ColumnDef<TData, any>[];
+  data: TData[];
+}>();
+
+const sorting = ref<SortingState>([{ id: "name", desc: false }]);
+
+const table = useVueTable({
+  get data() {
+    return props.data;
+  },
+  get columns() {
+    return props.columns;
+  },
+  getCoreRowModel: getCoreRowModel(),
+  getSortedRowModel: getSortedRowModel(),
+  onSortingChange: (updater) => {
+    sorting.value =
+      typeof updater === "function" ? updater(sorting.value) : updater;
+  },
+  state: {
+    get sorting() {
+      return sorting.value;
+    },
+  },
+});
+</script>

--- a/src/pages/AdminPermissionsPage/GroupMembersTable.vue
+++ b/src/pages/AdminPermissionsPage/GroupMembersTable.vue
@@ -32,7 +32,14 @@
         </TableRow>
       </TableHeader>
       <TableBody>
-        <template v-if="table.getRowModel().rows?.length">
+        <template v-if="isLoading">
+          <TableRow v-for="row in SKELETON_ROW_COUNT" :key="`skeleton-${row}`">
+            <TableCell v-for="(_, index) in columns" :key="index">
+              <Skeleton height="1rem" width="70%" />
+            </TableCell>
+          </TableRow>
+        </template>
+        <template v-else-if="table.getRowModel().rows?.length">
           <TableRow v-for="row in table.getRowModel().rows" :key="row.id">
             <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id">
               <FlexRender
@@ -73,11 +80,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-vue-next";
+import Skeleton from "@/components/Skeleton/Skeleton.vue";
+
+// Placeholder rows shown while the member list loads.
+const SKELETON_ROW_COUNT = 3;
 
 const props = defineProps<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   columns: ColumnDef<TData, any>[];
   data: TData[];
+  isLoading?: boolean;
 }>();
 
 const sorting = ref<SortingState>([{ id: "name", desc: false }]);

--- a/src/pages/AdminPermissionsPage/GroupMembersTableColumns.tsx
+++ b/src/pages/AdminPermissionsPage/GroupMembersTableColumns.tsx
@@ -1,0 +1,66 @@
+import { createColumnHelper } from "@tanstack/vue-table";
+import { XIcon } from "lucide-vue-next";
+import type { CSSClass, GroupMember } from "@/types";
+import { cn } from "@/lib/utils";
+import IconButton from "@/components/IconButton/IconButton.vue";
+
+const columnHelper = createColumnHelper<GroupMember>();
+
+const ColHeader = (props: { text: string; class?: CSSClass }) => (
+  <div class={cn(["font-medium", props.class])}>{props.text}</div>
+);
+
+export const createGroupMemberColumns = (
+  onRemove: (member: GroupMember) => void
+) => [
+  columnHelper.accessor("name", {
+    header: () => <ColHeader text="Name" />,
+    cell: (ctx) => <div class="text-sm">{ctx.getValue()}</div>,
+  }),
+  columnHelper.accessor("email", {
+    header: () => <ColHeader text="Email" />,
+    cell: (ctx) => (
+      <div class="text-sm text-muted-foreground">{ctx.getValue() || "—"}</div>
+    ),
+  }),
+  columnHelper.accessor("username", {
+    header: () => <ColHeader text="Username" />,
+    cell: (ctx) => (
+      <div class="text-sm text-muted-foreground">{ctx.getValue() || "—"}</div>
+    ),
+  }),
+  columnHelper.accessor("userType", {
+    header: () => <ColHeader text="Type" />,
+    cell: (ctx) => (
+      <div class="text-sm text-muted-foreground">{ctx.getValue()}</div>
+    ),
+  }),
+  columnHelper.accessor("createdAt", {
+    header: () => <ColHeader text="Created" />,
+    cell: (ctx) => {
+      const value = ctx.getValue();
+      return (
+        <div class="text-sm text-muted-foreground">
+          {value ? new Date(value).toLocaleDateString() : "—"}
+        </div>
+      );
+    },
+  }),
+  {
+    id: "actions",
+    header: () => <ColHeader text="" />,
+    enableSorting: false,
+    cell: ({ row }: { row: { original: GroupMember } }) => (
+      <div class="flex justify-end">
+        <IconButton
+          onClick={() => onRemove(row.original)}
+          title="Remove member"
+          showTooltip={false}
+          class="enabled:text-error enabled:hover:bg-error-container enabled:hover:text-on-error-container">
+          <XIcon class="size-4" />
+        </IconButton>
+      </div>
+    ),
+    maxSize: 64,
+  },
+];

--- a/src/pages/AdminPermissionsPage/GroupMembersTableColumns.tsx
+++ b/src/pages/AdminPermissionsPage/GroupMembersTableColumns.tsx
@@ -7,7 +7,9 @@ import IconButton from "@/components/IconButton/IconButton.vue";
 const columnHelper = createColumnHelper<GroupMember>();
 
 const ColHeader = (props: { text: string; class?: CSSClass }) => (
-  <div class={cn(["font-medium", props.class])}>{props.text}</div>
+  <div class={cn(["font-medium uppercase text-xs leading-loose", props.class])}>
+    {props.text}
+  </div>
 );
 
 export const createGroupMemberColumns = (
@@ -15,24 +17,26 @@ export const createGroupMemberColumns = (
 ) => [
   columnHelper.accessor("name", {
     header: () => <ColHeader text="Name" />,
-    cell: (ctx) => <div class="text-sm">{ctx.getValue()}</div>,
+    cell: (ctx) => (
+      <div class="text-sm text-on-surface font-medium">{ctx.getValue()}</div>
+    ),
   }),
   columnHelper.accessor("email", {
     header: () => <ColHeader text="Email" />,
     cell: (ctx) => (
-      <div class="text-sm text-muted-foreground">{ctx.getValue() || "—"}</div>
+      <div class="text-sm text-on-surface-variant">{ctx.getValue() || "—"}</div>
     ),
   }),
   columnHelper.accessor("username", {
     header: () => <ColHeader text="Username" />,
     cell: (ctx) => (
-      <div class="text-sm text-muted-foreground">{ctx.getValue() || "—"}</div>
+      <div class="text-sm text-on-surface-variant">{ctx.getValue() || "—"}</div>
     ),
   }),
   columnHelper.accessor("userType", {
     header: () => <ColHeader text="Type" />,
     cell: (ctx) => (
-      <div class="text-sm text-muted-foreground">{ctx.getValue()}</div>
+      <div class="text-sm text-on-surface-variant">{ctx.getValue()}</div>
     ),
   }),
   columnHelper.accessor("createdAt", {
@@ -40,7 +44,7 @@ export const createGroupMemberColumns = (
     cell: (ctx) => {
       const value = ctx.getValue();
       return (
-        <div class="text-sm text-muted-foreground">
+        <div class="text-sm text-on-surface-variant">
           {value ? new Date(value).toLocaleDateString() : "—"}
         </div>
       );

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="flex items-center justify-between">
-    <p>Help text goes here about groups and how they work.</p>
+  <div class="flex justify-end">
     <Button variant="primary" @click="openCreate">Create Group</Button>
   </div>
 
@@ -15,50 +14,34 @@
     v-else
     v-model="openGroupIds"
     type="multiple"
-    class="mt-4 flex flex-col gap-2">
+    class="mt-4 flex flex-col rounded-md overflow-hidden border border-outline-variant">
     <AccordionItem
       v-for="group in groups"
       :key="group.id"
       :value="String(group.id)"
-      class="rounded-md border border-outline-variant bg-surface-container">
-      <AccordionHeader
-        class="group flex w-full items-center gap-4 p-4 text-left">
-        <AccordionTrigger class="flex items-center gap-4">
+      class="border-b border-outline-variant bg-surface-container">
+      <AccordionHeader class="group flex w-full items-center gap-4 p-2">
+        <AccordionTrigger
+          class="flex items-center gap-2 text-sm font-medium text-left">
           <ChevronRightIcon
-            class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90" />
-          <span class="text-lg font-bold">{{ group.label }}</span>
+            class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90 !size-4" />
+          {{ group.label }}
         </AccordionTrigger>
         <div
-          class="ml-auto flex items-center text-sm text-on-surface-variant gap-2">
+          class="ml-auto flex items-center text-sm text-on-surface-variant gap-1">
           <Chip
             v-if="group.type === GROUP_TYPES.USER"
             class="bg-secondary-container">
             {{ group.values.length }}
             {{ pluralize(group.values.length, "member") }}
           </Chip>
-          <div v-else>{{ typeLabel(group.type) }}</div>
-        </div>
-        <DropDown
-          alignment="right"
-          :showChevron="false"
-          labelClass="rounded-full hover:bg-surface-container-high">
-          <template #label>
-            <VerticalDotsIcon class="size-5" />
-            <span class="sr-only">More actions</span>
-          </template>
-          <DropDownItem @click="openEdit(group)">Edit Group</DropDownItem>
-          <DropDownItem @click="handleDelete(group)">
-            <span class="text-error">Delete Group</span>
-          </DropDownItem>
-        </DropDown>
-      </AccordionHeader>
-      <AccordionContent
-        class="border-t border-outline-variant p-4 bg-surface-container-lowest">
-        <div class="flex justify-end">
+          <div v-else>
+            {{ groupTypesMap.get(group.type)?.label ?? group.type }}
+          </div>
           <DropDown
             alignment="right"
             :showChevron="false"
-            labelClass="rounded-full hover:bg-surface-container-high">
+            labelClass="rounded-full hover:bg-surface-container-high justify-self-end">
             <template #label>
               <VerticalDotsIcon class="size-5" />
               <span class="sr-only">More actions</span>
@@ -69,11 +52,15 @@
             </DropDownItem>
           </DropDown>
         </div>
+      </AccordionHeader>
+      <AccordionContent
+        class="border-t border-outline-variant p-4 pl-8 bg-surface-container-lowest text-sm">
+        {{ groupTypesMap.get(group.type)?.description }}
         <GroupMemberManager
           v-if="group.type === GROUP_TYPES.USER"
           :group="group"
           :isOpen="openGroupIds.includes(String(group.id))"
-          class="mt-2" />
+          class="my-2 max-w-screen-md m-auto" />
       </AccordionContent>
     </AccordionItem>
   </AccordionRoot>
@@ -102,20 +89,21 @@ import GroupMemberManager from "./GroupMemberManager.vue";
 import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
 import { GROUP_TYPES } from "@/types";
-import type { GroupTypeValues, PermissionsGroup } from "@/types";
+import type {
+  GroupTypeValues,
+  LabelledGroupType,
+  PermissionsGroup,
+} from "@/types";
 import { pluralize } from "@/helpers/pluralize.js";
 import Chip from "@/components/Chip/Chip.vue";
 
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
 
-const typeLabelByValue = computed(
-  () => new Map(groupTypes.value?.map((type) => [type.type, type.label]) ?? [])
-);
-
-function typeLabel(type: GroupTypeValues) {
-  return typeLabelByValue.value.get(type) ?? type;
-}
+const groupTypesMap = computed((): Map<GroupTypeValues, LabelledGroupType> => {
+  const entries = groupTypes.value?.map((g) => [g.type, g] as const) ?? [];
+  return new Map(entries);
+});
 
 // ids of the currently expanded accordion items, so each group fetches its
 // members only when opened

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -11,7 +11,11 @@
     No groups yet. Create one to get started.
   </p>
 
-  <AccordionRoot v-else type="multiple" class="mt-4 flex flex-col gap-2">
+  <AccordionRoot
+    v-else
+    v-model="openGroupIds"
+    type="multiple"
+    class="mt-4 flex flex-col gap-2">
     <AccordionItem
       v-for="group in groups"
       :key="group.id"
@@ -35,6 +39,11 @@
       </AccordionHeader>
       <AccordionContent
         class="border-t border-outline-variant p-4 bg-surface-container-lowest">
+        <GroupMemberManager
+          v-if="group.type === GROUP_TYPES.USER"
+          :group="group"
+          :isOpen="openGroupIds.includes(String(group.id))"
+          class="mb-4" />
         <div class="flex items-center gap-2">
           <Button variant="secondary" @click="openEdit(group)">
             Edit Group
@@ -62,6 +71,7 @@ import {
 } from "reka-ui";
 import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
 import GroupFormModal from "./GroupFormModal.vue";
+import GroupMemberManager from "./GroupMemberManager.vue";
 import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
 import { GROUP_TYPES } from "@/types";
@@ -77,6 +87,10 @@ const typeLabelByValue = computed(
 function typeLabel(type: GroupTypeValues) {
   return typeLabelByValue.value.get(type) ?? type;
 }
+
+// ids of the currently expanded accordion items, so each group fetches its
+// members only when opened
+const openGroupIds = ref<string[]>([]);
 
 const editingGroup = ref<PermissionsGroup | null>(null);
 const isGroupModalOpen = ref(false);

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="flex items-center justify-between">
+    <p>Help text goes here about groups and how they work.</p>
+    <Button variant="primary" @click="isCreateGroupOpen = true">
+      Create Group
+    </Button>
+  </div>
+
+  <AccordionRoot type="multiple" class="mt-4 flex flex-col gap-2">
+    <AccordionItem
+      v-for="groupType in groupTypes"
+      :key="groupType.type"
+      :value="groupType.type"
+      class="rounded-md border border-outline-variant bg-surface-container">
+      <AccordionHeader>
+        <AccordionTrigger
+          class="group flex w-full items-center gap-4 p-4 text-left">
+          <ChevronRightIcon
+            class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90" />
+          <span class="text-lg font-bold">{{ groupType.label }}</span>
+          <span
+            class="ml-auto flex items-center gap-4 text-sm text-on-surface-variant">
+            <span>{{ groupType.description }}</span>
+            <!-- <span>1 grant</span> -->
+          </span>
+        </AccordionTrigger>
+      </AccordionHeader>
+      <AccordionContent
+        class="border-t border-outline-variant p-4 bg-surface-container-lowest">
+        <Button variant="danger">Delete Group</Button>
+      </AccordionContent>
+    </AccordionItem>
+  </AccordionRoot>
+  <Modal
+    :isOpen="isCreateGroupOpen"
+    label="New Group"
+    class="max-w-md"
+    @close="isCreateGroupOpen = false">
+    <InputGroup v-model="newGroupForm.name" label="Name" />
+    <SelectGroup v-model="newGroupForm.type" label="Type" :options="[]" />
+  </Modal>
+</template>
+<script setup lang="ts">
+import { reactive, ref } from "vue";
+import Button from "@/components/Button/Button.vue";
+import {
+  AccordionRoot,
+  AccordionTrigger,
+  AccordionContent,
+  AccordionHeader,
+  AccordionItem,
+} from "reka-ui";
+import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
+import Modal from "@/components/Modal/Modal.vue";
+import InputGroup from "@/components/InputGroup/InputGroup.vue";
+import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
+import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
+
+const { data: groupTypes } = useGroupTypesQuery();
+
+const isCreateGroupOpen = ref(false);
+const newGroupForm = reactive({
+  name: "",
+  type: "",
+});
+</script>
+<style scoped></style>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -72,6 +72,20 @@
       :isOpen="isGroupModalOpen"
       :group="editingGroup"
       @close="closeGroupModal" />
+
+    <ConfirmModal
+      :isOpen="Boolean(groupPendingDelete)"
+      title="Delete Group"
+      type="danger"
+      confirmLabel="Delete"
+      @close="groupPendingDelete = null"
+      @confirm="confirmDelete">
+      <p>
+        Are you sure you want to delete group
+        <b>{{ groupPendingDelete?.label || groupPendingDelete?.type }}</b>
+        ? This action cannot be undone.
+      </p>
+    </ConfirmModal>
   </div>
 </template>
 <script setup lang="ts">
@@ -90,6 +104,7 @@ import DropDown from "@/components/DropDown/DropDown.vue";
 import DropDownItem from "@/components/DropDown/DropDownItem.vue";
 import GroupFormModal from "./GroupFormModal.vue";
 import GroupMemberManager from "./GroupMemberManager.vue";
+import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
 import { GROUP_TYPES } from "@/types";
@@ -132,9 +147,17 @@ function closeGroupModal() {
   isGroupModalOpen.value = false;
 }
 
+// the group awaiting delete confirmation; also drives the modal's open state
+const groupPendingDelete = ref<PermissionsGroup | null>(null);
+
 function handleDelete(group: PermissionsGroup) {
-  // TODO: delete is not wired yet. The backend deleteGroup returns 501.
-  deleteGroup(group);
+  groupPendingDelete.value = group;
+}
+
+function confirmDelete() {
+  if (!groupPendingDelete.value) return;
+  deleteGroup(groupPendingDelete.value);
+  groupPendingDelete.value = null;
 }
 </script>
 <style scoped></style>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -38,7 +38,8 @@
         class="border-b border-outline-variant last:border-b-0">
         <AccordionHeader class="group flex w-full items-center gap-4">
           <AccordionTrigger
-            class="flex items-center gap-2 text-sm font-medium text-left flex-1 p-4 data-[state=open]:font-bold">
+            :data-group-trigger="group.id"
+            class="flex items-center gap-2 text-sm font-medium text-left flex-1 p-4 data-[state=open]:font-bold focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary">
             <ChevronRightIcon
               class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90 !size-4" />
             {{ group.label || group.type }}
@@ -83,7 +84,8 @@
     <GroupFormModal
       :isOpen="isGroupModalOpen"
       :group="editingGroup"
-      @close="closeGroupModal" />
+      @close="closeGroupModal"
+      @created="handleCreated" />
 
     <ConfirmModal
       :isOpen="Boolean(groupPendingDelete)"
@@ -127,6 +129,7 @@ import type {
   PermissionsGroup,
 } from "@/types";
 import { pluralize } from "@/helpers/pluralize.js";
+import { tryFocus } from "@/helpers/tryFocus";
 import Chip from "@/components/Chip/Chip.vue";
 import { useDeleteGroupMutation } from "@/queries/useDeleteGroupMutation.js";
 
@@ -154,6 +157,32 @@ const groupTypesMap = computed((): Map<GroupTypeValues, LabelledGroupType> => {
 // ids of the currently expanded accordion items, so each group fetches its
 // members only when opened
 const openGroupIds = ref<string[]>([]);
+
+// Open a freshly created group and move focus into it: a User group lands on
+// its add-member field so the admin can start adding people, other types land
+// on the accordion trigger and scroll into view. The row, its open content,
+// and the input mount across several frames, so tryFocus retries until focus
+// lands rather than guessing a single tick.
+async function handleCreated(group: PermissionsGroup) {
+  const groupId = String(group.id);
+  if (!openGroupIds.value.includes(groupId)) {
+    openGroupIds.value = [...openGroupIds.value, groupId];
+  }
+
+  // the User input sits inside reka's PopoverAnchor — reach it through our own
+  // wrapper's data attribute; other types focus the accordion trigger
+  const isUserGroup = group.type === GROUP_TYPES.USER;
+  const selector = isUserGroup
+    ? `[data-group-add-member="${group.id}"] input`
+    : `[data-group-trigger="${group.id}"]`;
+
+  try {
+    const focused = await tryFocus(selector);
+    if (!isUserGroup) focused.scrollIntoView({ block: "nearest" });
+  } catch (error) {
+    console.warn(`Could not focus new ${group.type} group`, error);
+  }
+}
 
 const editingGroup = ref<PermissionsGroup | null>(null);
 const isGroupModalOpen = ref(false);

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -7,7 +7,18 @@
       <Button variant="primary" @click="openCreate">Create Group</Button>
     </div>
 
-    <p v-if="isLoading" class="mt-4 text-on-surface-variant">Loading groups…</p>
+    <div
+      v-if="isLoading"
+      class="my-4 flex flex-col border-y border-outline-variant">
+      <div
+        v-for="row in SKELETON_ROW_COUNT"
+        :key="`skeleton-${row}`"
+        class="flex items-center gap-4 border-b border-outline-variant p-4 last:border-b-0">
+        <Skeleton width="1rem" height="1rem" />
+        <Skeleton width="30%" height="1rem" />
+        <Skeleton width="5rem" height="1.5rem" class="ml-auto rounded-full" />
+      </div>
+    </div>
     <p
       v-else-if="!sortedGroups?.length"
       class="mt-4 rounded-md border border-dashed border-outline-variant p-8 text-center text-on-surface-variant">
@@ -101,6 +112,7 @@ import {
 } from "reka-ui";
 import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
 import VerticalDotsIcon from "@/icons/VerticalDotsIcon.vue";
+import Skeleton from "@/components/Skeleton/Skeleton.vue";
 import DropDown from "@/components/DropDown/DropDown.vue";
 import DropDownItem from "@/components/DropDown/DropDownItem.vue";
 import GroupFormModal from "./GroupFormModal.vue";
@@ -117,6 +129,9 @@ import type {
 import { pluralize } from "@/helpers/pluralize.js";
 import Chip from "@/components/Chip/Chip.vue";
 import { useDeleteGroupMutation } from "@/queries/useDeleteGroupMutation.js";
+
+// Placeholder rows shown while the group list loads.
+const SKELETON_ROW_COUNT = 3;
 
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -9,7 +9,7 @@
 
     <p v-if="isLoading" class="mt-4 text-on-surface-variant">Loading groups…</p>
     <p
-      v-else-if="!groups?.length"
+      v-else-if="!sortedGroups?.length"
       class="mt-4 rounded-md border border-dashed border-outline-variant p-8 text-center text-on-surface-variant">
       No groups yet. Create one to get started.
     </p>
@@ -20,7 +20,7 @@
       type="multiple"
       class="my-4 flex flex-col border-y border-outline-variant">
       <AccordionItem
-        v-for="group in groups"
+        v-for="group in sortedGroups"
         :key="group.id"
         :value="String(group.id)"
         class="border-b border-outline-variant last:border-b-0">
@@ -120,6 +120,15 @@ import { useDeleteGroupMutation } from "@/queries/useDeleteGroupMutation.js";
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
 const { mutate: deleteGroup } = useDeleteGroupMutation();
+
+const byAlphaNumeric = (a: PermissionsGroup, b: PermissionsGroup) => {
+  const labelA = a.label || a.type;
+  const labelB = b.label || b.type;
+  return labelA.localeCompare(labelB, undefined, { numeric: true });
+};
+const sortedGroups = computed(
+  () => groups.value?.toSorted(byAlphaNumeric) ?? []
+);
 
 const groupTypesMap = computed((): Map<GroupTypeValues, LabelledGroupType> => {
   const entries = groupTypes.value?.map((g) => [g.type, g] as const) ?? [];

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -28,7 +28,7 @@
           <span
             class="ml-auto flex items-center gap-4 text-sm text-on-surface-variant">
             <span>{{ typeLabel(group.type) }}</span>
-            <span v-if="group.type === PERMISSIONS_GROUP_TYPES.USER">
+            <span v-if="group.type === GROUP_TYPES.USER">
               {{ group.values.length }}
               {{ group.values.length === 1 ? "member" : "members" }}
             </span>
@@ -60,8 +60,8 @@ import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
 import CreateGroupModal from "./CreateGroupModal.vue";
 import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
-import { PERMISSIONS_GROUP_TYPES } from "@/types";
-import type { PermissionsGroupTypeValues } from "@/types";
+import { GROUP_TYPES } from "@/types";
+import type { GroupTypeValues } from "@/types";
 
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
@@ -70,7 +70,7 @@ const typeLabelByValue = computed(
   () => new Map(groupTypes.value?.map((type) => [type.type, type.label]) ?? [])
 );
 
-function typeLabel(type: PermissionsGroupTypeValues) {
+function typeLabel(type: GroupTypeValues) {
   return typeLabelByValue.value.get(type) ?? type;
 }
 

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -1,74 +1,78 @@
 <template>
-  <div class="flex justify-end">
-    <Button variant="primary" @click="openCreate">Create Group</Button>
-  </div>
+  <div>
+    <div class="flex justify-between items-center gap-8">
+      <p class="text-sm">
+        Create a group to manage permissions for a set of users.
+      </p>
+      <Button variant="primary" @click="openCreate">Create Group</Button>
+    </div>
 
-  <p v-if="isLoading" class="mt-4 text-on-surface-variant">Loading groups…</p>
-  <p
-    v-else-if="!groups?.length"
-    class="mt-4 rounded-md border border-dashed border-outline-variant p-8 text-center text-on-surface-variant">
-    No groups yet. Create one to get started.
-  </p>
+    <p v-if="isLoading" class="mt-4 text-on-surface-variant">Loading groups…</p>
+    <p
+      v-else-if="!groups?.length"
+      class="mt-4 rounded-md border border-dashed border-outline-variant p-8 text-center text-on-surface-variant">
+      No groups yet. Create one to get started.
+    </p>
 
-  <AccordionRoot
-    v-else
-    v-model="openGroupIds"
-    type="multiple"
-    class="mt-4 flex flex-col rounded-md overflow-hidden border border-outline-variant">
-    <AccordionItem
-      v-for="group in groups"
-      :key="group.id"
-      :value="String(group.id)"
-      class="border-b border-outline-variant bg-surface-container">
-      <AccordionHeader class="group flex w-full items-center gap-4 p-2">
-        <AccordionTrigger
-          class="flex items-center gap-2 text-sm font-medium text-left">
-          <ChevronRightIcon
-            class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90 !size-4" />
-          {{ group.label }}
-        </AccordionTrigger>
-        <div
-          class="ml-auto flex items-center text-sm text-on-surface-variant gap-1">
-          <Chip
-            v-if="group.type === GROUP_TYPES.USER"
-            class="bg-secondary-container">
-            {{ group.values.length }}
-            {{ pluralize(group.values.length, "member") }}
-          </Chip>
-          <div v-else>
-            {{ groupTypesMap.get(group.type)?.label ?? group.type }}
+    <AccordionRoot
+      v-else
+      v-model="openGroupIds"
+      type="multiple"
+      class="my-4 flex flex-col border-y border-outline-variant">
+      <AccordionItem
+        v-for="group in groups"
+        :key="group.id"
+        :value="String(group.id)"
+        class="border-b border-outline-variant last:border-b-0">
+        <AccordionHeader class="group flex w-full items-center gap-4 p-2">
+          <AccordionTrigger
+            class="flex items-center gap-2 text-sm font-medium text-left">
+            <ChevronRightIcon
+              class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90 !size-4" />
+            {{ group.label || group.type }}
+          </AccordionTrigger>
+          <div
+            class="ml-auto flex items-center text-sm text-on-surface-variant gap-1">
+            <Chip
+              v-if="group.type === GROUP_TYPES.USER"
+              class="bg-secondary-container">
+              {{ group.values.length }}
+              {{ pluralize(group.values.length, "member") }}
+            </Chip>
+            <div v-else>
+              {{ groupTypesMap.get(group.type)?.label ?? group.type }}
+            </div>
+            <DropDown
+              alignment="right"
+              :showChevron="false"
+              labelClass="rounded-full hover:bg-surface-container-high justify-self-end">
+              <template #label>
+                <VerticalDotsIcon class="size-5" />
+                <span class="sr-only">More actions</span>
+              </template>
+              <DropDownItem @click="openEdit(group)">Edit Group</DropDownItem>
+              <DropDownItem @click="handleDelete(group)">
+                <span class="text-error">Delete Group</span>
+              </DropDownItem>
+            </DropDown>
           </div>
-          <DropDown
-            alignment="right"
-            :showChevron="false"
-            labelClass="rounded-full hover:bg-surface-container-high justify-self-end">
-            <template #label>
-              <VerticalDotsIcon class="size-5" />
-              <span class="sr-only">More actions</span>
-            </template>
-            <DropDownItem @click="openEdit(group)">Edit Group</DropDownItem>
-            <DropDownItem @click="handleDelete(group)">
-              <span class="text-error">Delete Group</span>
-            </DropDownItem>
-          </DropDown>
-        </div>
-      </AccordionHeader>
-      <AccordionContent
-        class="border-t border-outline-variant p-4 pl-8 bg-surface-container-lowest text-sm">
-        {{ groupTypesMap.get(group.type)?.description }}
-        <GroupMemberManager
-          v-if="group.type === GROUP_TYPES.USER"
-          :group="group"
-          :isOpen="openGroupIds.includes(String(group.id))"
-          class="my-2 max-w-screen-md m-auto" />
-      </AccordionContent>
-    </AccordionItem>
-  </AccordionRoot>
+        </AccordionHeader>
+        <AccordionContent class="p-4 pt-0 pl-8 text-sm">
+          {{ groupTypesMap.get(group.type)?.description }}
+          <GroupMemberManager
+            v-if="group.type === GROUP_TYPES.USER"
+            :group="group"
+            :isOpen="openGroupIds.includes(String(group.id))"
+            class="my-2 max-w-screen-md m-auto" />
+        </AccordionContent>
+      </AccordionItem>
+    </AccordionRoot>
 
-  <GroupFormModal
-    :isOpen="isGroupModalOpen"
-    :group="editingGroup"
-    @close="closeGroupModal" />
+    <GroupFormModal
+      :isOpen="isGroupModalOpen"
+      :group="editingGroup"
+      @close="closeGroupModal" />
+  </div>
 </template>
 <script setup lang="ts">
 import { computed, ref } from "vue";

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -22,11 +22,12 @@
       <AccordionItem
         v-for="group in sortedGroups"
         :key="group.id"
+        v-slot="{ open }"
         :value="String(group.id)"
         class="border-b border-outline-variant last:border-b-0">
-        <AccordionHeader class="group flex w-full items-center gap-4 p-2">
+        <AccordionHeader class="group flex w-full items-center gap-4">
           <AccordionTrigger
-            class="flex items-center gap-2 text-sm font-medium text-left">
+            class="flex items-center gap-2 text-sm font-medium text-left flex-1 p-4 data-[state=open]:font-bold">
             <ChevronRightIcon
               class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90 !size-4" />
             {{ group.label || group.type }}
@@ -57,12 +58,12 @@
             </DropDown>
           </div>
         </AccordionHeader>
-        <AccordionContent class="p-4 pt-0 pl-8 text-sm">
+        <AccordionContent class="p-4 pt-0 pl-8 text-sm text-on-surface-variant">
           {{ groupTypesMap.get(group.type)?.description }}
           <GroupMemberManager
             v-if="group.type === GROUP_TYPES.USER"
             :group="group"
-            :isOpen="openGroupIds.includes(String(group.id))"
+            :isOpen="open"
             class="my-2 max-w-screen-md m-auto" />
         </AccordionContent>
       </AccordionItem>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -63,8 +63,10 @@
                 <VerticalDotsIcon class="size-5" />
                 <span class="sr-only">More actions</span>
               </template>
-              <DropDownItem @click="openEdit(group)">Edit Group</DropDownItem>
-              <DropDownItem @click="handleDelete(group)">
+              <DropDownItem is="button" @click="openEdit(group)">
+                Edit Group
+              </DropDownItem>
+              <DropDownItem is="button" @click="handleDelete(group)">
                 <span class="text-error">Delete Group</span>
               </DropDownItem>
             </DropDown>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="flex items-center justify-between">
     <p>Help text goes here about groups and how they work.</p>
-    <Button variant="primary" @click="isCreateGroupOpen = true">
-      Create Group
-    </Button>
+    <Button variant="primary" @click="openCreate">Create Group</Button>
   </div>
 
   <p v-if="isLoading" class="mt-4 text-on-surface-variant">Loading groups…</p>
@@ -37,14 +35,20 @@
       </AccordionHeader>
       <AccordionContent
         class="border-t border-outline-variant p-4 bg-surface-container-lowest">
-        <Button variant="danger">Delete Group</Button>
+        <div class="flex items-center gap-2">
+          <Button variant="secondary" @click="openEdit(group)">
+            Edit Group
+          </Button>
+          <Button variant="danger">Delete Group</Button>
+        </div>
       </AccordionContent>
     </AccordionItem>
   </AccordionRoot>
 
-  <CreateGroupModal
-    :isOpen="isCreateGroupOpen"
-    @close="isCreateGroupOpen = false" />
+  <GroupFormModal
+    :isOpen="isGroupModalOpen"
+    :group="editingGroup"
+    @close="closeGroupModal" />
 </template>
 <script setup lang="ts">
 import { computed, ref } from "vue";
@@ -57,11 +61,11 @@ import {
   AccordionItem,
 } from "reka-ui";
 import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
-import CreateGroupModal from "./CreateGroupModal.vue";
+import GroupFormModal from "./GroupFormModal.vue";
 import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
 import { GROUP_TYPES } from "@/types";
-import type { GroupTypeValues } from "@/types";
+import type { GroupTypeValues, PermissionsGroup } from "@/types";
 
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
@@ -74,6 +78,21 @@ function typeLabel(type: GroupTypeValues) {
   return typeLabelByValue.value.get(type) ?? type;
 }
 
-const isCreateGroupOpen = ref(false);
+const editingGroup = ref<PermissionsGroup | null>(null);
+const isGroupModalOpen = ref(false);
+
+function openCreate() {
+  editingGroup.value = null;
+  isGroupModalOpen.value = true;
+}
+
+function openEdit(group: PermissionsGroup) {
+  editingGroup.value = group;
+  isGroupModalOpen.value = true;
+}
+
+function closeGroupModal() {
+  isGroupModalOpen.value = false;
+}
 </script>
 <style scoped></style>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -132,10 +132,12 @@ import { pluralize } from "@/helpers/pluralize.js";
 import { tryFocus } from "@/helpers/tryFocus";
 import Chip from "@/components/Chip/Chip.vue";
 import { useDeleteGroupMutation } from "@/queries/useDeleteGroupMutation.js";
+import { useToastStore } from "@/stores/toastStore";
 
 // Placeholder rows shown while the group list loads.
 const SKELETON_ROW_COUNT = 3;
 
+const toastStore = useToastStore();
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
 const { mutate: deleteGroup } = useDeleteGroupMutation();
@@ -209,8 +211,23 @@ function handleDelete(group: PermissionsGroup) {
 }
 
 function confirmDelete() {
-  if (!groupPendingDelete.value) return;
-  deleteGroup(groupPendingDelete.value);
+  const group = groupPendingDelete.value;
+  if (!group) return;
+  deleteGroup(group.id, {
+    onSuccess: () =>
+      toastStore.addToast({
+        message: `Group "${group.label || group.type}" deleted.`,
+        variant: "success",
+      }),
+    onError: (error) =>
+      toastStore.addToast({
+        title: "Delete Group Failed",
+        message: `Failed to delete group "${group.label || group.type}": ${
+          error.message
+        }`,
+        variant: "error",
+      }),
+  });
   groupPendingDelete.value = null;
 }
 </script>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -100,9 +100,11 @@ import type {
 } from "@/types";
 import { pluralize } from "@/helpers/pluralize.js";
 import Chip from "@/components/Chip/Chip.vue";
+import { useDeleteGroupMutation } from "@/queries/useDeleteGroupMutation.js";
 
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
+const { mutate: deleteGroup } = useDeleteGroupMutation();
 
 const groupTypesMap = computed((): Map<GroupTypeValues, LabelledGroupType> => {
   const entries = groupTypes.value?.map((g) => [g.type, g] as const) ?? [];
@@ -130,8 +132,9 @@ function closeGroupModal() {
   isGroupModalOpen.value = false;
 }
 
-function handleDelete(_group: PermissionsGroup) {
+function handleDelete(group: PermissionsGroup) {
   // TODO: delete is not wired yet. The backend deleteGroup returns 501.
+  deleteGroup(group);
 }
 </script>
 <style scoped></style>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -6,22 +6,32 @@
     </Button>
   </div>
 
-  <AccordionRoot type="multiple" class="mt-4 flex flex-col gap-2">
+  <p v-if="isLoading" class="mt-4 text-on-surface-variant">Loading groups…</p>
+  <p
+    v-else-if="!groups?.length"
+    class="mt-4 rounded-md border border-dashed border-outline-variant p-8 text-center text-on-surface-variant">
+    No groups yet. Create one to get started.
+  </p>
+
+  <AccordionRoot v-else type="multiple" class="mt-4 flex flex-col gap-2">
     <AccordionItem
-      v-for="groupType in groupTypes"
-      :key="groupType.type"
-      :value="groupType.type"
+      v-for="group in groups"
+      :key="group.id"
+      :value="String(group.id)"
       class="rounded-md border border-outline-variant bg-surface-container">
       <AccordionHeader>
         <AccordionTrigger
           class="group flex w-full items-center gap-4 p-4 text-left">
           <ChevronRightIcon
             class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90" />
-          <span class="text-lg font-bold">{{ groupType.label }}</span>
+          <span class="text-lg font-bold">{{ group.label }}</span>
           <span
             class="ml-auto flex items-center gap-4 text-sm text-on-surface-variant">
-            <span>{{ groupType.description }}</span>
-            <!-- <span>1 grant</span> -->
+            <span>{{ typeLabel(group.type) }}</span>
+            <span v-if="group.type === PERMISSIONS_GROUP_TYPES.USER">
+              {{ group.values.length }}
+              {{ group.values.length === 1 ? "member" : "members" }}
+            </span>
           </span>
         </AccordionTrigger>
       </AccordionHeader>
@@ -31,17 +41,13 @@
       </AccordionContent>
     </AccordionItem>
   </AccordionRoot>
-  <Modal
+
+  <CreateGroupModal
     :isOpen="isCreateGroupOpen"
-    label="New Group"
-    class="max-w-md"
-    @close="isCreateGroupOpen = false">
-    <InputGroup v-model="newGroupForm.name" label="Name" />
-    <SelectGroup v-model="newGroupForm.type" label="Type" :options="[]" />
-  </Modal>
+    @close="isCreateGroupOpen = false" />
 </template>
 <script setup lang="ts">
-import { reactive, ref } from "vue";
+import { computed, ref } from "vue";
 import Button from "@/components/Button/Button.vue";
 import {
   AccordionRoot,
@@ -51,17 +57,23 @@ import {
   AccordionItem,
 } from "reka-ui";
 import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
-import Modal from "@/components/Modal/Modal.vue";
-import InputGroup from "@/components/InputGroup/InputGroup.vue";
-import SelectGroup from "@/components/SelectGroup/SelectGroup.vue";
+import CreateGroupModal from "./CreateGroupModal.vue";
+import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
+import { PERMISSIONS_GROUP_TYPES } from "@/types";
+import type { PermissionsGroupTypeValues } from "@/types";
 
+const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
 
+const typeLabelByValue = computed(
+  () => new Map(groupTypes.value?.map((type) => [type.type, type.label]) ?? [])
+);
+
+function typeLabel(type: PermissionsGroupTypeValues) {
+  return typeLabelByValue.value.get(type) ?? type;
+}
+
 const isCreateGroupOpen = ref(false);
-const newGroupForm = reactive({
-  name: "",
-  type: "",
-});
 </script>
 <style scoped></style>

--- a/src/pages/AdminPermissionsPage/GroupsTabContent.vue
+++ b/src/pages/AdminPermissionsPage/GroupsTabContent.vue
@@ -21,35 +21,59 @@
       :key="group.id"
       :value="String(group.id)"
       class="rounded-md border border-outline-variant bg-surface-container">
-      <AccordionHeader>
-        <AccordionTrigger
-          class="group flex w-full items-center gap-4 p-4 text-left">
+      <AccordionHeader
+        class="group flex w-full items-center gap-4 p-4 text-left">
+        <AccordionTrigger class="flex items-center gap-4">
           <ChevronRightIcon
             class="shrink-0 text-on-surface-variant transition-transform group-data-[state=open]:rotate-90" />
           <span class="text-lg font-bold">{{ group.label }}</span>
-          <span
-            class="ml-auto flex items-center gap-4 text-sm text-on-surface-variant">
-            <span>{{ typeLabel(group.type) }}</span>
-            <span v-if="group.type === GROUP_TYPES.USER">
-              {{ group.values.length }}
-              {{ group.values.length === 1 ? "member" : "members" }}
-            </span>
-          </span>
         </AccordionTrigger>
+        <div
+          class="ml-auto flex items-center text-sm text-on-surface-variant gap-2">
+          <Chip
+            v-if="group.type === GROUP_TYPES.USER"
+            class="bg-secondary-container">
+            {{ group.values.length }}
+            {{ pluralize(group.values.length, "member") }}
+          </Chip>
+          <div v-else>{{ typeLabel(group.type) }}</div>
+        </div>
+        <DropDown
+          alignment="right"
+          :showChevron="false"
+          labelClass="rounded-full hover:bg-surface-container-high">
+          <template #label>
+            <VerticalDotsIcon class="size-5" />
+            <span class="sr-only">More actions</span>
+          </template>
+          <DropDownItem @click="openEdit(group)">Edit Group</DropDownItem>
+          <DropDownItem @click="handleDelete(group)">
+            <span class="text-error">Delete Group</span>
+          </DropDownItem>
+        </DropDown>
       </AccordionHeader>
       <AccordionContent
         class="border-t border-outline-variant p-4 bg-surface-container-lowest">
+        <div class="flex justify-end">
+          <DropDown
+            alignment="right"
+            :showChevron="false"
+            labelClass="rounded-full hover:bg-surface-container-high">
+            <template #label>
+              <VerticalDotsIcon class="size-5" />
+              <span class="sr-only">More actions</span>
+            </template>
+            <DropDownItem @click="openEdit(group)">Edit Group</DropDownItem>
+            <DropDownItem @click="handleDelete(group)">
+              <span class="text-error">Delete Group</span>
+            </DropDownItem>
+          </DropDown>
+        </div>
         <GroupMemberManager
           v-if="group.type === GROUP_TYPES.USER"
           :group="group"
           :isOpen="openGroupIds.includes(String(group.id))"
-          class="mb-4" />
-        <div class="flex items-center gap-2">
-          <Button variant="secondary" @click="openEdit(group)">
-            Edit Group
-          </Button>
-          <Button variant="danger">Delete Group</Button>
-        </div>
+          class="mt-2" />
       </AccordionContent>
     </AccordionItem>
   </AccordionRoot>
@@ -70,12 +94,17 @@ import {
   AccordionItem,
 } from "reka-ui";
 import ChevronRightIcon from "@/icons/ChevronRightIcon.vue";
+import VerticalDotsIcon from "@/icons/VerticalDotsIcon.vue";
+import DropDown from "@/components/DropDown/DropDown.vue";
+import DropDownItem from "@/components/DropDown/DropDownItem.vue";
 import GroupFormModal from "./GroupFormModal.vue";
 import GroupMemberManager from "./GroupMemberManager.vue";
 import { useGroupsQuery } from "@/queries/useGroupsQuery";
 import { useGroupTypesQuery } from "@/queries/useGroupTypesQuery";
 import { GROUP_TYPES } from "@/types";
 import type { GroupTypeValues, PermissionsGroup } from "@/types";
+import { pluralize } from "@/helpers/pluralize.js";
+import Chip from "@/components/Chip/Chip.vue";
 
 const { data: groups, isLoading } = useGroupsQuery();
 const { data: groupTypes } = useGroupTypesQuery();
@@ -107,6 +136,10 @@ function openEdit(group: PermissionsGroup) {
 
 function closeGroupModal() {
   isGroupModalOpen.value = false;
+}
+
+function handleDelete(_group: PermissionsGroup) {
+  // TODO: delete is not wired yet. The backend deleteGroup returns 501.
 }
 </script>
 <style scoped></style>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditTagWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditTagWidget.vue
@@ -30,7 +30,7 @@
           <TagsInputItemDelete />
         </TagsInputItem>
 
-        <AutoCompleteInput
+        <FieldAutoComplete
           v-if="widgetDef.attemptAutocomplete"
           :id="`edit-tag-widget-autocomplete-${item.id}`"
           v-model="tagInput"
@@ -59,7 +59,7 @@ import {
   TagsInputItemDelete,
   TagsInputInput,
 } from "@/components/ui/tags-input";
-import AutoCompleteInput from "@/components/AutoCompleteInput/AutoCompleteInput.vue";
+import FieldAutoComplete from "@/components/AutoCompleteInput/FieldAutoComplete.vue";
 import { computed, ref, nextTick } from "vue";
 import { useAssetEditor } from "../useAssetEditor/useAssetEditor";
 import invariant from "tiny-invariant";

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditTextWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditTextWidget.vue
@@ -38,7 +38,7 @@
 
         <!-- Autocomplete Text Input -->
         <div v-if="widgetDef.attemptAutocomplete">
-          <AutoCompleteInput
+          <FieldAutoComplete
             :id="`${item.id}-input`"
             :modelValue="(item as Type.WithId<Type.TextWidgetContent>).fieldContents"
             :placeholder="widgetDef.label"
@@ -71,7 +71,7 @@
 import * as Type from "@/types";
 import { Input } from "@/components/ui/input";
 import EditWidgetLayout from "./EditWidgetLayout.vue";
-import AutoCompleteInput from "@/components/AutoCompleteInput/AutoCompleteInput.vue";
+import FieldAutoComplete from "@/components/AutoCompleteInput/FieldAutoComplete.vue";
 import * as ops from "./helpers/editWidgetOps";
 import { computed } from "vue";
 import { useAssetEditor } from "../useAssetEditor/useAssetEditor";

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -13,3 +13,4 @@ export const FILE_DOWNLOADS_QUERY_KEY = "fileDownloads";
 export const ORIGINAL_STORAGE_STATUS_QUERY_KEY = "originalStorageStatus";
 export const PERMISSIONS_GROUPS_QUERY_KEY = "permissionsGroups";
 export const USER_AUTOCOMPLETE_QUERY_KEY = "userAutocomplete";
+export const GROUP_MEMBERS_QUERY_KEY = "groupMembers";

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -11,3 +11,4 @@ export const DRAWERS_QUERY_KEY = "drawers";
 export const FIELD_TYPES_QUERY_KEY = "fieldTypes";
 export const FILE_DOWNLOADS_QUERY_KEY = "fileDownloads";
 export const ORIGINAL_STORAGE_STATUS_QUERY_KEY = "originalStorageStatus";
+export const PERMISSIONS_GROUPS_QUERY_KEY = "permissionsGroups";

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -12,3 +12,4 @@ export const FIELD_TYPES_QUERY_KEY = "fieldTypes";
 export const FILE_DOWNLOADS_QUERY_KEY = "fileDownloads";
 export const ORIGINAL_STORAGE_STATUS_QUERY_KEY = "originalStorageStatus";
 export const PERMISSIONS_GROUPS_QUERY_KEY = "permissionsGroups";
+export const USER_AUTOCOMPLETE_QUERY_KEY = "userAutocomplete";

--- a/src/queries/useAddGroupMemberMutation.ts
+++ b/src/queries/useAddGroupMemberMutation.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import {
+  GROUP_MEMBERS_QUERY_KEY,
+  PERMISSIONS_GROUPS_QUERY_KEY,
+} from "./queryKeys";
+import { useToastStore } from "@/stores/toastStore";
+
+export function useAddGroupMemberMutation() {
+  const queryClient = useQueryClient();
+  const toastStore = useToastStore();
+
+  return useMutation({
+    mutationFn: (vars: { groupId: number; userId: number }) =>
+      fetchers.addGroupMember(vars.groupId, vars.userId),
+    onSuccess: (member, vars) => {
+      // refresh the member list and the group list (its count changed)
+      queryClient.invalidateQueries({
+        queryKey: [GROUP_MEMBERS_QUERY_KEY, vars.groupId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
+      });
+      toastStore.addToast({
+        message: `${member.name} added.`,
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      toastStore.addToast({
+        title: "Could not add member",
+        message: error.message ?? "Something went wrong. Unknown error.",
+        variant: "error",
+        duration: Infinity,
+      });
+    },
+  });
+}

--- a/src/queries/useAddGroupMemberMutation.ts
+++ b/src/queries/useAddGroupMemberMutation.ts
@@ -6,6 +6,7 @@ import {
   PERMISSIONS_GROUPS_QUERY_KEY,
 } from "./queryKeys";
 import { useToastStore } from "@/stores/toastStore";
+import type { GroupMember } from "@/types";
 
 export function useAddGroupMemberMutation() {
   const queryClient = useQueryClient();
@@ -14,10 +15,16 @@ export function useAddGroupMemberMutation() {
   return useMutation({
     mutationFn: (vars: AddGroupMemberInput) => fetchers.addGroupMember(vars),
     onSuccess: (member, vars) => {
-      // refresh the member list and the group list (its count changed)
-      queryClient.invalidateQueries({
-        queryKey: [GROUP_MEMBERS_QUERY_KEY, vars.groupId],
-      });
+      // The server returns the fully-resolved member, so write it straight
+      // into the cache instead of invalidating — no second round-trip.
+      queryClient.setQueryData<GroupMember[]>(
+        [GROUP_MEMBERS_QUERY_KEY, vars.groupId],
+        (members = []) =>
+          members.some((m) => m.userId === member.userId)
+            ? members
+            : [...members, member]
+      );
+      // The group list still needs a refresh — its member count changed.
       queryClient.invalidateQueries({
         queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
       });

--- a/src/queries/useAddGroupMemberMutation.ts
+++ b/src/queries/useAddGroupMemberMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import * as fetchers from "@/api/fetchers";
+import type { AddGroupMemberInput } from "@/api/fetchers";
 import {
   GROUP_MEMBERS_QUERY_KEY,
   PERMISSIONS_GROUPS_QUERY_KEY,
@@ -11,8 +12,7 @@ export function useAddGroupMemberMutation() {
   const toastStore = useToastStore();
 
   return useMutation({
-    mutationFn: (vars: { groupId: number; userId: number }) =>
-      fetchers.addGroupMember(vars.groupId, vars.userId),
+    mutationFn: (vars: AddGroupMemberInput) => fetchers.addGroupMember(vars),
     onSuccess: (member, vars) => {
       // refresh the member list and the group list (its count changed)
       queryClient.invalidateQueries({

--- a/src/queries/useCreateGroupMutation.ts
+++ b/src/queries/useCreateGroupMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
+import { useToastStore } from "@/stores/toastStore";
+
+export function useCreateGroupMutation() {
+  const queryClient = useQueryClient();
+  const toastStore = useToastStore();
+
+  return useMutation({
+    mutationFn: fetchers.createGroup,
+    onSuccess: (group) => {
+      queryClient.invalidateQueries({
+        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
+      });
+      toastStore.addToast({
+        message: `Group "${group.label}" created.`,
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      toastStore.addToast({
+        title: "Could not create group",
+        message: error.message ?? "Something went wrong. Unknown error.",
+        variant: "error",
+        duration: Infinity,
+      });
+    },
+  });
+}

--- a/src/queries/useCreateGroupMutation.ts
+++ b/src/queries/useCreateGroupMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import * as fetchers from "@/api/fetchers";
 import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
 import { useToastStore } from "@/stores/toastStore";
+import type { PermissionsGroup } from "@/types";
 
 export function useCreateGroupMutation() {
   const queryClient = useQueryClient();
@@ -10,9 +11,12 @@ export function useCreateGroupMutation() {
   return useMutation({
     mutationFn: fetchers.createGroup,
     onSuccess: (group) => {
-      queryClient.invalidateQueries({
-        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
-      });
+      // The server returns the new group, so append it to the cache instead
+      // of invalidating — no refetch. The list is sorted in the component.
+      queryClient.setQueryData<PermissionsGroup[]>(
+        [PERMISSIONS_GROUPS_QUERY_KEY],
+        (groups = []) => [...groups, group]
+      );
       toastStore.addToast({
         message: `Group "${group.label}" created.`,
         variant: "success",

--- a/src/queries/useDeleteGroupMutation.ts
+++ b/src/queries/useDeleteGroupMutation.ts
@@ -1,36 +1,18 @@
 import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import * as fetchers from "@/api/fetchers";
 import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
-import { useToastStore } from "@/stores/toastStore";
 import type { PermissionsGroup } from "@/types";
 
 export function useDeleteGroupMutation() {
   const queryClient = useQueryClient();
-  const toastStore = useToastStore();
 
   return useMutation({
-    // the delete response is empty, so carry the label for the toast
-    mutationFn: (vars: { id: number; label: string }) =>
-      fetchers.deleteGroup(vars.id),
-    onSuccess: (_data, vars) => {
-      // Drop the deleted group from the cache by id instead of invalidating
-      // — no refetch.
+    mutationFn: (id: PermissionsGroup['id']) => fetchers.deleteGroup(id),
+    onSuccess: (_data, id) => {
       queryClient.setQueryData<PermissionsGroup[]>(
         [PERMISSIONS_GROUPS_QUERY_KEY],
-        (groups = []) => groups.filter((g) => g.id !== vars.id)
+        (groups = []) => groups.filter((g) => g.id !== id)
       );
-      toastStore.addToast({
-        message: `Group "${vars.label}" deleted.`,
-        variant: "success",
-      });
-    },
-    onError: (error) => {
-      toastStore.addToast({
-        title: "Could not delete group",
-        message: error.message ?? "Something went wrong. Unknown error.",
-        variant: "error",
-        duration: Infinity,
-      });
     },
   });
 }

--- a/src/queries/useDeleteGroupMutation.ts
+++ b/src/queries/useDeleteGroupMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import * as fetchers from "@/api/fetchers";
 import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
 import { useToastStore } from "@/stores/toastStore";
+import type { PermissionsGroup } from "@/types";
 
 export function useDeleteGroupMutation() {
   const queryClient = useQueryClient();
@@ -12,9 +13,12 @@ export function useDeleteGroupMutation() {
     mutationFn: (vars: { id: number; label: string }) =>
       fetchers.deleteGroup(vars.id),
     onSuccess: (_data, vars) => {
-      queryClient.invalidateQueries({
-        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
-      });
+      // Drop the deleted group from the cache by id instead of invalidating
+      // — no refetch.
+      queryClient.setQueryData<PermissionsGroup[]>(
+        [PERMISSIONS_GROUPS_QUERY_KEY],
+        (groups = []) => groups.filter((g) => g.id !== vars.id)
+      );
       toastStore.addToast({
         message: `Group "${vars.label}" deleted.`,
         variant: "success",

--- a/src/queries/useDeleteGroupMutation.ts
+++ b/src/queries/useDeleteGroupMutation.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
+import { useToastStore } from "@/stores/toastStore";
+
+export function useDeleteGroupMutation() {
+  const queryClient = useQueryClient();
+  const toastStore = useToastStore();
+
+  return useMutation({
+    // the delete response is empty, so carry the label for the toast
+    mutationFn: (vars: { id: number; label: string }) =>
+      fetchers.deleteGroup(vars.id),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
+      });
+      toastStore.addToast({
+        message: `Group "${vars.label}" deleted.`,
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      toastStore.addToast({
+        title: "Could not delete group",
+        message: error.message ?? "Something went wrong. Unknown error.",
+        variant: "error",
+        duration: Infinity,
+      });
+    },
+  });
+}

--- a/src/queries/useGroupMembersQuery.ts
+++ b/src/queries/useGroupMembersQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/vue-query";
+import { MaybeRefOrGetter, computed, toValue } from "vue";
+import { fetchGroupMembers } from "@/api/fetchers";
+import { GroupMember } from "@/types";
+import { GROUP_MEMBERS_QUERY_KEY } from "./queryKeys";
+
+// A User group's members, resolved to names. Pass `enabled` so the list is
+// fetched only when its group is expanded, not for every group at once.
+export function useGroupMembersQuery(
+  groupId: MaybeRefOrGetter<number>,
+  options?: { enabled?: MaybeRefOrGetter<boolean> }
+) {
+  return useQuery({
+    queryKey: computed(() => [GROUP_MEMBERS_QUERY_KEY, toValue(groupId)]),
+    queryFn: () => fetchGroupMembers(toValue(groupId)),
+    placeholderData: () => [] as GroupMember[],
+    enabled: computed(() => toValue(options?.enabled) ?? true),
+  });
+}

--- a/src/queries/useGroupMembersQuery.ts
+++ b/src/queries/useGroupMembersQuery.ts
@@ -13,7 +13,6 @@ export function useGroupMembersQuery(
   return useQuery({
     queryKey: computed(() => [GROUP_MEMBERS_QUERY_KEY, toValue(groupId)]),
     queryFn: () => fetchGroupMembers(toValue(groupId)),
-    placeholderData: () => [] as GroupMember[],
     enabled: computed(() => toValue(options?.enabled) ?? true),
   });
 }

--- a/src/queries/useGroupTypesQuery.ts
+++ b/src/queries/useGroupTypesQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/vue-query";
+import { fetchGroupTypes } from "@/api/fetchers";
+
+export function useGroupTypesQuery(options = {}) {
+  return useQuery({
+    queryKey: ["GROUP_TYPES"],
+    queryFn: fetchGroupTypes,
+    // Group types essentially never change, so treat the data as
+    // permanently fresh — fetch once, then reuse for the page's life.
+    staleTime: Infinity,
+    ...options,
+  });
+}

--- a/src/queries/useGroupsQuery.ts
+++ b/src/queries/useGroupsQuery.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/vue-query";
 import { fetchGroups } from "@/api/fetchers";
-import { PermissionsGroup } from "@/types";
 import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
 
 export function useGroupsQuery() {

--- a/src/queries/useGroupsQuery.ts
+++ b/src/queries/useGroupsQuery.ts
@@ -7,6 +7,5 @@ export function useGroupsQuery() {
   return useQuery({
     queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
     queryFn: fetchGroups,
-    placeholderData: () => [] as PermissionsGroup[],
   });
 }

--- a/src/queries/useGroupsQuery.ts
+++ b/src/queries/useGroupsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/vue-query";
+import { fetchGroups } from "@/api/fetchers";
+import { PermissionsGroup } from "@/types";
+import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
+
+export function useGroupsQuery() {
+  return useQuery({
+    queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
+    queryFn: fetchGroups,
+    placeholderData: () => [] as PermissionsGroup[],
+  });
+}

--- a/src/queries/useRemoveGroupMemberMutation.ts
+++ b/src/queries/useRemoveGroupMemberMutation.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import {
+  GROUP_MEMBERS_QUERY_KEY,
+  PERMISSIONS_GROUPS_QUERY_KEY,
+} from "./queryKeys";
+import { useToastStore } from "@/stores/toastStore";
+
+export function useRemoveGroupMemberMutation() {
+  const queryClient = useQueryClient();
+  const toastStore = useToastStore();
+
+  return useMutation({
+    mutationFn: (vars: { groupId: number; userId: number }) =>
+      fetchers.removeGroupMember(vars.groupId, vars.userId),
+    onSuccess: (_data, vars) => {
+      // refresh the member list and the group list (its count changed)
+      queryClient.invalidateQueries({
+        queryKey: [GROUP_MEMBERS_QUERY_KEY, vars.groupId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
+      });
+      toastStore.addToast({
+        message: "Member removed.",
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      toastStore.addToast({
+        title: "Could not remove member",
+        message: error.message ?? "Something went wrong. Unknown error.",
+        variant: "error",
+        duration: Infinity,
+      });
+    },
+  });
+}

--- a/src/queries/useRemoveGroupMemberMutation.ts
+++ b/src/queries/useRemoveGroupMemberMutation.ts
@@ -5,6 +5,7 @@ import {
   PERMISSIONS_GROUPS_QUERY_KEY,
 } from "./queryKeys";
 import { useToastStore } from "@/stores/toastStore";
+import type { GroupMember } from "@/types";
 
 export function useRemoveGroupMemberMutation() {
   const queryClient = useQueryClient();
@@ -14,10 +15,13 @@ export function useRemoveGroupMemberMutation() {
     mutationFn: (vars: { groupId: number; userId: number }) =>
       fetchers.removeGroupMember(vars.groupId, vars.userId),
     onSuccess: (_data, vars) => {
-      // refresh the member list and the group list (its count changed)
-      queryClient.invalidateQueries({
-        queryKey: [GROUP_MEMBERS_QUERY_KEY, vars.groupId],
-      });
+      // Drop the removed member from the cache by id instead of invalidating
+      // — no refetch.
+      queryClient.setQueryData<GroupMember[]>(
+        [GROUP_MEMBERS_QUERY_KEY, vars.groupId],
+        (members = []) => members.filter((m) => m.userId !== vars.userId)
+      );
+      // The group list still needs a refresh — its member count changed.
       queryClient.invalidateQueries({
         queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
       });

--- a/src/queries/useUpdateGroupMutation.ts
+++ b/src/queries/useUpdateGroupMutation.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as fetchers from "@/api/fetchers";
+import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
+import { useToastStore } from "@/stores/toastStore";
+import type { UpdateGroupPayload } from "@/types";
+
+export function useUpdateGroupMutation() {
+  const queryClient = useQueryClient();
+  const toastStore = useToastStore();
+
+  return useMutation({
+    mutationFn: (vars: { id: number; payload: UpdateGroupPayload }) =>
+      fetchers.updateGroup(vars.id, vars.payload),
+    onSuccess: (group) => {
+      queryClient.invalidateQueries({
+        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
+      });
+      toastStore.addToast({
+        message: `Group "${group.label}" updated.`,
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      toastStore.addToast({
+        title: "Could not update group",
+        message: error.message ?? "Something went wrong. Unknown error.",
+        variant: "error",
+        duration: Infinity,
+      });
+    },
+  });
+}

--- a/src/queries/useUpdateGroupMutation.ts
+++ b/src/queries/useUpdateGroupMutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import * as fetchers from "@/api/fetchers";
 import { PERMISSIONS_GROUPS_QUERY_KEY } from "./queryKeys";
 import { useToastStore } from "@/stores/toastStore";
-import type { UpdateGroupPayload } from "@/types";
+import type { PermissionsGroup, UpdateGroupPayload } from "@/types";
 
 export function useUpdateGroupMutation() {
   const queryClient = useQueryClient();
@@ -12,9 +12,12 @@ export function useUpdateGroupMutation() {
     mutationFn: (vars: { id: number; payload: UpdateGroupPayload }) =>
       fetchers.updateGroup(vars.id, vars.payload),
     onSuccess: (group) => {
-      queryClient.invalidateQueries({
-        queryKey: [PERMISSIONS_GROUPS_QUERY_KEY],
-      });
+      // The server returns the updated group, so swap it into the cache by
+      // id instead of invalidating — no refetch.
+      queryClient.setQueryData<PermissionsGroup[]>(
+        [PERMISSIONS_GROUPS_QUERY_KEY],
+        (groups = []) => groups.map((g) => (g.id === group.id ? group : g))
+      );
       toastStore.addToast({
         message: `Group "${group.label}" updated.`,
         variant: "success",

--- a/src/queries/useUserAutocompleteQuery.ts
+++ b/src/queries/useUserAutocompleteQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/vue-query";
+import { MaybeRefOrGetter, computed, toValue } from "vue";
+import { fetchUserAutocomplete } from "@/api/fetchers";
+import { UserAutocompleteMatch } from "@/types";
+import { USER_AUTOCOMPLETE_QUERY_KEY } from "./queryKeys";
+
+// Suggest people for a "Specific People" group member field. Reactive on
+// the search term; only fires at 2+ chars to mirror the backend's
+// short-circuit and to spare API-school directory lookups per keystroke.
+export function useUserAutocompleteQuery(
+  searchTerm: MaybeRefOrGetter<string>
+) {
+  return useQuery({
+    queryKey: computed(() => [
+      USER_AUTOCOMPLETE_QUERY_KEY,
+      toValue(searchTerm),
+    ]),
+    placeholderData: () => [] as UserAutocompleteMatch[],
+    queryFn: ({ signal }) =>
+      fetchUserAutocomplete(toValue(searchTerm), { signal }),
+    enabled: computed(() => toValue(searchTerm).trim().length >= 2),
+  });
+}

--- a/src/queries/useUserAutocompleteQuery.ts
+++ b/src/queries/useUserAutocompleteQuery.ts
@@ -4,9 +4,8 @@ import { fetchUserAutocomplete } from "@/api/fetchers";
 import { UserAutocompleteMatch } from "@/types";
 import { USER_AUTOCOMPLETE_QUERY_KEY } from "./queryKeys";
 
-// Suggest people for a "Specific People" group member field. Reactive on
-// the search term; only fires at 2+ chars to mirror the backend's
-// short-circuit and to spare API-school directory lookups per keystroke.
+// Reactive user-search for a group's member field. Only fires at 2+ chars
+// to avoid a directory lookup on every keystroke.
 export function useUserAutocompleteQuery(
   searchTerm: MaybeRefOrGetter<string>
 ) {

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -35,6 +35,17 @@ export interface PermissionsGroup {
   values: PermissionsGroupValue[];
 }
 
+// One suggestion from the user-autocomplete endpoint. `completionId` is
+// the local user id when the person already has a row; it is null for a
+// directory-only match (someone central auth knows but who has never
+// logged in here), in which case `username` is what provisioning keys on.
+export interface UserAutocompleteMatch {
+  name: string;
+  email: string;
+  completionId: number | null;
+  username: string;
+}
+
 // `values` is only meaningful for "User"-type groups; the backend
 // resolves each entry (user id or internet ID) to a user on submit.
 export interface CreateGroupPayload {

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -48,6 +48,12 @@ export interface GroupMember {
   userId: number;
   name: string;
   email: string;
+  username: string;
+  // "Local" or "Remote" — a Remote member may be a stub that has never
+  // signed in.
+  userType: string;
+  // ISO 8601, or null. When the user account was created.
+  createdAt: string | null;
 }
 
 // `values` holds "User"-group members. Always sent, even when empty for a

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -5,11 +5,9 @@ export const GROUP_TYPES = {
   USER: "User",
 } as const;
 
-
 type GroupTypeKeys = keyof typeof GROUP_TYPES;
 
-export type GroupTypeValues =
-  (typeof GROUP_TYPES)[GroupTypeKeys];
+export type GroupTypeValues = (typeof GROUP_TYPES)[GroupTypeKeys];
 
 export interface LabelledGroupType {
   type: GroupTypeValues;
@@ -52,3 +50,9 @@ export interface CreateGroupPayload {
   values: string[];
 }
 
+// Edit a group's label and type. Members are not edited here. Changing the
+// type clears existing members server-side.
+export interface UpdateGroupPayload {
+  type: GroupTypeValues;
+  label: string;
+}

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -46,11 +46,12 @@ export interface UserAutocompleteMatch {
   username: string;
 }
 
-// `values` is only meaningful for "User"-type groups; the backend
-// resolves each entry (user id or internet ID) to a user on submit.
+// `values` carries "User"-group members; always sent (empty for a group
+// created with no members yet). The vestigial group_value scalar is set
+// by the backend at creation, never by the client.
 export interface CreateGroupPayload {
   type: GroupTypeValues;
   label: string;
-  values?: string[];
+  values: string[];
 }
 

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -42,6 +42,14 @@ export interface UserAutocompleteMatch {
   username: string;
 }
 
+// A member of a User group, resolved to display data so the UI can show who
+// belongs (the group list itself only carries ids).
+export interface GroupMember {
+  userId: number;
+  name: string;
+  email: string;
+}
+
 // `values` holds "User"-group members. Always sent, even when empty for a
 // group with no members yet. The backend sets group_value itself.
 export interface CreateGroupPayload {

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -1,0 +1,60 @@
+export const PERMISSIONS_GROUP_TYPES = {
+  ALL: "All",
+  AUTHED: "Authed",
+  SSO: "Authed_remote", // SSO
+  USER: "User",
+} as const;
+
+type PermissionsGroupTypeKeys = keyof typeof PERMISSIONS_GROUP_TYPES;
+
+export type PermissionsGroupTypeValues =
+  (typeof PERMISSIONS_GROUP_TYPES)[PermissionsGroupTypeKeys];
+
+export interface PermissionsGroupType {
+  type: PermissionsGroupTypeValues;
+  label: string;
+  description: string;
+}
+
+// A member of a "User"-type group. `value` is the local user id the
+// backend resolved the member to; the list response carries no name.
+export interface PermissionsGroupValue {
+  id: number;
+  value: string;
+}
+
+export interface PermissionsGroup {
+  id: number;
+  type: PermissionsGroupTypeValues;
+  // Vestigial scalar: 1 for global types (All/Authed/Authed_remote),
+  // null for User groups (whose membership lives in `values`).
+  value: number | null;
+  label: string;
+  expiration: string | null;
+  values: PermissionsGroupValue[];
+}
+
+// `values` is only meaningful for "User"-type groups; the backend
+// resolves each entry (user id or internet ID) to a user on submit.
+export interface CreateGroupPayload {
+  type: PermissionsGroupTypeValues;
+  label: string;
+  values?: string[];
+}
+
+// A match from the user autocompleter, for adding "User"-group members.
+export interface GroupUserMatch {
+  id: string;
+  username: string;
+  displayName: string;
+  email: string | null;
+  source: "local" | "central";
+}
+
+// A member chosen in the create-group form, before submission.
+// `groupValue` is the username or internet ID sent to the backend;
+// `label` is what we show in the chip.
+export interface GroupMemberDraft {
+  groupValue: string;
+  label: string;
+}

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -33,12 +33,12 @@ export interface PermissionsGroup {
   values: PermissionsGroupValue[];
 }
 
-// A user-autocomplete suggestion. `completionId` is the local user id, or
+// A user-autocomplete suggestion. `localUserId` is the local user id, or
 // null for someone the directory knows but who has no local row yet.
 export interface UserAutocompleteMatch {
   name: string;
   email: string;
-  completionId: number | null;
+  localUserId: number | null;
   username: string;
 }
 

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -1,17 +1,18 @@
-export const PERMISSIONS_GROUP_TYPES = {
+export const GROUP_TYPES = {
   ALL: "All",
   AUTHED: "Authed",
-  SSO: "Authed_remote", // SSO
+  REMOTE: "Authed_remote", // SSO
   USER: "User",
 } as const;
 
-type PermissionsGroupTypeKeys = keyof typeof PERMISSIONS_GROUP_TYPES;
 
-export type PermissionsGroupTypeValues =
-  (typeof PERMISSIONS_GROUP_TYPES)[PermissionsGroupTypeKeys];
+type GroupTypeKeys = keyof typeof GROUP_TYPES;
 
-export interface PermissionsGroupType {
-  type: PermissionsGroupTypeValues;
+export type GroupTypeValues =
+  (typeof GROUP_TYPES)[GroupTypeKeys];
+
+export interface LabelledGroupType {
+  type: GroupTypeValues;
   label: string;
   description: string;
 }
@@ -25,7 +26,7 @@ export interface PermissionsGroupValue {
 
 export interface PermissionsGroup {
   id: number;
-  type: PermissionsGroupTypeValues;
+  type: GroupTypeValues;
   // Vestigial scalar: 1 for global types (All/Authed/Authed_remote),
   // null for User groups (whose membership lives in `values`).
   value: number | null;
@@ -37,7 +38,7 @@ export interface PermissionsGroup {
 // `values` is only meaningful for "User"-type groups; the backend
 // resolves each entry (user id or internet ID) to a user on submit.
 export interface CreateGroupPayload {
-  type: PermissionsGroupTypeValues;
+  type: GroupTypeValues;
   label: string;
   values?: string[];
 }

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -42,19 +42,3 @@ export interface CreateGroupPayload {
   values?: string[];
 }
 
-// A match from the user autocompleter, for adding "User"-group members.
-export interface GroupUserMatch {
-  id: string;
-  username: string;
-  displayName: string;
-  email: string | null;
-  source: "local" | "central";
-}
-
-// A member chosen in the create-group form, before submission.
-// `groupValue` is the username or internet ID sent to the backend;
-// `label` is what we show in the chip.
-export interface GroupMemberDraft {
-  groupValue: string;
-  label: string;
-}

--- a/src/types/PermissionsTypes.ts
+++ b/src/types/PermissionsTypes.ts
@@ -35,10 +35,8 @@ export interface PermissionsGroup {
   values: PermissionsGroupValue[];
 }
 
-// One suggestion from the user-autocomplete endpoint. `completionId` is
-// the local user id when the person already has a row; it is null for a
-// directory-only match (someone central auth knows but who has never
-// logged in here), in which case `username` is what provisioning keys on.
+// A user-autocomplete suggestion. `completionId` is the local user id, or
+// null for someone the directory knows but who has no local row yet.
 export interface UserAutocompleteMatch {
   name: string;
   email: string;
@@ -46,9 +44,8 @@ export interface UserAutocompleteMatch {
   username: string;
 }
 
-// `values` carries "User"-group members; always sent (empty for a group
-// created with no members yet). The vestigial group_value scalar is set
-// by the backend at creation, never by the client.
+// `values` holds "User"-group members. Always sent, even when empty for a
+// group with no members yet. The backend sets group_value itself.
 export interface CreateGroupPayload {
   type: GroupTypeValues;
   label: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ import { AxiosRequestConfig } from "axios";
 import { CascaderSelectOptions } from "@/components/CascadeSelect/CascadeSelect.vue";
 
 export * from "./TimelineJSTypes";
+export * from "./PermissionsTypes";
 
 export interface AppConfig {
   instance: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -138,8 +138,10 @@ export default {
         },
         "inverse-surface": "var(--inverse-surface)",
         "inverse-on-surface": "var(--inverse-on-surface)",
+        "inverse-on-surface-variant":
+          "color-mix(in oklch, var(--inverse-on-surface) 60%, transparent)",
         "inverse-on-surface-muted":
-          "color-mix(in oklch, var(--on-surface) 38%, transparent)",
+          "color-mix(in oklch, var(--inverse-on-surface) 40%, transparent)",
         "inverse-primary": "var(--inverse-primary)",
         scrim: "var(--scrim)",
         shadow: "var(--shadow)",


### PR DESCRIPTION
Adds part of the Groups UI slice for #538. Complements api  in https://github.com/UMN-LATIS/elevator/pull/238

This is gated behind a feature flag env variable. (Requires setting`VITE_FEATURE_ADMIN_PERMISSIONS=true` during the build phase to be available to users).

- Adds a working **Group** tab under Admin > Permissions (WIP). Instance admins can create, edit, and delete groups.
- Adds support for "Specific User" groups including member management: search, add, remove members.
- When a new group is created, the group name or member input will be focused in the UI.
- Support for value-based permission groups (e.g. course codes) aren't part of this slice. (The types will appear disabled in the group type dropdown).

Supporting changes:
- fixes Toast/Modal z-index conflict. Toast now correctly appear above standard modals. (e.g. error toast will appear above group creation modal).
- cancelled api requests are now properly handled without triggering global error (e.g. autocomplete sends updated query and cancels previous).
- TansStack query used for managing group requests, caching, invalidation, and request deduping.
- added `tryFocus` helper to better support focusing an input after update. It will retry (default 10 times) to find the dom element to focus before giving up. This handles an issue where Vue updates require more than one tick (so `await nextTick()` isn't enough).
- Some color fixes (inverse colors, modal surface color not different enough from input color)

on dev