### PR TITLE
Handle bad lnglat without crashing the page

### DIFF
--- a/mock-server/db/assets.ts
+++ b/mock-server/db/assets.ts
@@ -185,6 +185,38 @@ const assetSeeds: WithMeta<Asset>[] = [
     collectionId: 1,
     modifiedBy: 1,
   },
+  // Asset with out-of-range coordinates for location widget fallback tests
+  {
+    ...baseAsset,
+    title_1: [
+      {
+        isPrimary: false,
+        fieldContents: "Invalid Location Asset",
+      },
+    ],
+    location_1: [
+      {
+        isPrimary: false,
+        locationLabel: null,
+        address: null,
+        loc: {
+          type: "Point",
+          coordinates: [181, 95],
+        },
+      },
+    ],
+    assetId: "6875871d4eb080a4880a0abc",
+    firstFileHandlerId: "handler_invalid_location_001",
+    title: ["Invalid Location Asset"],
+    templateId: 68, // All Fields Test template (includes a location widget)
+    modified: {
+      date: "2025-07-14 22:40:25.000000",
+      timezone_type: 3,
+      timezone: "UTC",
+    },
+    collectionId: 1,
+    modifiedBy: 1,
+  },
   // Auth-required asset for testing 401 / login-redirect flows
   {
     ...baseAsset,

--- a/src/components/Widget/LocationWidget/LocationItem.vue
+++ b/src/components/Widget/LocationWidget/LocationItem.vue
@@ -22,7 +22,8 @@
 
   <Modal :isOpen="isOpen" :label="locationLabel" @close="isOpen = false">
     <Map
-      :center="mapCenter"
+      v-if="lngLat"
+      :center="lngLat"
       :zoom="10"
       mapStyle="streets"
       :apiKey="config.arcgis.apiKey"
@@ -30,8 +31,8 @@
       mapContainerClass="!h-[50vh]">
       <MapMarker
         :id="`locationItem-${locationLabel}`"
-        :lng="mapCenter.lng"
-        :lat="mapCenter.lat" />
+        :lng="lngLat.lng"
+        :lat="lngLat.lat" />
     </Map>
     <div class="w-min flex gap-4 my-4">
       <Tuple label="Latitude" class="w-auto">{{ latStr }}</Tuple>
@@ -48,6 +49,7 @@ import config from "@/config";
 import Tuple from "@/components/Tuple/Tuple.vue";
 import Button from "@/components/Button/Button.vue";
 import Accordion from "@/components/Accordion/Accordion.vue";
+import { toLngLat } from "@/helpers/coordinates";
 
 const Map = defineAsyncComponent(() => import("@/components/Map/Map.vue"));
 const MapMarker = defineAsyncComponent(
@@ -61,23 +63,18 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const lat = computed((): number => {
-  return props.locationContent.loc?.coordinates?.[1] ?? 0;
+// (0,0) doubles as "no location" in stored data, treat it as absent
+const lngLat = computed((): LngLat | null => {
+  const stored = toLngLat(props.locationContent.loc?.coordinates);
+  const isZeroLngLat = stored?.lng === 0 && stored?.lat === 0;
+  return isZeroLngLat ? null : stored;
 });
 
-const lng = computed((): number => {
-  return props.locationContent.loc?.coordinates?.[0] ?? 0;
-});
-
-const lngStr = computed((): string => (lng.value ? lng.value.toFixed(4) : "-"));
-const latStr = computed((): string => (lat.value ? lat.value.toFixed(4) : "-"));
-
-const mapCenter = computed(
-  () =>
-    ({
-      lng: lng.value,
-      lat: lat.value,
-    } as LngLat)
+const lngStr = computed((): string =>
+  lngLat.value ? lngLat.value.lng.toFixed(4) : "-"
+);
+const latStr = computed((): string =>
+  lngLat.value ? lngLat.value.lat.toFixed(4) : "-"
 );
 
 const locationLabel = computed(
@@ -86,9 +83,7 @@ const locationLabel = computed(
     null
 );
 
-const hasLocation = computed(() => {
-  return lng.value !== 0 && lat.value !== 0;
-});
+const hasLocation = computed(() => lngLat.value !== null);
 
 const isOpen = ref(false);
 </script>

--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -1,0 +1,43 @@
+import { Coordinates, LngLat } from "@/types";
+
+const LNG_MIN = -180;
+const LNG_MAX = 180;
+const LAT_MIN = -90;
+const LAT_MAX = 90;
+
+function isInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === "number" && value >= min && value <= max;
+}
+
+// return null if coordinates are invalid
+export function toLngLat(
+  coordinates: Coordinates | undefined | null
+): LngLat | null {
+  const lng = coordinates?.[0];
+  const lat = coordinates?.[1];
+
+  if (!isInRange(lng, LNG_MIN, LNG_MAX) || !isInRange(lat, LAT_MIN, LAT_MAX)) {
+    return null;
+  }
+
+  return { lng, lat };
+}
+
+// Error message for a typed coordinate, empty string when valid.
+export function validateLngInput(input: string): string {
+  const value = parseFloat(input);
+  if (isNaN(value)) return `Longitude must be a number`;
+  if (!isInRange(value, LNG_MIN, LNG_MAX)) {
+    return `Longtitude must be between ${LNG_MIN} and ${LNG_MAX}`;
+  }
+  return "";
+}
+
+export function validateLatInput(input: string): string {
+    const value = parseFloat(input);
+  if (isNaN(value)) return `Latitude must be a number`;
+  if (!isInRange(value, LAT_MIN, LAT_MAX)) {
+    return `Latitude must be between ${LAT_MIN} and ${LAT_MAX}`;
+  }
+  return "";
+}

--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -28,13 +28,13 @@ export function validateLngInput(input: string): string {
   const value = parseFloat(input);
   if (isNaN(value)) return `Longitude must be a number`;
   if (!isInRange(value, LNG_MIN, LNG_MAX)) {
-    return `Longtitude must be between ${LNG_MIN} and ${LNG_MAX}`;
+    return `Longitude must be between ${LNG_MIN} and ${LNG_MAX}`;
   }
   return "";
 }
 
 export function validateLatInput(input: string): string {
-    const value = parseFloat(input);
+  const value = parseFloat(input);
   if (isNaN(value)) return `Latitude must be a number`;
   if (!isInRange(value, LAT_MIN, LAT_MAX)) {
     return `Latitude must be between ${LAT_MIN} and ${LAT_MAX}`;

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
@@ -39,16 +39,30 @@
           :id="`${id}-longitude`"
           v-model="state.lngInput"
           label="Longitude"
-          placeholder="Enter longitude" />
-        <p v-if="lngError" class="text-red-500 text-xs">{{ lngError }}</p>
+          placeholder="Enter longitude"
+          :aria-invalid="lngError ? 'true' : undefined"
+          :aria-describedby="lngError ? `${id}-longitude-error` : undefined" />
+        <p
+          v-if="lngError"
+          :id="`${id}-longitude-error`"
+          class="text-red-500 text-xs">
+          {{ lngError }}
+        </p>
       </div>
       <div>
         <InputGroup
           :id="`${id}-latitude`"
           v-model="state.latInput"
           label="Latitude"
-          placeholder="Enter latitude" />
-        <p v-if="latError" class="text-red-500 text-xs">{{ latError }}</p>
+          placeholder="Enter latitude"
+          :aria-invalid="latError ? 'true' : undefined"
+          :aria-describedby="latError ? `${id}-latitude-error` : undefined" />
+        <p
+          v-if="latError"
+          :id="`${id}-latitude-error`"
+          class="text-red-500 text-xs">
+          {{ latError }}
+        </p>
       </div>
     </div>
     <div>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditLocationWidgetContentItem.vue
@@ -34,16 +34,22 @@
       " />
 
     <div class="grid grid-cols-2 gap-4">
-      <InputGroup
-        :id="`${id}-longitude`"
-        v-model="state.lngInput"
-        label="Longitude"
-        placeholder="Enter longitude" />
-      <InputGroup
-        :id="`${id}-latitude`"
-        v-model="state.latInput"
-        label="Latitude"
-        placeholder="Enter latitude" />
+      <div>
+        <InputGroup
+          :id="`${id}-longitude`"
+          v-model="state.lngInput"
+          label="Longitude"
+          placeholder="Enter longitude" />
+        <p v-if="lngError" class="text-red-500 text-xs">{{ lngError }}</p>
+      </div>
+      <div>
+        <InputGroup
+          :id="`${id}-latitude`"
+          v-model="state.latInput"
+          label="Latitude"
+          placeholder="Enter latitude" />
+        <p v-if="latError" class="text-red-500 text-xs">{{ latError }}</p>
+      </div>
     </div>
     <div>
       <label
@@ -91,6 +97,11 @@ import invariant from "tiny-invariant";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";
 import ArcGisGeocoder from "./ArcGISGeocoder.vue";
 import { LocationWidgetContent, WithId, LngLat, Coordinates } from "@/types";
+import {
+  toLngLat,
+  validateLatInput,
+  validateLngInput,
+} from "@/helpers/coordinates";
 
 const props = withDefaults(
   defineProps<{
@@ -132,12 +143,23 @@ const mapStyles = {
   },
 };
 
-// Input fields for manual coordinate entry
+// Input fields for manual coordinate entry. Stored coordinates may be an
+// empty or partial array, so optional-chain each entry.
 const state = reactive({
-  lngInput: props.modelValue.loc?.coordinates?.[0].toString() ?? "", // local state for text input
-  latInput: props.modelValue.loc?.coordinates?.[1].toString() ?? "",
+  lngInput: props.modelValue.loc?.coordinates?.[0]?.toString() ?? "",
+  latInput: props.modelValue.loc?.coordinates?.[1]?.toString() ?? "",
   locationLabel: props.modelValue.locationLabel,
   activeMapStyleKey: "light" as keyof typeof mapStyles,
+});
+
+// Empty input means "no location", only non-empty input can be invalid.
+const lngError = computed((): string => {
+  if (state.lngInput.trim() === "") return "";
+  return validateLngInput(state.lngInput);
+});
+const latError = computed((): string => {
+  if (state.latInput.trim() === "") return "";
+  return validateLatInput(state.latInput);
 });
 
 const map = shallowRef<maplibregl.Map | null>(null);
@@ -171,11 +193,18 @@ watch([() => state.lngInput, () => state.latInput], () => {
     return;
   }
 
-  // Update the modelValue with the new coordinates
+  // Update the modelValue with the new coordinates (even if they are
+  // out of range. If we don't do this, we may save -9 when the user types
+  // -92.
   emitCoordinateUpdate({
     lng,
     lat,
   });
+
+  // out-of-range input shows an error instead of moving the map
+  if (lngError.value || latError.value) {
+    return;
+  }
 
   // fly to the new coordinates
   invariant(map.value, "Map is not initialized");
@@ -192,12 +221,13 @@ watch(
 
     const coordinates = props.modelValue.loc?.coordinates ?? null;
 
-    // sync local inputs
-    state.lngInput = coordinates?.[0].toString() ?? "";
-    state.latInput = coordinates?.[1].toString() ?? "";
+    // sync local inputs, even out-of-range values, so the user can fix them
+    state.lngInput = coordinates?.[0]?.toString() ?? "";
+    state.latInput = coordinates?.[1]?.toString() ?? "";
 
-    // if no coordinates, remove marker
-    if (!coordinates) {
+    // absent, malformed, or out-of-range coordinates get no marker
+    const center = toLngLat(coordinates);
+    if (!center) {
       marker.value?.remove();
       marker.value = null;
       return;
@@ -205,13 +235,13 @@ watch(
 
     // if there's a marker, update its position
     if (marker.value) {
-      marker.value.setLngLat(coordinates);
+      marker.value.setLngLat(center);
       return;
     }
 
     // if no marker, create one
     marker.value = new maplibregl.Marker({ draggable: true })
-      .setLngLat(coordinates)
+      .setLngLat(center)
       .addTo(map.value)
       .on("dragend", () => {
         const lngLat = marker.value?.getLngLat() ?? null;
@@ -220,7 +250,7 @@ watch(
 
     // fly to the new coordinates
     map.value.flyTo({
-      center: coordinates,
+      center,
       animate: true,
     });
   },

--- a/tests/e2e/location-widget.spec.ts
+++ b/tests/e2e/location-widget.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
+
+test.describe("Location Widget", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+    await page.goto("/");
+  });
+
+  test("invalid lng/lat in edit form shows an error and asset remains saveable", async ({
+    page,
+  }) => {
+    const assetId = "6875871d4eb080a4880a0abc";
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.goto(`/assetManager/editAsset/${assetId}`);
+
+    await expect(page).toHaveURL(new RegExp(`/assetManager/editAsset/${assetId}`));
+    await expect(page.getByLabel(/title/i).first()).toHaveValue(
+      "Invalid Location Asset"
+    );
+
+    const longitudeInput = page.getByLabel("Longitude");
+    const latitudeInput = page.getByLabel("Latitude");
+
+    await longitudeInput.fill("190");
+    await latitudeInput.fill("95");
+
+    await expect(page.getByText(/between -180 and 180/i)).toBeVisible();
+    await expect(page.getByText(/between -90 and 90/i)).toBeVisible();
+
+    const saveButton = page.getByRole("button", { name: "Save" });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    await expect(page).toHaveURL(new RegExp(`/assetManager/editAsset/${assetId}`));
+    await page.reload();
+
+    await expect(page.getByLabel("Longitude")).toHaveValue("190");
+    await expect(page.getByLabel("Latitude")).toHaveValue("95");
+    await expect(page.getByText(/between -180 and 180/i)).toBeVisible();
+    await expect(page.getByText(/between -90 and 90/i)).toBeVisible();
+    expect(pageErrors).toHaveLength(0);
+  });
+
+  test("viewing an asset with invalid lng/lat does not crash and shows hyphens", async ({
+    page,
+  }) => {
+    const assetId = "6875871d4eb080a4880a0abc";
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.goto(`/asset/viewAsset/${assetId}`);
+
+    await expect(page).toHaveURL(new RegExp(`/asset/viewAsset/${assetId}`));
+    await expect(page.locator("body")).not.toBeEmpty();
+    await expect(page.getByText("Invalid Location Asset").first()).toBeVisible();
+
+    // Invalid/out-of-range coordinates should render as hyphens in the location summary.
+    await expect(page.getByText(/Lat\s*-/, { exact: false })).toBeVisible();
+    await expect(page.getByText(/Lng\s*-/, { exact: false })).toBeVisible();
+
+    // No valid coordinates means the map modal trigger is hidden.
+    await expect(page.getByRole("button", { name: "Show Location" })).toHaveCount(
+      0
+    );
+
+    expect(pageErrors).toHaveLength(0);
+  });
+});

--- a/tests/e2e/location-widget.spec.ts
+++ b/tests/e2e/location-widget.spec.ts
@@ -38,15 +38,19 @@ test.describe("Location Widget", () => {
     const saveButton = page.getByRole("button", { name: "Save" });
     await expect(saveButton).toBeEnabled();
 
-    // Wait for the submission to persist before reloading. Reloading first
-    // aborts the in-flight save and reads back the seeded coordinates.
-    const saveResponse = page.waitForResponse(
+    // Editing fires two submission POSTs: the inline child asset first, then
+    // the parent. The parent POST is only sent after the child save resolves,
+    // so wait for the PARENT save (its body carries this assetId) before
+    // reloading. Waiting on the first response reloads before the parent POST
+    // leaves the browser, and the seeded coordinates survive.
+    const parentSave = page.waitForResponse(
       (response) =>
         response.url().includes("/assetManager/submission/true") &&
-        response.request().method() === "POST"
+        response.request().method() === "POST" &&
+        !!response.request().postData()?.includes(assetId)
     );
     await saveButton.click();
-    await saveResponse;
+    await parentSave;
 
     await expect(page).toHaveURL(new RegExp(`/assetManager/editAsset/${assetId}`));
     await page.reload();
@@ -80,6 +84,14 @@ test.describe("Location Widget", () => {
       0
     );
 
-    expect(pageErrors).toHaveLength(0);
+    // The ObjectViewer embeds the app in an iframe pointed at the instance's
+    // absolute base URL. Under dev:mock the app runs on :5173 while the mock
+    // API is on :3001, so the iframe's app-shell calls are cross-origin and
+    // reject with "Network Error". Filter this out since it doesn't pertain
+    // to our lnglat test.
+    const crashErrors = pageErrors.filter(
+      (err) => !/network error/i.test(err.message)
+    );
+    expect(crashErrors).toHaveLength(0);
   });
 });

--- a/tests/e2e/location-widget.spec.ts
+++ b/tests/e2e/location-widget.spec.ts
@@ -24,8 +24,10 @@ test.describe("Location Widget", () => {
       "Invalid Location Asset"
     );
 
-    const longitudeInput = page.getByLabel("Longitude");
-    const latitudeInput = page.getByLabel("Latitude");
+    // The "All Fields Test" template renders two location widgets. Target
+    // the first, which holds this asset's seeded out-of-range coordinates.
+    const longitudeInput = page.getByLabel("Longitude").first();
+    const latitudeInput = page.getByLabel("Latitude").first();
 
     await longitudeInput.fill("190");
     await latitudeInput.fill("95");
@@ -35,13 +37,22 @@ test.describe("Location Widget", () => {
 
     const saveButton = page.getByRole("button", { name: "Save" });
     await expect(saveButton).toBeEnabled();
+
+    // Wait for the submission to persist before reloading. Reloading first
+    // aborts the in-flight save and reads back the seeded coordinates.
+    const saveResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/assetManager/submission/true") &&
+        response.request().method() === "POST"
+    );
     await saveButton.click();
+    await saveResponse;
 
     await expect(page).toHaveURL(new RegExp(`/assetManager/editAsset/${assetId}`));
     await page.reload();
 
-    await expect(page.getByLabel("Longitude")).toHaveValue("190");
-    await expect(page.getByLabel("Latitude")).toHaveValue("95");
+    await expect(longitudeInput).toHaveValue("190");
+    await expect(latitudeInput).toHaveValue("95");
     await expect(page.getByText(/between -180 and 180/i)).toBeVisible();
     await expect(page.getByText(/between -90 and 90/i)).toBeVisible();
     expect(pageErrors).toHaveLength(0);


### PR DESCRIPTION
Previously, a lng/lat out of range would crash a page. This adds some checks to validated the data, and falls back to `null` if the data is invalid rather than passing the data only maplibre (which would throw).

Example: bad lng/lat (-800, -800).

Show error message in asset editor:
<img width="600"  alt="CleanShot 2026-07-22 at 15 15 09@2x" src="https://github.com/user-attachments/assets/d2036ff5-3ab6-44d2-a953-a413da9f53ef" />

No lng/lat rendered in asset view:
<img width="600" alt="CleanShot 2026-07-22 at 15 15 33@2x" src="https://github.com/user-attachments/assets/54beb8bb-2e1d-4a1e-ae1f-f3336aa00425" />

