### PR TITLE
make it easier to set mock server port in dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ VITE_BASE_ORIGIN="${BASE_ORIGIN}"
 # BASE_PATH="/defaultinstance"
 
 # MOCK SERVER
-VITE_API_PROXY_TARGET="http://localhost:3001"
+MOCK_SERVER_PORT=3001
+VITE_API_PROXY_TARGET="http://localhost:${MOCK_SERVER_PORT}"
 BASE_PATH="/defaultinstance"
 
 VITE_BASE_PATH="${BASE_PATH}"

--- a/mock-server/package.json
+++ b/mock-server/package.json
@@ -4,7 +4,7 @@
   "description": "Mock API server for Elevator UI development and testing",
   "type": "module",
   "scripts": {
-    "serve:watch": "tsx watch server.ts",
+    "serve:watch": "tsx watch --env-file-if-exists=../.env server.ts",
     "build": "tsc",
     "type-check": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mock:install": "cd mock-server && npm install",
     "mock:serve": "cd mock-server && npm run serve:watch",
     "mock:serve:test": "yarn build:test && cd mock-server && npm run serve:watch",
-    "dev:mock": "VITE_API_PROXY_TARGET=http://localhost:3001 VITE_IS_USING_MOCK_SERVER=true concurrently \"npm run mock:serve\" \"npm run dev\"",
+    "dev:mock": "VITE_IS_USING_MOCK_SERVER=true concurrently \"npm run mock:serve\" \"npm run dev\"",
     "deploy:dev": "./bin/deploy-dev.sh"
   },
   "dependencies": {


### PR DESCRIPTION
This permits more than one mock server to run similtaneously (which is friendlier to worktrees). 
- adds an env variable to `.env.example`
- uses node's newish feature to read in the MOCK_SERVER_PORT variable from .env

Impacts dev/test environment only