### PR TITLE
add `addOnPaste` prop to break pasted tags on `,`

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditTagWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditTagWidget.vue
@@ -18,6 +18,7 @@
       <TagsInput
         :modelValue="(item.tags as string[])"
         :addOnBlur="true"
+        :addOnPaste="true"
         class="tags-input !py-0"
         @update:modelValue="(tags) => handleUpdateTags(item.id, tags as string[])">
         <TagsInputItem


### PR DESCRIPTION
- Resolves #559 
- breaks tags apart on comma when pasted

https://github.com/user-attachments/assets/5b48c2e4-ce8a-417f-ab99-591ba880fa56

