### PR TITLE
handle search results with bad lnglat

### DIFF
--- a/src/helpers/mapResultsHelpers.test.ts
+++ b/src/helpers/mapResultsHelpers.test.ts
@@ -55,5 +55,30 @@ describe("mapResultsHelpers", () => {
         { lng: 7, lat: 8 },
       ]);
     });
+    it("drops out-of-range coordinates", () => {
+      const match: Partial<SearchResultMatch> = {
+        locations: [
+          {
+            label: "Bad and good locations",
+            entries: [
+              {
+                loc: {
+                  type: "Point",
+                  coordinates: [181, 95],
+                },
+              },
+              {
+                loc: {
+                  type: "Point",
+                  coordinates: [45, 45],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = convertSearchResultToLngLats(match as SearchResultMatch);
+      expect(result).toEqual([{ lng: 45, lat: 45 }]);
+    });
   });
 });

--- a/src/helpers/mapResultsHelpers.ts
+++ b/src/helpers/mapResultsHelpers.ts
@@ -1,4 +1,5 @@
 import { SearchResultMatch, LngLat } from "@/types";
+import { toLngLat } from "@/helpers/coordinates";
 
 export function convertSearchResultToLngLats(
   match: SearchResultMatch
@@ -9,14 +10,9 @@ export function convertSearchResultToLngLats(
     .flatMap((location) => {
       if (!location.entries) return [];
 
-      return location.entries.map((locationEntry) => {
-        if (!locationEntry.loc) return null;
-
-        return {
-          lng: locationEntry.loc.coordinates[0],
-          lat: locationEntry.loc.coordinates[1],
-        };
-      });
+      return location.entries.map((locationEntry) =>
+        toLngLat(locationEntry.loc?.coordinates)
+      );
     })
     .filter((lngLat): lngLat is LngLat => lngLat !== null);
 }


### PR DESCRIPTION
Fixes similar issue to #594 -- bad lnglats can crash search results map tab too. This maps results through the same `toLngLat` helper, which transforms bad coords to null.

Delicious example from dev:
<img width="500" alt="CleanShot 2026-07-23 at 14 44 38@2x" src="https://github.com/user-attachments/assets/644f722d-4994-4216-a9be-2de6931409db" />

Before:
<img width="500" alt="CleanShot 2026-07-23 at 14 36 33@2x" src="https://github.com/user-attachments/assets/0480ba99-96a3-4420-a622-b600054ba565" />

After:
<img width="500" alt="CleanShot 2026-07-23 at 14 41 35@2x" src="https://github.com/user-attachments/assets/0512e757-0460-48b1-a640-b4aead6856d4" />
