### PR TITLE
Configurable alt/description text below thumbnails (showThumbnailDescription setting)

### DIFF
--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -4,7 +4,7 @@
       <TooltipTrigger asChild>
         <slot />
       </TooltipTrigger>
-      <TooltipContent v-if="tip || $slots.content">
+      <TooltipContent v-if="tip || $slots.content" :class="props.class">
         <slot name="content">
           {{ tip }}
         </slot>
@@ -19,6 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { CSSClass } from "@/types";
 import { computed } from "vue";
 
 const props = withDefaults(
@@ -26,11 +27,13 @@ const props = withDefaults(
     openDelay?: number;
     delayDuration?: number;
     tip?: string;
+    class?: CSSClass;
   }>(),
   {
     openDelay: undefined, // previous api
     delayDuration: 300, // current api
     tip: "",
+    class: "",
   }
 );
 

--- a/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
+++ b/src/components/Widget/RelatedAssetWidget/ThumbnailRelatedAssetWidgetItem.vue
@@ -16,6 +16,7 @@
       <ThumbnailGeneric v-else :isActive="isActiveObject" />
 
       <SanitizedHTML
+        v-if="instanceStore.instance.showThumbnailDescription"
         class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
         :html="title" />
     </RouterLink>
@@ -27,6 +28,7 @@ import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
 import ThumbnailGeneric from "@/components/ThumbnailGeneric/ThumbnailGeneric.vue";
 import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import Tooltip from "@/components/Tooltip/Tooltip.vue";
+import { useInstanceStore } from "@/stores/instanceStore";
 import { RelatedAssetCacheItem } from "@/types";
 
 defineProps<{
@@ -35,5 +37,7 @@ defineProps<{
   isActiveObject: boolean;
   assetCacheItem: RelatedAssetCacheItem | null;
 }>();
+
+const instanceStore = useInstanceStore();
 </script>
 <style scoped></style>

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -46,6 +46,7 @@
       <Tooltip
         v-for="(content, key) in contents"
         :key="key"
+        class="max-w-sm"
         :tip="content.fileDescription">
         <button
           class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline w-24"

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -60,6 +60,13 @@
             :alt="content.fileDescription"
             :fileType="content.fileType"
             class="thumbnail-related-asset-widget__image max-w-full" />
+          <SanitizedHTML
+            v-if="
+              instanceStore.instance.showThumbnailDescription &&
+              content.fileDescription
+            "
+            class="whitespace-nowrap text-xs mt-1 truncate overflow-hidden w-full text-center"
+            :html="content.fileDescription" />
         </button>
       </Tooltip>
     </div>
@@ -70,12 +77,14 @@
 import { UploadWidgetDef, UploadWidgetContent } from "@/types";
 import config from "@/config";
 import { useAssetStore } from "@/stores/assetStore";
+import { useInstanceStore } from "@/stores/instanceStore";
 import { useToastStore } from "@/stores/toastStore";
 import {
   fetchOriginalFileStorageStatus,
   restoreOriginalFile,
 } from "@/api/fetchers";
 import ThumbnailImage from "@/components/ThumbnailImage/ThumbnailImage.vue";
+import SanitizedHTML from "@/components/SanitizedHTML/SanitizedHTML.vue";
 import Tooltip from "@/components/Tooltip/Tooltip.vue";
 import { computed, onMounted, onBeforeUnmount, ref } from "vue";
 import Tuple from "@/components/Tuple/Tuple.vue";
@@ -90,6 +99,7 @@ const props = defineProps<{
 }>();
 
 const assetStore = useAssetStore();
+const instanceStore = useInstanceStore();
 const toastStore = useToastStore();
 
 const isFileActive = (fileId: string) =>

--- a/src/helpers/getDefaultInstanceSettings.ts
+++ b/src/helpers/getDefaultInstanceSettings.ts
@@ -21,6 +21,7 @@ export function getDefaultInstanceSettings(
     showCollectionInSearchResults: true,
     showTemplateInSearchResults: false,
     showChildCollections: true,
+    showThumbnailDescription: false,
     showPreviousNextSearchResults: true,
     hideVideoAudio: false,
     allowIndexing: true,

--- a/src/helpers/selectInstanceFromResponse.ts
+++ b/src/helpers/selectInstanceFromResponse.ts
@@ -19,6 +19,7 @@ export function selectInstanceFromResponse(
     templates,
     useVoyagerViewer,
     showChildCollections,
+    showThumbnailDescription,
     theming,
   } = apiResponse;
 
@@ -56,8 +57,8 @@ export function selectInstanceFromResponse(
     showCollectionInSearchResults: instanceShowCollectionInSearchResults,
     showTemplateInSearchResults: instanceShowTemplateInSearchResults,
     useVoyagerViewer, // whether or not to use the Voyager viewer
-    // default on so a nav payload without the field keeps the panel showing
     showChildCollections: showChildCollections ?? true,
+    showThumbnailDescription: showThumbnailDescription ?? false,
     theming,
   };
 }

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -193,7 +193,7 @@
             label="Auto-generate Alt Text and Captions" />
           <ToggleGroup
             v-model="form.showThumbnailDescription"
-            label="Show Description below Upload Thumbnails" />
+            label="Show Description below Thumbnails" />
           <ToggleGroup
             v-model="form.useVoyagerViewer"
             label="Use Smithsonian Voyager for 3D" />

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -192,6 +192,9 @@
             v-model="form.automaticAltText"
             label="Auto-generate Alt Text and Captions" />
           <ToggleGroup
+            v-model="form.showThumbnailDescription"
+            label="Show Description below Upload Thumbnails" />
+          <ToggleGroup
             v-model="form.useVoyagerViewer"
             label="Use Smithsonian Voyager for 3D" />
           <ToggleGroup
@@ -391,12 +394,19 @@ const form = ref<InstanceSettings>(
   getDefaultInstanceSettings(props.instanceId)
 );
 
+// getInstance returns a partial settings object, so fill gaps with defaults.
+// toggles need a real boolean, and edit-tracking compares against this shape.
+const savedSettings = computed<InstanceSettings>(() => ({
+  ...getDefaultInstanceSettings(props.instanceId),
+  ...(settingsData.value ?? {}),
+}));
+
 // Sync form with fetched data
 watch(
   settingsData,
   (newData) => {
     if (newData) {
-      form.value = { ...newData };
+      form.value = { ...savedSettings.value };
     }
   },
   { immediate: true }
@@ -405,13 +415,13 @@ watch(
 // Track unsaved changes by comparing form to saved data
 const hasUnsavedChanges = computed(() => {
   if (!settingsData.value) return false;
-  return JSON.stringify(form.value) !== JSON.stringify(settingsData.value);
+  return JSON.stringify(form.value) !== JSON.stringify(savedSettings.value);
 });
 
 // Reset form to saved state
 function handleCancel() {
   if (!settingsData.value) return;
-  form.value = { ...settingsData.value };
+  form.value = { ...savedSettings.value };
   selectedHeaderImage.value = null;
 }
 

--- a/src/stores/instanceStore.ts
+++ b/src/stores/instanceStore.ts
@@ -45,6 +45,7 @@ const createState = () => ({
     showCollectionInSearchResults: true,
     showTemplateInSearchResults: true,
     showChildCollections: true,
+    showThumbnailDescription: false,
     useVoyagerViewer: false, // whether or not to use the Voyager viewer
     theming: {
       enabled: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -610,6 +610,7 @@ export interface ApiInstanceNavResponse {
   useVoyagerViewer: boolean; // whether or not to use the Voyager viewer
   // optional so an older API build still works
   showChildCollections?: boolean;
+  showThumbnailDescription?: boolean;
   useCustomCSS: boolean; // whether or not to use custom CSS
   customHeaderCSS: string | null; // custom CSS for header if useCustomCSS is true
   theming: {
@@ -652,6 +653,8 @@ export interface ElevatorInstance {
   showCollectionInSearchResults: boolean; // whether or not to show collection in search results
   showTemplateInSearchResults: boolean; // whether or not to show template in search results
   showChildCollections: boolean; // whether to list child collections when browsing
+  // whether related-asset and upload widgets show titles below thumbnails
+  showThumbnailDescription: boolean;
   useVoyagerViewer: boolean; // whether or not to use the Voyager viewer
   theming: {
     enabled: boolean;
@@ -681,6 +684,7 @@ export interface InstanceSettings {
   showCollectionInSearchResults: boolean;
   showTemplateInSearchResults: boolean;
   showChildCollections: boolean;
+  showThumbnailDescription: boolean;
   showPreviousNextSearchResults: boolean;
   hideVideoAudio: boolean;
   allowIndexing: boolean;


### PR DESCRIPTION
- Fixes #592.
- Adds an instance-wide **`showThumbnailDescription`** toggle (default **off**) that governs the title/description text below thumbnails in **both** the RelatedAssetWidget and the UploadWidget, replacing today's hardcoded split.
- Both widgets read the flag from the instance store; admins flip it with a toggle on the Instance Settings page.
- Stacked on the elevator API companion PR that serves the field.

Toggle in the Instance Settings:
<img width="800" alt="CleanShot 2026-07-23 at 00 37 46@2x" src="https://github.com/user-attachments/assets/63278a37-abda-41be-9034-7ccf29c5f8f1" />

With show descriptions off:
<img width="400" alt="CleanShot 2026-07-23 at 00 38 41@2x" src="https://github.com/user-attachments/assets/cd493ba6-bb58-46c8-af59-a96d051f3442" />

With show description on:
<img width="400"  alt="CleanShot 2026-07-23 at 00 36 53@2x" src="https://github.com/user-attachments/assets/9c09a62e-1dd2-4eec-ad80-5b4ba9e8378d" />
