### PR TITLE
Feat/529 remove link to legacy reordering page

### DIFF
--- a/mock-server/routes/templates.ts
+++ b/mock-server/routes/templates.ts
@@ -405,4 +405,56 @@ app.delete("/delete/:templateId", (c) => {
   return c.json({ success: true });
 });
 
+// GET /templates/copy/:templateId — mirrors Templates::copy() legacy route
+// Persist a real duplicate so the client's invalidated list query shows it.
+app.get("/copy/:templateId", (c) => {
+  const user = c.get("user");
+
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+  if (!user.isInstanceAdmin && !user.isSuperAdmin)
+    return c.json({ error: "Forbidden" }, 403);
+
+  const db = c.get("db");
+  const templateId = Number(c.req.param("templateId"));
+  const source = db.templates.get(templateId) as AdminTemplateSeed | undefined;
+
+  if (!source) return c.json({ error: "Template not found" }, 404);
+
+  const now = new Date().toISOString();
+  const copy = (db.templates as ReturnType<typeof createTemplatesTable>).create(
+    {
+      ...source,
+      templateName: `${source.templateName} (copy)`,
+      createdAt: now,
+      modifiedAt: now,
+    }
+  );
+
+  const summary: TemplateSummary = {
+    id: copy.templateId,
+    name: copy.templateName,
+    createdAt: copy.createdAt,
+    modifiedAt: copy.modifiedAt,
+  };
+  return c.json(summary, 201);
+});
+
+// GET /templates/forceRecache/:templateId — mirrors Templates::forceRecache()
+// Reindex only rebuilds search data, so there is nothing to persist here.
+app.get("/forceRecache/:templateId", (c) => {
+  const user = c.get("user");
+
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+  if (!user.isInstanceAdmin && !user.isSuperAdmin)
+    return c.json({ error: "Forbidden" }, 403);
+
+  const db = c.get("db");
+  const templateId = Number(c.req.param("templateId"));
+  const template = db.templates.get(templateId);
+
+  if (!template) return c.json({ error: "Template not found" }, 404);
+
+  return c.json({ success: true });
+});
+
 export default app;

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1071,6 +1071,16 @@ export async function deleteTemplate(templateId: number) {
   return res.data;
 }
 
+// Both routes are legacy templates-controller actions, hit today as GET
+// links, so we call them the same way here rather than POST.
+export async function copyTemplate(templateId: number): Promise<void> {
+  await axios.get(`${BASE_URL}/templates/copy/${templateId}`);
+}
+
+export async function reindexTemplate(templateId: number): Promise<void> {
+  await axios.get(`${BASE_URL}/templates/forceRecache/${templateId}`);
+}
+
 export async function fetchAdminTemplate(
   templateId: number
 ): Promise<AdminTemplate> {

--- a/src/pages/AllTemplatesPage/AllTemplatesPage.vue
+++ b/src/pages/AllTemplatesPage/AllTemplatesPage.vue
@@ -14,10 +14,40 @@
       </Notification>
       <p v-else-if="!templates?.length" class="text-lg">No templates found.</p>
       <TemplatesTable v-else :columns="columns" :data="templates" />
+
+      <ConfirmModal
+        :isOpen="Boolean(templatePendingReindex)"
+        title="Reindex Template"
+        type="warning"
+        confirmLabel="Reindex"
+        @close="templatePendingReindex = null"
+        @confirm="confirmReindex">
+        <p>
+          Reindex
+          <b>{{ templatePendingReindex?.name }}</b>
+          and any related templates?
+        </p>
+      </ConfirmModal>
+
+      <ConfirmModal
+        :isOpen="Boolean(templatePendingDelete)"
+        title="Delete Template"
+        type="danger"
+        confirmLabel="Delete"
+        @close="templatePendingDelete = null"
+        @confirm="confirmDelete">
+        <p>
+          Are you sure you want to delete
+          <b>{{ templatePendingDelete?.name }}</b>
+          ? This action cannot be undone.
+        </p>
+      </ConfirmModal>
     </div>
   </DefaultLayout>
 </template>
 <script setup lang="ts">
+import { ref } from "vue";
+import { useRouter } from "vue-router";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { useToastStore } from "@/stores/toastStore";
 import { createColumns } from "./TemplatesTableColumns";
@@ -25,52 +55,105 @@ import TemplatesTable from "./TemplatesTable.vue";
 import Notification from "@/components/Notification/Notification.vue";
 import Skeleton from "@/components/Skeleton/Skeleton.vue";
 import Button from "@/components/Button/Button.vue";
+import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import {
   useAllTemplatesQuery,
+  useCopyTemplateMutation,
   useDeleteTemplateMutation,
+  useReindexTemplateMutation,
 } from "@/queries/useTemplateQuery";
-const { data: templates, isPending, isError } = useAllTemplatesQuery();
-const { mutateAsync: deleteTemplate } = useDeleteTemplateMutation();
+import type { TemplateSummary } from "@/types";
 
+const { data: templates, isPending, isError } = useAllTemplatesQuery();
+
+const router = useRouter();
 const toastStore = useToastStore();
 
-const handleDelete = async (templateId: number) => {
-  const template = templates.value?.find((t) => t.id === templateId);
-
-  if (!template) {
-    toastStore.addToast({
-      title: "Error",
-      message: "Template not found.",
-      variant: "error",
-    });
-    return;
-  }
-
-  if (
-    !confirm(`Are you sure you want to delete template "${template.name}"?`)
-  ) {
-    return;
-  }
-
-  try {
-    await deleteTemplate(templateId);
-    toastStore.addToast({
-      title: "Template Deleted",
-      message: `The template "${template.name}" has been deleted successfully.`,
-      variant: "success",
-      duration: 3000,
-    });
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Unknown error occurred";
-    toastStore.addToast({
-      title: "Error",
-      message: `Failed to delete template: ${message}`,
-      variant: "error",
-    });
-  }
+const openEdit = (template: TemplateSummary): void => {
+  router.push({ name: "templatesEdit", params: { id: template.id } });
 };
 
-const columns = createColumns(handleDelete);
+const duplicateMutation = useCopyTemplateMutation();
+
+const duplicateTemplate = (template: TemplateSummary): void => {
+  duplicateMutation.mutate(template.id, {
+    onSuccess: () =>
+      toastStore.addToast({
+        title: "Template Duplicated",
+        message: `A copy of "${template.name}" was created.`,
+        variant: "success",
+        duration: 3000,
+      }),
+    onError: (error) =>
+      toastStore.addToast({
+        title: "Duplicate Failed",
+        message: `Failed to duplicate template: ${error.message}`,
+        variant: "error",
+      }),
+  });
+};
+
+const reindexMutation = useReindexTemplateMutation();
+const templatePendingReindex = ref<TemplateSummary | null>(null);
+
+const askToReindexTemplate = (template: TemplateSummary): void => {
+  templatePendingReindex.value = template;
+};
+
+const confirmReindex = (): void => {
+  const template = templatePendingReindex.value;
+  if (!template) return;
+  reindexMutation.mutate(template.id, {
+    onSuccess: () =>
+      toastStore.addToast({
+        title: "Reindex Started",
+        message: `Reindexing "${template.name}" and any related templates.`,
+        variant: "success",
+        duration: 3000,
+      }),
+    onError: (error) =>
+      toastStore.addToast({
+        title: "Reindex Failed",
+        message: `Failed to reindex template: ${error.message}`,
+        variant: "error",
+      }),
+  });
+  templatePendingReindex.value = null;
+};
+
+const deleteMutation = useDeleteTemplateMutation();
+const templatePendingDelete = ref<TemplateSummary | null>(null);
+
+const askToDeleteTemplate = (template: TemplateSummary): void => {
+  templatePendingDelete.value = template;
+};
+
+const confirmDelete = (): void => {
+  const template = templatePendingDelete.value;
+  if (!template) return;
+  deleteMutation.mutate(template.id, {
+    onSuccess: () =>
+      toastStore.addToast({
+        title: "Template Deleted",
+        message: `The template "${template.name}" has been deleted successfully.`,
+        variant: "success",
+        duration: 3000,
+      }),
+    onError: (error) =>
+      toastStore.addToast({
+        title: "Delete Failed",
+        message: `Failed to delete template: ${error.message}`,
+        variant: "error",
+      }),
+  });
+  templatePendingDelete.value = null;
+};
+
+const columns = createColumns({
+  onEdit: openEdit,
+  onDuplicate: duplicateTemplate,
+  onReindex: askToReindexTemplate,
+  onDelete: askToDeleteTemplate,
+});
 </script>
 <style scoped></style>

--- a/src/pages/AllTemplatesPage/TemplatesTable.vue
+++ b/src/pages/AllTemplatesPage/TemplatesTable.vue
@@ -16,11 +16,13 @@
             <TableHead
               v-for="header in headerGroup.headers"
               :key="header.id"
-              :style="{ width: `${header.getSize()}px` }"
               class="bg-surface-container-lowest"
-              :class="{
-                'cursor-pointer select-none': header.column.getCanSort(),
-              }"
+              :class="[
+                header.column.columnDef.meta?.widthClass,
+                {
+                  'cursor-pointer select-none': header.column.getCanSort(),
+                },
+              ]"
               @click="header.column.getToggleSortingHandler()?.($event)">
               <div class="flex items-center gap-2">
                 <FlexRender
@@ -98,11 +100,11 @@ const props = defineProps<{
   data: TData[];
 }>();
 
-const isLgScreen = useMediaQuery("(min-width: 1024px)");
+const isMdScreen = useMediaQuery("(min-width: 768px)");
 
 const columnVisibility = computed<VisibilityState>(() => ({
-  createdAt: isLgScreen.value,
-  modifiedAt: isLgScreen.value,
+  createdAt: isMdScreen.value,
+  modifiedAt: isMdScreen.value,
 }));
 
 const sorting = ref<SortingState>([{ id: "name", desc: false }]);

--- a/src/pages/AllTemplatesPage/TemplatesTableColumns.tsx
+++ b/src/pages/AllTemplatesPage/TemplatesTableColumns.tsx
@@ -1,15 +1,13 @@
 import { createColumnHelper } from "@tanstack/vue-table";
 import type { CSSClass, TemplateSummary } from "@/types";
 import {
-  ArrowUpDownIcon,
   CopyPlusIcon,
   PencilIcon,
   RefreshCcwDotIcon,
   Trash2,
 } from "lucide-vue-next";
-import IconButton from "@/components/IconButton/IconButton.vue";
+import KebabMenu from "@/components/KebabMenu/KebabMenu.vue";
 import { cn } from "@/lib/utils";
-import config from "@/config";
 
 const columnHelper = createColumnHelper<TemplateSummary>();
 
@@ -17,14 +15,22 @@ const ColHeader = (props: { text: string; class?: CSSClass }) => (
   <div class={cn(["font-medium", props.class])}>{props.text}</div>
 );
 
-export const createColumns = (onDelete: (templateId: number) => void) => [
+export interface TemplateColumnsDeps {
+  onEdit: (template: TemplateSummary) => void;
+  onDuplicate: (template: TemplateSummary) => void;
+  onReindex: (template: TemplateSummary) => void;
+  onDelete: (template: TemplateSummary) => void;
+}
+
+export const createColumns = (deps: TemplateColumnsDeps) => [
   columnHelper.accessor("id", {
     header: () => <ColHeader text="ID" />,
     cell: (ctx) => (
       <div class="text-sm text-muted-foreground">{ctx.getValue()}</div>
     ),
-    maxSize: 64,
+    meta: { widthClass: "w-16" },
   }),
+  // No widthClass: table-fixed gives this column all the leftover width.
   columnHelper.accessor("name", {
     header: () => <ColHeader text="Name" />,
     cell: (ctx) => (
@@ -41,7 +47,7 @@ export const createColumns = (onDelete: (templateId: number) => void) => [
         </div>
       );
     },
-    maxSize: 96,
+    meta: { widthClass: "w-28" },
   }),
   columnHelper.accessor("modifiedAt", {
     header: () => <ColHeader text="Modified" />,
@@ -53,56 +59,42 @@ export const createColumns = (onDelete: (templateId: number) => void) => [
         </div>
       );
     },
-    maxSize: 96,
+    meta: { widthClass: "w-28" },
   }),
   {
     id: "actions",
-    header: () => <ColHeader text="Actions" class=" w-full text-center" />,
+    header: () => <ColHeader text="Actions" class="sr-only" />,
     enableSorting: false,
     cell: ({ row }: { row: { original: TemplateSummary } }) => (
-      <div class="flex gap-2 items-center justify-center">
-        <IconButton
-          to={{ name: "templatesEdit", params: { id: row.original.id } }}
-          showTooltip={false}
-          title="Edit">
-          <PencilIcon class="size-4" />
-        </IconButton>
-        <IconButton
-          href={`${config.instance.base.url}/templates/sort/${row.original.id}`}
-          showTooltip={false}
-          title="Reorder Widgets">
-          <ArrowUpDownIcon class="size-4" />
-        </IconButton>
-        <IconButton
-          href={`${config.instance.base.url}/templates/copy/${row.original.id}`}
-          showTooltip={false}
-          title="Duplicate">
-          <CopyPlusIcon class="size-4" />
-        </IconButton>
-        <IconButton
-          onClick={() => {
-            if (
-              !window.confirm(
-                "Are you sure you wish to reindex this template and any related templates?"
-              )
-            ) {
-              return;
-            }
-            window.location.href = `${config.instance.base.url}/templates/forceRecache/${row.original.id}`;
-          }}
-          showTooltip={false}
-          title="Reindex">
-          <RefreshCcwDotIcon class="size-4" />
-        </IconButton>
-        <IconButton
-          onClick={() => onDelete(row.original.id)}
-          class="enabled:text-error enabled:hover:bg-error-container enabled:hover:text-on-error-container"
-          showTooltip={false}
-          title="Delete">
-          <Trash2 class="size-4" />
-        </IconButton>
+      <div class="flex items-center justify-end">
+        <KebabMenu
+          label={`Actions for ${row.original.name}`}
+          items={[
+            {
+              label: "Edit",
+              icon: PencilIcon,
+              onSelect: () => deps.onEdit(row.original),
+            },
+            {
+              label: "Duplicate",
+              icon: CopyPlusIcon,
+              onSelect: () => deps.onDuplicate(row.original),
+            },
+            {
+              label: "Reindex",
+              icon: RefreshCcwDotIcon,
+              onSelect: () => deps.onReindex(row.original),
+            },
+            {
+              label: "Delete",
+              icon: Trash2,
+              variant: "danger",
+              onSelect: () => deps.onDelete(row.original),
+            },
+          ]}
+        />
       </div>
     ),
-    maxSize: 128,
+    meta: { widthClass: "w-16" },
   },
 ];

--- a/src/queries/useTemplateQuery.ts
+++ b/src/queries/useTemplateQuery.ts
@@ -1,8 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
 import * as fetchers from "@/api/fetchers";
 import { toValue, type MaybeRefOrGetter } from "vue";
-import { INSTANCE_QUERY_KEY, TEMPLATES_QUERY_KEY, FIELD_TYPES_QUERY_KEY } from "./queryKeys";
-import type { TemplateSummary, AdminTemplate, TemplatePayload, FieldType } from "@/types";
+import {
+  INSTANCE_QUERY_KEY,
+  TEMPLATES_QUERY_KEY,
+  FIELD_TYPES_QUERY_KEY,
+} from "./queryKeys";
+import type {
+  TemplateSummary,
+  AdminTemplate,
+  TemplatePayload,
+  FieldType,
+} from "@/types";
 import { useInstanceStore } from "@/stores/instanceStore";
 
 export function useTemplateQuery(
@@ -50,6 +59,28 @@ export function useDeleteTemplateMutation() {
       const instanceStore = useInstanceStore();
       instanceStore.refresh();
     },
+  });
+}
+
+export function useCopyTemplateMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (templateId: number) => fetchers.copyTemplate(templateId),
+    onSuccess: () => {
+      // A copy appears in both the list and the instance nav.
+      queryClient.invalidateQueries({ queryKey: [TEMPLATES_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [INSTANCE_QUERY_KEY] });
+      const instanceStore = useInstanceStore();
+      instanceStore.refresh();
+    },
+  });
+}
+
+// Reindex rebuilds search data server-side, so no cached query goes stale.
+export function useReindexTemplateMutation() {
+  return useMutation({
+    mutationFn: (templateId: number) => fetchers.reindexTemplate(templateId),
   });
 }
 


### PR DESCRIPTION
- Remove legacy reorder fields action (resolves #529)
- Collapse other template to kebab-menu
- switch from `window.confirm` to our Confirm Modal
- change to TSQ mutations for copy template and reindex

<img width="500"  alt="CleanShot 2026-07-23 at 16 03 38@2x" src="https://github.com/user-attachments/assets/56112615-ddfd-4b02-a233-34c5f7e44148" />
