### PR TITLE
Browse child collections on the collection page

### DIFF
--- a/src/components/AssetMetadata/CollectionTuple.vue
+++ b/src/components/AssetMetadata/CollectionTuple.vue
@@ -18,6 +18,7 @@ import Link from "@/components/Link/Link.vue";
 import { computed } from "vue";
 import { useInstanceStore } from "@/stores/instanceStore";
 import { AssetCollection } from "@/types";
+import { toCollectionAncestry } from "@/helpers/collectionHelpers";
 
 const props = defineProps<{
   label: string;
@@ -26,29 +27,9 @@ const props = defineProps<{
 
 const instanceStore = useInstanceStore();
 
-// create a path to the collection
-// so we can display it as a breadcrumb
-// like "Collection A / Collection B / Collection C"
-const collectionPath = computed(() => {
-  if (!props.collectionId) return null;
-
-  const collection = instanceStore.collectionIndex[props.collectionId];
-
-  if (!collection) {
-    throw new Error(
-      `Collection ${props.collectionId} not found in instanceStore`
-    );
-  }
-
-  // construct a path to this collection
-  const path = [collection];
-  let child = collection;
-  while (child.parentId) {
-    child = instanceStore.collectionIndex[child.parentId];
-    path.unshift(child);
-  }
-
-  return path;
-});
+// breadcrumb path like "Collection A / Collection B / Collection C"
+const collectionPath = computed((): AssetCollection[] =>
+  toCollectionAncestry(instanceStore.collectionIndex, props.collectionId)
+);
 </script>
 <style scoped></style>

--- a/src/components/CollectionItem/CollectionItem.vue
+++ b/src/components/CollectionItem/CollectionItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="all-collections-page__collection-item collection-item p-4 rounded border transition-colors duration-150">
+    class="collection-item p-4 rounded border transition-colors duration-150">
     <div class="flex items-center gap-1">
       <button
         v-if="collection.children && collection.children.length > 0"

--- a/src/helpers/collectionHelpers.test.ts
+++ b/src/helpers/collectionHelpers.test.ts
@@ -1,6 +1,28 @@
 import { describe, it, expect } from "vitest";
-import { filterCollections } from "./collectionHelpers";
+import { filterCollections, toCollectionAncestry } from "./collectionHelpers";
 import type { AssetCollection } from "@/types";
+
+function makeCollection(
+  partial: Partial<AssetCollection> & Pick<AssetCollection, "id">
+): AssetCollection {
+  return {
+    title: `Collection ${partial.id}`,
+    description: null,
+    previewImageId: null,
+    children: [],
+    parentId: null,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+    ...partial,
+  };
+}
+
+function toIndex(
+  collections: AssetCollection[]
+): { [id: number]: AssetCollection } {
+  return Object.fromEntries(collections.map((c) => [c.id, c]));
+}
 
 describe("filterCollections", () => {
 
@@ -480,5 +502,52 @@ describe("filterCollections", () => {
     // Second child should be the promoted grandchild
     expect(result[0].children![1].id).toBe(4);
     expect(result[0].children![1].parentId).toBe(1);
+  });
+});
+
+describe("toCollectionAncestry", () => {
+  it("returns empty array when the id is not indexed", () => {
+    const result = toCollectionAncestry(
+      toIndex([makeCollection({ id: 1 })]),
+      99
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns just the collection when it is a root", () => {
+    const root = makeCollection({ id: 1, parentId: null });
+
+    const result = toCollectionAncestry(toIndex([root]), 1);
+
+    expect(result.map((c) => c.id)).toEqual([1]);
+  });
+
+  it("walks parentId from the top-most ancestor down to the collection", () => {
+    const root = makeCollection({ id: 1, parentId: null });
+    const middle = makeCollection({ id: 2, parentId: 1 });
+    const leaf = makeCollection({ id: 3, parentId: 2 });
+
+    const result = toCollectionAncestry(toIndex([root, middle, leaf]), 3);
+
+    expect(result.map((c) => c.id)).toEqual([1, 2, 3]);
+  });
+
+  it("stops when a parent is missing from the index", () => {
+    // parentId points at 1, which is not in the index
+    const orphan = makeCollection({ id: 2, parentId: 1 });
+
+    const result = toCollectionAncestry(toIndex([orphan]), 2);
+
+    expect(result.map((c) => c.id)).toEqual([2]);
+  });
+
+  it("stops on a cycle instead of looping forever", () => {
+    const a = makeCollection({ id: 1, parentId: 2 });
+    const b = makeCollection({ id: 2, parentId: 1 });
+
+    const result = toCollectionAncestry(toIndex([a, b]), 1);
+
+    expect(result.map((c) => c.id)).toEqual([2, 1]);
   });
 });

--- a/src/helpers/collectionHelpers.ts
+++ b/src/helpers/collectionHelpers.ts
@@ -41,6 +41,34 @@ export function toCollectionIndex(collections: AssetCollection[] | null): {
 }
 
 /**
+ * Ancestry path from the top-most ancestor down to the given collection,
+ * for rendering a breadcrumb trail.
+ *
+ * @returns [rootAncestor, ..., collection], or [] when the id is not indexed.
+ */
+export function toCollectionAncestry(
+  collectionIndex: { [id: number]: AssetCollection },
+  collectionId: number
+): AssetCollection[] {
+  const collection = collectionIndex[collectionId];
+  if (!collection) return [];
+
+  const ancestry = [collection];
+  const seen = new Set<number>([collection.id]);
+  let node = collection;
+  while (node.parentId != null) {
+    const parent = collectionIndex[node.parentId];
+    // A collection tree is acyclic, so stop if a parent is missing from the
+    // index or a malformed tree points back at a collection already seen.
+    if (!parent || seen.has(parent.id)) break;
+    ancestry.unshift(parent);
+    seen.add(parent.id);
+    node = parent;
+  }
+  return ancestry;
+}
+
+/**
  * list of collections with titles that include their parent titles
  */
 export function flattenCollections(

--- a/src/helpers/getDefaultInstanceSettings.ts
+++ b/src/helpers/getDefaultInstanceSettings.ts
@@ -20,6 +20,7 @@ export function getDefaultInstanceSettings(
     bucketRegion: null,
     showCollectionInSearchResults: true,
     showTemplateInSearchResults: false,
+    showChildCollections: true,
     showPreviousNextSearchResults: true,
     hideVideoAudio: false,
     allowIndexing: true,

--- a/src/helpers/selectInstanceFromResponse.ts
+++ b/src/helpers/selectInstanceFromResponse.ts
@@ -18,6 +18,7 @@ export function selectInstanceFromResponse(
     userCanSearchAndBrowse,
     templates,
     useVoyagerViewer,
+    showChildCollections,
     theming,
   } = apiResponse;
 
@@ -55,6 +56,8 @@ export function selectInstanceFromResponse(
     showCollectionInSearchResults: instanceShowCollectionInSearchResults,
     showTemplateInSearchResults: instanceShowTemplateInSearchResults,
     useVoyagerViewer, // whether or not to use the Voyager viewer
+    // default on so a nav payload without the field keeps the panel showing
+    showChildCollections: showChildCollections ?? true,
     theming,
   };
 }

--- a/src/pages/AllCollectionsPage/AllCollectionsPage.vue
+++ b/src/pages/AllCollectionsPage/AllCollectionsPage.vue
@@ -32,7 +32,7 @@
 </template>
 <script setup lang="ts">
 import { computed, onMounted, ref, useTemplateRef } from "vue";
-import CollectionItem from "./CollectionItem.vue";
+import CollectionItem from "@/components/CollectionItem/CollectionItem.vue";
 import CustomAppHeader from "@/components/CustomAppHeader/CustomAppHeader.vue";
 import AppFooter from "@/components/AppFooter/AppFooter.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -150,6 +150,12 @@
             @update:modelValue="form.featuredAssetText = $event || null" />
         </FormSection>
 
+        <FormSection id="collections" title="Collections">
+          <ToggleGroup
+            v-model="form.showChildCollections"
+            label="Show Sub-Collections When Browsing" />
+        </FormSection>
+
         <FormSection id="search-settings" title="Search">
           <ToggleGroup
             v-model="form.showCollectionInSearchResults"
@@ -450,6 +456,7 @@ const tocSections: TocItem[] = [
   { id: "customization", label: "Customization" },
   { id: "storage", label: "Storage" },
   { id: "featured-asset", label: "Featured Asset" },
+  { id: "collections", label: "Collections" },
   { id: "search-settings", label: "Search" },
   { id: "assets", label: "Assets" },
   { id: "user-interface", label: "User Interface" },

--- a/src/pages/SearchResultsPage/BrowseChildCollections.vue
+++ b/src/pages/SearchResultsPage/BrowseChildCollections.vue
@@ -1,5 +1,5 @@
 <template>
-  <section v-if="browsableChildren.length" class="my-8">
+  <section v-if="isPanelEnabled && browsableChildren.length" class="my-8">
     <h2 class="text-xl font-bold mb-4">Sub-Collections</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
       <CollectionItem
@@ -21,6 +21,11 @@ const props = defineProps<{
 }>();
 
 const instanceStore = useInstanceStore();
+
+// Instance admins can turn the browse panel off for the whole instance.
+const isPanelEnabled = computed(
+  () => instanceStore.instance.showChildCollections
+);
 
 // Same predicate the All Collections page uses for its top level, so the
 // panel and the full page agree on which children are shown.

--- a/src/pages/SearchResultsPage/BrowseChildCollections.vue
+++ b/src/pages/SearchResultsPage/BrowseChildCollections.vue
@@ -1,0 +1,34 @@
+<template>
+  <section v-if="browsableChildren.length" class="my-8">
+    <h2 class="text-xl font-bold mb-4">Collections</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+      <CollectionItem
+        v-for="child in browsableChildren"
+        :key="child.id"
+        :collection="child" />
+    </div>
+  </section>
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import { useInstanceStore } from "@/stores/instanceStore";
+import { filterCollections } from "@/helpers/collectionHelpers";
+import { AssetCollection } from "@/types";
+import CollectionItem from "@/components/CollectionItem/CollectionItem.vue";
+
+const props = defineProps<{
+  collectionId: number;
+}>();
+
+const instanceStore = useInstanceStore();
+
+// Same predicate the All Collections page uses for its top level, so the
+// panel and the full page agree on which children are shown.
+const browsableChildren = computed((): AssetCollection[] => {
+  const collection = instanceStore.collectionIndex[props.collectionId];
+  return filterCollections(
+    (col) => col.canView && col.showInBrowse,
+    collection?.children ?? []
+  );
+});
+</script>

--- a/src/pages/SearchResultsPage/BrowseChildCollections.vue
+++ b/src/pages/SearchResultsPage/BrowseChildCollections.vue
@@ -1,6 +1,6 @@
 <template>
   <section v-if="browsableChildren.length" class="my-8">
-    <h2 class="text-xl font-bold mb-4">Collections</h2>
+    <h2 class="text-xl font-bold mb-4">Sub-Collections</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
       <CollectionItem
         v-for="child in browsableChildren"

--- a/src/pages/SearchResultsPage/BrowseCollectionHeader.vue
+++ b/src/pages/SearchResultsPage/BrowseCollectionHeader.vue
@@ -1,10 +1,31 @@
 <template>
   <div class="search-results-page__browser-collection-header">
     <header class="pb-8 my-8">
-      <Link :to="`/search/listCollections`" class="flex items-center gap-1">
-        <ArrowForwardIcon class="transform rotate-180 h-4 w-4" />
-        Back to Collections
-      </Link>
+      <nav aria-label="Breadcrumb">
+        <ol
+          class="flex flex-wrap items-center gap-1 text-sm text-on-surface-variant">
+          <li>
+            <Link :to="`/search/listCollections`">Collections</Link>
+          </li>
+          <li
+            v-for="(crumb, index) in ancestry"
+            :key="crumb.id"
+            class="flex items-center gap-1">
+            <span aria-hidden="true">&rsaquo;</span>
+            <Link
+              v-if="index < ancestry.length - 1"
+              :to="`/collections/browseCollection/${crumb.id}`">
+              {{ crumb.title }}
+            </Link>
+            <span
+              v-else
+              aria-current="page"
+              class="font-semibold text-on-surface">
+              {{ crumb.title }}
+            </span>
+          </li>
+        </ol>
+      </nav>
       <div class="mt-4 flex flex-wrap items-center justify-between gap-4">
         <h2 v-if="collection?.title" class="text-4xl font-bold">
           Browsing {{ collection?.title }}
@@ -32,12 +53,12 @@
   </div>
 </template>
 <script setup lang="ts">
-import { watch, ref } from "vue";
+import { watch, ref, computed } from "vue";
 import { AssetCollection } from "@/types";
 import { useInstanceStore } from "@/stores/instanceStore";
+import { toCollectionAncestry } from "@/helpers/collectionHelpers";
 import Button from "@/components/Button/Button.vue";
 import Link from "@/components/Link/Link.vue";
-import { ArrowForwardIcon } from "@/icons";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import Skeleton from "@/components/Skeleton/Skeleton.vue";
 
@@ -47,6 +68,10 @@ const props = defineProps<{
 
 const instanceStore = useInstanceStore();
 const collection = ref<AssetCollection | null>(null);
+
+const ancestry = computed((): AssetCollection[] =>
+  toCollectionAncestry(instanceStore.collectionIndex, props.collectionId)
+);
 
 watch(
   [() => props.collectionId, () => instanceStore.isReady],

--- a/src/pages/SearchResultsPage/SearchResultsPage.vue
+++ b/src/pages/SearchResultsPage/SearchResultsPage.vue
@@ -19,6 +19,10 @@
           <Skeleton v-else class="!w-1/2 !h-12" />
         </div>
 
+        <BrowseChildCollections
+          v-if="searchStore.browsingCollectionId"
+          :collectionId="searchStore.browsingCollectionId" />
+
         <DidYouMeanSuggestions
           v-if="searchStore.isReady"
           :searchTerm="searchStore.currentSearchTerm" />
@@ -136,6 +140,7 @@ import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useSearchStore } from "@/stores/searchStore";
 import config from "@/config";
 import BrowseCollectionHeader from "./BrowseCollectionHeader.vue";
+import BrowseChildCollections from "./BrowseChildCollections.vue";
 import Tab from "@/components/Tabs/Tab.vue";
 import Tabs from "@/components/Tabs/Tabs.vue";
 import SearchResultsGrid from "@/components/SearchResultsGrid/SearchResultsGrid.vue";

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -44,6 +44,7 @@ const createState = () => ({
     templates: [],
     showCollectionInSearchResults: true,
     showTemplateInSearchResults: true,
+    showChildCollections: true,
     useVoyagerViewer: false, // whether or not to use the Voyager viewer
     theming: {
       enabled: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -608,6 +608,8 @@ export interface ApiInstanceNavResponse {
   customHeaderText: string | null; // html
   customFooterText: string | null; // html
   useVoyagerViewer: boolean; // whether or not to use the Voyager viewer
+  // optional so an older API build still works
+  showChildCollections?: boolean;
   useCustomCSS: boolean; // whether or not to use custom CSS
   customHeaderCSS: string | null; // custom CSS for header if useCustomCSS is true
   theming: {
@@ -649,6 +651,7 @@ export interface ElevatorInstance {
   templates: { id: number; name: string }[];
   showCollectionInSearchResults: boolean; // whether or not to show collection in search results
   showTemplateInSearchResults: boolean; // whether or not to show template in search results
+  showChildCollections: boolean; // whether to list child collections when browsing
   useVoyagerViewer: boolean; // whether or not to use the Voyager viewer
   theming: {
     enabled: boolean;
@@ -677,6 +680,7 @@ export interface InstanceSettings {
   // Display options
   showCollectionInSearchResults: boolean;
   showTemplateInSearchResults: boolean;
+  showChildCollections: boolean;
   showPreviousNextSearchResults: boolean;
   hideVideoAudio: boolean;
   allowIndexing: boolean;


### PR DESCRIPTION
- Closes #453
- Browsing a collection now shows a "Sub-Collections" panel above the results tabs listing that collection's child collections, so you can drill into a nested hierarchy without going back to the All Collections page.
- Reuses the existing `CollectionItem` tile (thumbnail, title, chevron-expand nesting). Instance admins can turn the panel off under Instance Settings › Collections; it defaults on.
- Replaces the "Back to Collections" link on the browse header with a breadcrumb trail eyebrow (`Collections › Parent › Current`), so you can jump to any ancestor, not just the top.

<img width="800"  alt="CleanShot 2026-07-22 at 13 13 26@2x" src="https://github.com/user-attachments/assets/191e65e6-fbd8-4804-868b-7f167c268574" />
