### PR TITLE
Add theme preview for admins

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
     <Teleport to="body">
       <ErrorModal />
       <ToastRoot class="z-[60]" />
+      <ThemePreviewPill />
     </Teleport>
     <ErrorBoundary>
       <RouterView v-if="instanceStore.hasData && drawerStore.isReady" />
@@ -27,6 +28,7 @@ import { useTheming } from "./helpers/useTheming";
 import { useElevatorSessionStorage } from "./helpers/useElevatorSessionStorage";
 import ErrorModal from "@/components/ErrorModal/ErrorModal.vue";
 import ToastRoot from "@/components/ToastRoot/ToastRoot.vue";
+import ThemePreviewPill from "@/components/ThemePreviewPill/ThemePreviewPill.vue";
 import config from "@/config";
 import ErrorBoundary from "@/components/ErrorBoundary/ErrorBoundary.vue";
 import { useCustomCSS } from "./composables/useCustomCSS";

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@
     <Teleport to="body">
       <ErrorModal />
       <ToastRoot class="z-[60]" />
-      <ThemePreviewPill />
+      <ThemePreviewBar />
     </Teleport>
     <ErrorBoundary>
       <RouterView v-if="instanceStore.hasData && drawerStore.isReady" />
@@ -28,7 +28,7 @@ import { useTheming } from "./helpers/useTheming";
 import { useElevatorSessionStorage } from "./helpers/useElevatorSessionStorage";
 import ErrorModal from "@/components/ErrorModal/ErrorModal.vue";
 import ToastRoot from "@/components/ToastRoot/ToastRoot.vue";
-import ThemePreviewPill from "@/components/ThemePreviewPill/ThemePreviewPill.vue";
+import ThemePreviewBar from "@/components/ThemePreviewBar/ThemePreviewBar.vue";
 import config from "@/config";
 import ErrorBoundary from "@/components/ErrorBoundary/ErrorBoundary.vue";
 import { useCustomCSS } from "./composables/useCustomCSS";

--- a/src/components/Map/Map.vue
+++ b/src/components/Map/Map.vue
@@ -128,12 +128,12 @@ const mapStyles = {
   },
 };
 
-const { activeTheme } = useTheming();
+const { effectiveTheme } = useTheming();
 
 // Determine default map style based on theme
 const defaultMapStyle = computed<keyof typeof mapStyles>(() => {
   // If theme name contains "dark", use dark map style
-  return activeTheme.value?.includes("dark") ? "dark" : "light";
+  return effectiveTheme.value?.includes("dark") ? "dark" : "light";
 });
 
 // Track whether user has manually selected a style

--- a/src/components/ObjectViewer/ObjectViewer.vue
+++ b/src/components/ObjectViewer/ObjectViewer.vue
@@ -23,7 +23,7 @@
 <script setup lang="ts">
 import config from "@/config";
 import { useTheming } from "@/helpers/useTheming";
-import { computed, ref, watch } from "vue";
+import { ref, watch } from "vue";
 
 withDefaults(
   defineProps<{
@@ -43,7 +43,7 @@ const theme = useTheming();
 const iframeBackground = ref("white");
 // recalcuate iframe background when theme changes
 watch(
-  theme.activeTheme,
+  theme.effectiveTheme,
   () => {
     const surfaceContainerColor = getComputedStyle(
       document.documentElement

--- a/src/components/ThemePreviewBar/ThemePreviewBar.vue
+++ b/src/components/ThemePreviewBar/ThemePreviewBar.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     v-if="previewTheme"
-    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-full bg-inverse-surface text-inverse-on-surface pl-4 pr-2 py-2 shadow-lg">
+    ref="barRef"
+    class="fixed bottom-0 inset-x-0 z-50 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 bg-inverse-surface text-inverse-on-surface px-4 py-2 border-t border-outline">
     <label for="theme-preview-select" class="text-sm">Previewing</label>
     <select
       id="theme-preview-select"
@@ -29,7 +30,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watchEffect, onUnmounted } from "vue";
+import { useElementSize } from "@vueuse/core";
 import Button from "@/components/Button/Button.vue";
 import { useTheming } from "@/helpers/useTheming";
 import { prettyThemeName } from "@/helpers/prettyThemeName";
@@ -41,6 +43,24 @@ const { previewTheme, previewInstanceId, startPreview, endPreview } =
 // Every theme, not just the enabled ones: the point of previewing is
 // judging a theme before enabling it.
 const themeOptions = computed(() => ALL_THEMES.toSorted());
+
+const barRef = ref<HTMLElement | null>(null);
+
+// Reserve the bar's height at the bottom of the page so it never covers
+// content. Measured rather than hard-coded because themes change fonts,
+// and with them the bar's height.
+const { height: barHeight } = useElementSize(
+  barRef,
+  { width: 0, height: 0 },
+  { box: "border-box" }
+);
+watchEffect(() => {
+  document.body.style.paddingBottom =
+    previewTheme.value && barHeight.value ? `${barHeight.value}px` : "";
+});
+onUnmounted(() => {
+  document.body.style.paddingBottom = "";
+});
 
 const settingsRoute = computed(() => {
   if (previewInstanceId.value === null) return null;

--- a/src/components/ThemePreviewBar/ThemePreviewBar.vue
+++ b/src/components/ThemePreviewBar/ThemePreviewBar.vue
@@ -13,12 +13,6 @@
         {{ prettyThemeName(theme) }}
       </option>
     </select>
-    <RouterLink
-      v-if="settingsRoute"
-      :to="settingsRoute"
-      class="text-sm underline">
-      Theme settings
-    </RouterLink>
     <Button
       variant="secondary"
       type="button"
@@ -37,8 +31,7 @@ import { useTheming } from "@/helpers/useTheming";
 import { prettyThemeName } from "@/helpers/prettyThemeName";
 import { ALL_THEMES } from "@/config";
 
-const { previewTheme, previewInstanceId, startPreview, endPreview } =
-  useTheming();
+const { previewTheme, startPreview, endPreview } = useTheming();
 
 // Every theme, not just the enabled ones: the point of previewing is
 // judging a theme before enabling it.
@@ -62,18 +55,8 @@ onUnmounted(() => {
   document.body.style.paddingBottom = "";
 });
 
-const settingsRoute = computed(() => {
-  if (previewInstanceId.value === null) return null;
-  return {
-    name: "editInstanceSettingsPage",
-    params: { instanceId: previewInstanceId.value },
-    hash: "#user-interface",
-  };
-});
-
 function handleThemeChange(event: Event): void {
   const select = event.target as HTMLSelectElement;
-  if (previewInstanceId.value === null) return;
-  startPreview(select.value, previewInstanceId.value);
+  startPreview(select.value);
 }
 </script>

--- a/src/components/ThemePreviewPill/ThemePreviewPill.vue
+++ b/src/components/ThemePreviewPill/ThemePreviewPill.vue
@@ -1,0 +1,59 @@
+<template>
+  <div
+    v-if="previewTheme"
+    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-full bg-inverse-surface text-inverse-on-surface pl-4 pr-2 py-2 shadow-lg">
+    <label for="theme-preview-select" class="text-sm">Previewing</label>
+    <select
+      id="theme-preview-select"
+      :value="previewTheme"
+      class="rounded-md border border-outline bg-inverse-surface text-inverse-on-surface text-sm py-1"
+      @change="handleThemeChange">
+      <option v-for="theme in themeOptions" :key="theme" :value="theme">
+        {{ prettyThemeName(theme) }}
+      </option>
+    </select>
+    <RouterLink
+      v-if="settingsRoute"
+      :to="settingsRoute"
+      class="text-sm underline">
+      Theme settings
+    </RouterLink>
+    <Button
+      variant="secondary"
+      type="button"
+      class="py-1 px-3 text-sm"
+      @click="endPreview">
+      Revert
+    </Button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import Button from "@/components/Button/Button.vue";
+import { useTheming } from "@/helpers/useTheming";
+import { prettyThemeName } from "@/helpers/prettyThemeName";
+import { ALL_THEMES } from "@/config";
+
+const { previewTheme, previewInstanceId, startPreview, endPreview } =
+  useTheming();
+
+// Every theme, not just the enabled ones: the point of previewing is
+// judging a theme before enabling it.
+const themeOptions = computed(() => ALL_THEMES.toSorted());
+
+const settingsRoute = computed(() => {
+  if (previewInstanceId.value === null) return null;
+  return {
+    name: "editInstanceSettingsPage",
+    params: { instanceId: previewInstanceId.value },
+    hash: "#user-interface",
+  };
+});
+
+function handleThemeChange(event: Event): void {
+  const select = event.target as HTMLSelectElement;
+  if (previewInstanceId.value === null) return;
+  startPreview(select.value, previewInstanceId.value);
+}
+</script>

--- a/src/components/ThemeSelector/ThemeSelector.vue
+++ b/src/components/ThemeSelector/ThemeSelector.vue
@@ -22,6 +22,7 @@ import ThemeIcon from "@/icons/ThemeIcon.vue";
 import DropDown from "../DropDown/DropDown.vue";
 import DropDownItem from "../DropDown/DropDownItem.vue";
 import { useTheming } from "@/helpers/useTheming";
+import { prettyThemeName } from "@/helpers/prettyThemeName";
 
 const {
   activeTheme,
@@ -29,15 +30,4 @@ const {
   setTheme,
   isEnabled: isThemingEnabled,
 } = useTheming();
-
-function capitalize(str: string) {
-  return str
-    .split(" ")
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-    .join(" ");
-}
-
-function prettyThemeName(theme: string) {
-  return capitalize(theme.replace(/-/g, " "));
-}
 </script>

--- a/src/css/themes/_default.css
+++ b/src/css/themes/_default.css
@@ -17,7 +17,14 @@
  * @see https://m3.material.io/styles/color/roles
  */
 
-:root {
+/*
+ * Also scoped to [data-theme] so a nested themed element (the settings
+ * page theme cards) starts from this baseline instead of inheriting
+ * tokens its theme doesn't set from the page's active theme. Theme files
+ * still win: equal specificity, loaded later.
+ */
+:root,
+[data-theme] {
   /* ============================================
    * SURFACE - Background colors
    *

--- a/src/helpers/prettyThemeName.ts
+++ b/src/helpers/prettyThemeName.ts
@@ -1,0 +1,7 @@
+/** Formats a theme slug for display, e.g. "nord-dark" becomes "Nord Dark". */
+export function prettyThemeName(theme: string): string {
+  return theme
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/src/helpers/useTheming.ts
+++ b/src/helpers/useTheming.ts
@@ -44,12 +44,15 @@ let pendingTheme: string | null = null;
 // Never persisted, so a full reload always reverts.
 const previewTheme = ref<string | null>(null);
 
-// Fetch a theme's stylesheet without activating the theme. Safe to call for
-// a theme that is already loaded or in flight. When the fetch settles, the
-// handler activates the theme only if it is still the one `pendingTheme`
-// wants, so preloading never flips the page and activation is never lost to
-// a preload that started first.
-function loadThemeCss(theme: string): void {
+/**
+ * Fetch a theme's stylesheet without activating the theme. Safe to call for
+ * a theme that is already loaded or in flight. A successful fetch activates
+ * the theme only if it is still the one `pendingTheme` wants, so preloading
+ * never flips the page and activation is never lost to a preload that
+ * started first. A failed fetch is discarded, so a later call retries
+ * instead of activating a theme whose CSS never arrived.
+ */
+export function loadThemeCss(theme: string): void {
   const href = themeUrlLookup[theme];
   if (!href || loadedThemes.has(theme) || inFlightThemes.has(theme)) return;
   inFlightThemes.add(theme);
@@ -59,24 +62,19 @@ function loadThemeCss(theme: string): void {
   link.href = href;
   link.setAttribute(THEME_LINK_ATTR, theme);
 
-  const onReady = () => {
+  const onLoad = () => {
     inFlightThemes.delete(theme);
     loadedThemes.add(theme);
     if (pendingTheme !== theme) return;
     document.documentElement?.setAttribute("data-theme", theme);
   };
-  link.addEventListener("load", onReady, { once: true });
-  link.addEventListener("error", onReady, { once: true });
+  const onError = () => {
+    inFlightThemes.delete(theme);
+    link.remove();
+  };
+  link.addEventListener("load", onLoad, { once: true });
+  link.addEventListener("error", onError, { once: true });
   document.head.appendChild(link);
-}
-
-/**
- * Fetch every theme's stylesheet without activating any of them. The theme
- * cards on the instance settings page render each theme's colors and fonts
- * from its own CSS, so all of it must be present.
- */
-export function loadAllThemeCss(): void {
-  ALL_THEMES.forEach(loadThemeCss);
 }
 
 /**
@@ -84,7 +82,8 @@ export function loadAllThemeCss(): void {
  * for it to load before flipping the `data-theme` attribute — otherwise the
  * attribute would point at a theme whose rules haven't arrived, briefly
  * rendering the default baseline. For already-loaded themes, the attribute
- * flip is immediate.
+ * flip is immediate. If the fetch fails, the page stays on the current theme
+ * and the next activation retries.
  */
 function applyTheme(theme: string) {
   pendingTheme = theme;

--- a/src/helpers/useTheming.ts
+++ b/src/helpers/useTheming.ts
@@ -44,29 +44,14 @@ let pendingTheme: string | null = null;
 // Never persisted, so a full reload always reverts.
 const previewTheme = ref<string | null>(null);
 
-// The instance whose settings page started the preview, so the preview
-// pill can link back to it.
-const previewInstanceId = ref<number | null>(null);
-
-/**
- * Activate a theme. On first activation, fetches the theme's CSS and waits
- * for it to load before flipping the `data-theme` attribute — otherwise the
- * attribute would point at a theme whose rules haven't arrived, briefly
- * rendering the default baseline. For already-loaded themes, the attribute
- * flip is immediate.
- */
-function applyTheme(theme: string) {
-  pendingTheme = theme;
-
+// Fetch a theme's stylesheet without activating the theme. Safe to call for
+// a theme that is already loaded or in flight. When the fetch settles, the
+// handler activates the theme only if it is still the one `pendingTheme`
+// wants, so preloading never flips the page and activation is never lost to
+// a preload that started first.
+function loadThemeCss(theme: string): void {
   const href = themeUrlLookup[theme];
-  if (!href || loadedThemes.has(theme)) {
-    document.documentElement?.setAttribute("data-theme", theme);
-    return;
-  }
-
-  // Fetch already in flight from a previous call — its existing onReady will
-  // check `pendingTheme` when it fires.
-  if (inFlightThemes.has(theme)) return;
+  if (!href || loadedThemes.has(theme) || inFlightThemes.has(theme)) return;
   inFlightThemes.add(theme);
 
   const link = document.createElement("link");
@@ -83,6 +68,33 @@ function applyTheme(theme: string) {
   link.addEventListener("load", onReady, { once: true });
   link.addEventListener("error", onReady, { once: true });
   document.head.appendChild(link);
+}
+
+/**
+ * Fetch every theme's stylesheet without activating any of them. The theme
+ * cards on the instance settings page render each theme's colors and fonts
+ * from its own CSS, so all of it must be present.
+ */
+export function loadAllThemeCss(): void {
+  ALL_THEMES.forEach(loadThemeCss);
+}
+
+/**
+ * Activate a theme. On first activation, fetches the theme's CSS and waits
+ * for it to load before flipping the `data-theme` attribute — otherwise the
+ * attribute would point at a theme whose rules haven't arrived, briefly
+ * rendering the default baseline. For already-loaded themes, the attribute
+ * flip is immediate.
+ */
+function applyTheme(theme: string) {
+  pendingTheme = theme;
+
+  const href = themeUrlLookup[theme];
+  if (!href || loadedThemes.has(theme)) {
+    document.documentElement?.setAttribute("data-theme", theme);
+    return;
+  }
+  loadThemeCss(theme);
 }
 
 export function useTheming() {
@@ -127,26 +139,19 @@ export function useTheming() {
     activeTheme,
     effectiveTheme,
     previewTheme,
-    previewInstanceId,
     availableThemes,
     isEnabled,
     setTheme(theme: string): void {
       // choosing a theme outright ends any preview
       previewTheme.value = null;
-      previewInstanceId.value = null;
       activeTheme.value = theme;
     },
-    /**
-     * Preview a theme without touching the saved choice. The instanceId
-     * ties the preview back to the settings page that started it.
-     */
-    startPreview(theme: string, instanceId: number): void {
+    /** Preview a theme without touching the saved choice. */
+    startPreview(theme: string): void {
       previewTheme.value = theme;
-      previewInstanceId.value = instanceId;
     },
     endPreview(): void {
       previewTheme.value = null;
-      previewInstanceId.value = null;
     },
   };
 }

--- a/src/helpers/useTheming.ts
+++ b/src/helpers/useTheming.ts
@@ -1,4 +1,4 @@
-import { watch, computed } from "vue";
+import { watch, computed, ref } from "vue";
 import { useStorage } from "@vueuse/core";
 import { useInstanceQuery } from "@/queries/useInstanceQuery";
 import { ALL_THEMES } from "@/config";
@@ -37,6 +37,16 @@ const inFlightThemes = new Set<string>();
 // superseded theme must NOT apply its attribute — otherwise rapid
 // theme-switching can briefly flash to a stale in-flight theme.
 let pendingTheme: string | null = null;
+
+// An admin's temporary theme override. Module-scoped so a preview outlives
+// any single page: remounts re-run each consumer's immediate watch below,
+// which re-applies the preview instead of resetting to the stored theme.
+// Never persisted, so a full reload always reverts.
+const previewTheme = ref<string | null>(null);
+
+// The instance whose settings page started the preview, so the preview
+// pill can link back to it.
+const previewInstanceId = ref<number | null>(null);
 
 /**
  * Activate a theme. On first activation, fetches the theme's CSS and waits
@@ -97,22 +107,46 @@ export function useTheming() {
     null
   );
 
+  // The theme the UI actually shows: the preview when one is active,
+  // otherwise the saved choice.
+  const effectiveTheme = computed(
+    () => previewTheme.value ?? activeTheme.value
+  );
+
   watch(
-    [activeTheme, instanceData],
+    [activeTheme, previewTheme, instanceData],
     () => {
       if (!instanceData.value) return;
       activeTheme.value = activeTheme.value || defaultTheme.value;
-      applyTheme(activeTheme.value);
+      applyTheme(effectiveTheme.value ?? defaultTheme.value);
     },
     { immediate: true }
   );
 
   return {
     activeTheme,
+    effectiveTheme,
+    previewTheme,
+    previewInstanceId,
     availableThemes,
     isEnabled,
-    setTheme(theme: string) {
+    setTheme(theme: string): void {
+      // choosing a theme outright ends any preview
+      previewTheme.value = null;
+      previewInstanceId.value = null;
       activeTheme.value = theme;
+    },
+    /**
+     * Preview a theme without touching the saved choice. The instanceId
+     * ties the preview back to the settings page that started it.
+     */
+    startPreview(theme: string, instanceId: number): void {
+      previewTheme.value = theme;
+      previewInstanceId.value = instanceId;
+    },
+    endPreview(): void {
+      previewTheme.value = null;
+      previewInstanceId.value = null;
     },
   };
 }

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
@@ -105,10 +105,10 @@ const props = withDefaults(
 
 const id = computed(() => props.modelValue.id || useId());
 
-const { activeTheme } = useTheming();
+const { effectiveTheme } = useTheming();
 
 const getDefaultMapStyle = (): keyof typeof mapStyles =>
-  activeTheme.value.includes("dark") ? "dark" : "light";
+  effectiveTheme.value?.includes("dark") ? "dark" : "light";
 
 const roundFloat = (value: number, decimalPlaces: number): number =>
   Number(value.toFixed(decimalPlaces));

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/FileUploader.vue
@@ -43,7 +43,7 @@ const emit = defineEmits<{
 
 const uploadStore = useUploadStore();
 
-const { activeTheme } = useTheming();
+const { effectiveTheme } = useTheming();
 
 // Explicit list of themes that should use Uppy's dark color scheme.
 const DARK_THEMES = new Set([
@@ -57,7 +57,7 @@ const DARK_THEMES = new Set([
 ]);
 
 const uppyTheme = computed<"dark" | "light">(() =>
-  DARK_THEMES.has(activeTheme.value ?? "") ? "dark" : "light"
+  DARK_THEMES.has(effectiveTheme.value ?? "") ? "dark" : "light"
 );
 
 // Local index: filename → uploadId.

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -314,7 +314,7 @@ import ToggleGroup from "@/components/ToggleGroup/ToggleGroup.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import ElevatorIcon from "@/icons/ElevatorIcon.vue";
 import ThemeCard from "./ThemeCard.vue";
-import { useTheming, loadAllThemeCss } from "@/helpers/useTheming";
+import { useTheming } from "@/helpers/useTheming";
 
 const props = defineProps<{
   instanceId: number;
@@ -326,7 +326,6 @@ const toastStore = useToastStore();
 const instanceStore = useInstanceStore();
 
 const { startPreview, previewTheme } = useTheming();
-loadAllThemeCss();
 
 const {
   data: settingsData,

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -240,31 +240,17 @@
                     Toggle All
                   </Button>
                 </div>
-                <div class="grid grid-cols-3 gap-4">
-                  <div
+                <div class="grid grid-cols-2 gap-x-6 gap-y-2">
+                  <ThemeCard
                     v-for="theme in allThemes.toSorted()"
                     :key="theme"
-                    class="flex items-center gap-2 text-sm">
-                    <label class="flex flex-1 items-center gap-2">
-                      <input
-                        type="checkbox"
-                        :value="theme"
-                        :checked="form.availableThemes?.includes(theme)"
-                        class="rounded border-outline text-primary focus:ring-m3-primary"
-                        @change="toggleTheme(theme)" />
-                      {{ theme }}
-                    </label>
-                    <IconButton
-                      :title="`Preview ${theme}`"
-                      class="p-1"
-                      :class="{
-                        'bg-primary-container text-on-primary-container':
-                          previewTheme === theme,
-                      }"
-                      @click="startPreview(theme, instanceId)">
-                      <EyeIcon class="w-4 h-4" />
-                    </IconButton>
-                  </div>
+                    :theme="theme"
+                    :isAvailable="
+                      form.availableThemes?.includes(theme) ?? false
+                    "
+                    :isPreviewing="previewTheme === theme"
+                    @toggleAvailable="toggleTheme(theme)"
+                    @preview="startPreview(theme)" />
                 </div>
               </div>
             </template>
@@ -327,8 +313,8 @@ import { FormSection, FormToc } from "@/components/Form";
 import ToggleGroup from "@/components/ToggleGroup/ToggleGroup.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import ElevatorIcon from "@/icons/ElevatorIcon.vue";
-import IconButton from "@/components/IconButton/IconButton.vue";
-import { useTheming } from "@/helpers/useTheming";
+import ThemeCard from "./ThemeCard.vue";
+import { useTheming, loadAllThemeCss } from "@/helpers/useTheming";
 
 const props = defineProps<{
   instanceId: number;
@@ -340,6 +326,7 @@ const toastStore = useToastStore();
 const instanceStore = useInstanceStore();
 
 const { startPreview, previewTheme } = useTheming();
+loadAllThemeCss();
 
 const {
   data: settingsData,

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -241,18 +241,30 @@
                   </Button>
                 </div>
                 <div class="grid grid-cols-3 gap-4">
-                  <label
+                  <div
                     v-for="theme in allThemes.toSorted()"
                     :key="theme"
                     class="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
-                      :value="theme"
-                      :checked="form.availableThemes?.includes(theme)"
-                      class="rounded border-outline text-primary focus:ring-m3-primary"
-                      @change="toggleTheme(theme)" />
-                    {{ theme }}
-                  </label>
+                    <label class="flex flex-1 items-center gap-2">
+                      <input
+                        type="checkbox"
+                        :value="theme"
+                        :checked="form.availableThemes?.includes(theme)"
+                        class="rounded border-outline text-primary focus:ring-m3-primary"
+                        @change="toggleTheme(theme)" />
+                      {{ theme }}
+                    </label>
+                    <IconButton
+                      :title="`Preview ${theme}`"
+                      class="p-1"
+                      :class="{
+                        'bg-primary-container text-on-primary-container':
+                          previewTheme === theme,
+                      }"
+                      @click="startPreview(theme, instanceId)">
+                      <EyeIcon class="w-4 h-4" />
+                    </IconButton>
+                  </div>
                 </div>
               </div>
             </template>
@@ -315,6 +327,8 @@ import { FormSection, FormToc } from "@/components/Form";
 import ToggleGroup from "@/components/ToggleGroup/ToggleGroup.vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import ElevatorIcon from "@/icons/ElevatorIcon.vue";
+import IconButton from "@/components/IconButton/IconButton.vue";
+import { useTheming } from "@/helpers/useTheming";
 
 const props = defineProps<{
   instanceId: number;
@@ -324,6 +338,8 @@ const toastStore = useToastStore();
 
 // for easier access to logo url
 const instanceStore = useInstanceStore();
+
+const { startPreview, previewTheme } = useTheming();
 
 const {
   data: settingsData,

--- a/src/pages/InstanceSettingsPage/ThemeCard.vue
+++ b/src/pages/InstanceSettingsPage/ThemeCard.vue
@@ -37,12 +37,15 @@
 import IconButton from "@/components/IconButton/IconButton.vue";
 import EyeIcon from "@/icons/EyeIcon.vue";
 import { prettyThemeName } from "@/helpers/prettyThemeName";
+import { loadThemeCss } from "@/helpers/useTheming";
 
-defineProps<{
+const props = defineProps<{
   theme: string;
   isAvailable: boolean;
   isPreviewing: boolean;
 }>();
+
+loadThemeCss(props.theme);
 
 defineEmits<{
   (e: "toggleAvailable"): void;

--- a/src/pages/InstanceSettingsPage/ThemeCard.vue
+++ b/src/pages/InstanceSettingsPage/ThemeCard.vue
@@ -1,0 +1,51 @@
+<template>
+  <div
+    class="flex items-center gap-2 text-sm rounded-lg"
+    :class="{ 'ring-2 ring-primary': isPreviewing }">
+    <label class="flex flex-1 min-w-0 items-center gap-2">
+      <input
+        type="checkbox"
+        :checked="isAvailable"
+        class="shrink-0 rounded border-outline text-primary focus:ring-m3-primary"
+        @change="$emit('toggleAvailable')" />
+      <!-- The swatch scope: everything inside renders in the theme's own
+           colors and display font. Controls stay outside so they keep the
+           app theme and stay legible on every swatch. -->
+      <span
+        :data-theme="theme"
+        class="flex flex-1 min-w-0 items-center gap-2 rounded-lg border border-outline bg-surface text-on-surface px-3 py-2">
+        <span class="truncate [font-family:var(--font-display)]">
+          {{ prettyThemeName(theme) }}
+        </span>
+        <span aria-hidden="true" class="ml-auto flex shrink-0 gap-1">
+          <span class="size-3 rounded-full bg-primary" />
+          <span class="size-3 rounded-full bg-secondary" />
+          <span class="size-3 rounded-full bg-tertiary" />
+        </span>
+      </span>
+    </label>
+    <IconButton
+      :title="`Preview ${theme}`"
+      class="p-1 shrink-0"
+      @click="$emit('preview')">
+      <EyeIcon class="w-4 h-4" />
+    </IconButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+import IconButton from "@/components/IconButton/IconButton.vue";
+import EyeIcon from "@/icons/EyeIcon.vue";
+import { prettyThemeName } from "@/helpers/prettyThemeName";
+
+defineProps<{
+  theme: string;
+  isAvailable: boolean;
+  isPreviewing: boolean;
+}>();
+
+defineEmits<{
+  (e: "toggleAvailable"): void;
+  (e: "preview"): void;
+}>();
+</script>


### PR DESCRIPTION
- Admins can preview any theme from Instance Settings: an eye button per theme applies it to the whole app without saving anything, and a bottom bar offers a theme switcher and Revert.
- The preview follows SPA navigation so admins can judge real pages (search, asset views, maps), while a reload or Revert restores the saved theme. Nothing is written to the API or localStorage.
- The Available Themes grid renders each theme as swatch card: the theme's own surface color, display font, and primary/secondary/tertiary dots, with the checkbox and preview button in the app theme beside it.

<img width="800"  alt="CleanShot 2026-07-21 at 11 01 42@2x" src="https://github.com/user-attachments/assets/cf43c2c7-19a7-425a-916a-f244ff00a22e" />
