### PR TITLE
fix: text not legible in seconday nav on some themes

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -19,8 +19,7 @@
     </div>
     <div
       v-if="$slots.default"
-      class="app-header__secondary-nav bg-surface-container text-on-surface-container">
-      <slot />
+      class="app-header__secondary-nav bg-surface-container text-on-surface">
     </div>
   </header>
 </template>

--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -17,7 +17,9 @@
         <AppMenuButton />
       </div>
     </div>
-    <div v-if="$slots.default" class="app-header__secondary-nav">
+    <div
+      v-if="$slots.default"
+      class="app-header__secondary-nav bg-surface-container text-on-surface-container">
       <slot />
     </div>
   </header>
@@ -35,8 +37,4 @@ const instanceStore = useInstanceStore();
 
 const currentUser = computed(() => instanceStore.currentUser);
 </script>
-<style scoped>
-.app-header__secondary-nav {
-  background: transparent;
-}
-</style>
+<style scoped></style>

--- a/src/css/themes/barbie.css
+++ b/src/css/themes/barbie.css
@@ -88,10 +88,6 @@
     border-bottom: 3px solid oklch(75% 0.15 340);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(90% 0.06 350);
-  }
-
   & body {
     font-family: "Nunito", sans-serif;
   }

--- a/src/css/themes/bucky.css
+++ b/src/css/themes/bucky.css
@@ -108,10 +108,6 @@
     }
   }
 
-  .app-header__secondary-nav {
-    background: var(--badger-dark);
-  }
-
   .app-menu-button {
     color: white;
     background: var(--badger-red);

--- a/src/css/themes/construction.css
+++ b/src/css/themes/construction.css
@@ -90,10 +90,6 @@
     border-bottom: 4px solid oklch(72% 0.2 55);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(15% 0.01 80);
-  }
-
   & body {
     font-family: "Barlow", sans-serif;
   }

--- a/src/css/themes/folwell.css
+++ b/src/css/themes/folwell.css
@@ -161,9 +161,6 @@
     border-bottom: 2px solid var(--outline-variant);
   }
 
-  .app-header__secondary-nav {
-    background: var(--surface);
-  }
   .app-menu-button {
     background: hsla(0 0 0 / 0.1);
     color: black;

--- a/src/css/themes/hotdog.css
+++ b/src/css/themes/hotdog.css
@@ -78,9 +78,6 @@
     border-bottom: 2px solid var(--outline-variant);
   }
 
-  .app-header__secondary-nav {
-    background: var(--surface);
-  }
 
   & body {
     font-family: "Comic Sans MS", cursive;

--- a/src/css/themes/hotrod.css
+++ b/src/css/themes/hotrod.css
@@ -87,10 +87,6 @@
     border-bottom: 3px solid oklch(52% 0.22 25);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(10% 0.01 30);
-  }
-
   & body {
     font-family: "Chakra Petch", sans-serif;
   }

--- a/src/css/themes/matrix.css
+++ b/src/css/themes/matrix.css
@@ -88,10 +88,6 @@
     border-bottom: 1px solid oklch(40% 0.15 145);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(6% 0.01 145);
-  }
-
   & body {
     font-family: "Source Code Pro", monospace;
   }

--- a/src/css/themes/natural.css
+++ b/src/css/themes/natural.css
@@ -88,10 +88,6 @@
     border-bottom: 2px solid oklch(40% 0.05 130);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(92% 0.025 85);
-  }
-
   & body {
     font-family: "Outfit", sans-serif;
   }

--- a/src/css/themes/neobrutalist.css
+++ b/src/css/themes/neobrutalist.css
@@ -102,11 +102,6 @@
     border-bottom: 3px solid oklch(8% 0 0);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(96% 0.015 85);
-    border-bottom: 2px solid oklch(8% 0 0);
-  }
-
   /* --- Buttons: thick borders + hard shadow --- */
   .button {
     border: 3px solid oklch(8% 0 0) !important;

--- a/src/css/themes/nord-dark.css
+++ b/src/css/themes/nord-dark.css
@@ -91,10 +91,6 @@
     border-bottom: 1px solid oklch(35% 0.02 240);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(24% 0.02 245);
-  }
-
   & body {
     font-family: "DM Sans", sans-serif;
   }

--- a/src/css/themes/nord-light.css
+++ b/src/css/themes/nord-light.css
@@ -91,9 +91,6 @@
     border-bottom: 1px solid oklch(85% 0.01 240);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(94% 0.006 240);
-  }
 
   & body {
     font-family: "DM Sans", sans-serif;

--- a/src/css/themes/simple.css
+++ b/src/css/themes/simple.css
@@ -93,9 +93,4 @@
       }
     }
   }
-
-  .app-header__secondary-nav {
-    background: oklch(95% 0 0);
-    border-bottom: 3px solid oklch(0% 0 0);
-  }
 }

--- a/src/css/themes/tron.css
+++ b/src/css/themes/tron.css
@@ -92,10 +92,6 @@
     border-bottom: 1px solid oklch(60% 0.12 195 / 0.6);
   }
 
-  .app-header__secondary-nav {
-    background: oklch(8% 0.02 240);
-  }
-
   & body {
     font-family: "Exo 2", sans-serif;
   }

--- a/src/css/themes/vaporwave.css
+++ b/src/css/themes/vaporwave.css
@@ -88,10 +88,6 @@
     border-bottom: 2px solid oklch(60% 0.2 340 / 0.4);
   }
 
-  .app-header__secondary-nav {
-    background: var(--surface-container);
-  }
-
   & body {
     font-family: "Quicksand", sans-serif;
   }


### PR DESCRIPTION
- Fixes #585 
- change secondary nav to use  `surface-container` background and `on-surface-container` text color to guarantee 
legibility.
- remove individual theme overrides

Secondary nav in various themes:

<img width="500" alt="CleanShot 2026-07-23 at 13 57 44@2x" src="https://github.com/user-attachments/assets/61877fde-30f1-4ced-88d5-385c56420825" />

<img width="500"  alt="CleanShot 2026-07-23 at 13 57 57@2x" src="https://github.com/user-attachments/assets/8e0f0871-0e5f-4e29-9944-5c0ab8b97386" />

<img width="500"  alt="CleanShot 2026-07-23 at 13 58 07@2x" src="https://github.com/user-attachments/assets/87f4cab8-c7f1-478a-b81e-4fbdb132aa9a" />

<img width="500" alt="CleanShot 2026-07-23 at 13 58 20@2x" src="https://github.com/user-attachments/assets/8749970e-939e-49e1-a39d-8bb9e63752c2" />
