### PR TITLE
Fix required-field validation for null upload descriptions

### DIFF
--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -47,7 +47,7 @@
         v-for="(content, key) in contents"
         :key="key"
         class="max-w-sm"
-        :tip="descriptionTip(content)">
+        :tip="isDescriptionVisible ? descriptionText(content) : ''">
         <button
           class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline w-24"
           :class="{
@@ -61,7 +61,7 @@
             See https://www.w3.org/WAI/tutorials/images/functional/ example 2 -->
           <ThumbnailImage
             :src="`${config.instance.base.url}/fileManager/tinyImageByFileId/${content.fileId}/true`"
-            :alt="isDescriptionVisible ? '' : content.fileDescription"
+            :alt="isDescriptionVisible ? '' : descriptionText(content)"
             :fileType="content.fileType"
             class="thumbnail-related-asset-widget__image max-w-full" />
           <SanitizedHTML
@@ -112,8 +112,7 @@ const isDescriptionVisible = computed(
   () => instanceStore.instance.showThumbnailDescription
 );
 
-function descriptionTip(content: UploadWidgetContent): string {
-  if (!isDescriptionVisible.value) return "";
+function descriptionText(content: UploadWidgetContent): string {
   return content.fileDescription ?? "";
 }
 

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -47,7 +47,7 @@
         v-for="(content, key) in contents"
         :key="key"
         class="max-w-sm"
-        :tip="isDescriptionVisible ? content.fileDescription ?? '' : ''">
+        :tip="descriptionTip(content)">
         <button
           class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline w-24"
           :class="{
@@ -111,6 +111,11 @@ const isDownloadingAll = ref(false);
 const isDescriptionVisible = computed(
   () => instanceStore.instance.showThumbnailDescription
 );
+
+function descriptionTip(content: UploadWidgetContent): string {
+  if (!isDescriptionVisible.value) return "";
+  return content.fileDescription ?? "";
+}
 
 const activeIndex = computed(() =>
   props.contents.findIndex((content) => isFileActive(content.fileId))

--- a/src/components/Widget/UploadWidget/UploadWidget.vue
+++ b/src/components/Widget/UploadWidget/UploadWidget.vue
@@ -47,7 +47,7 @@
         v-for="(content, key) in contents"
         :key="key"
         class="max-w-sm"
-        :tip="isDescriptionVisible ? content.fileDescription : ''">
+        :tip="isDescriptionVisible ? content.fileDescription ?? '' : ''">
         <button
           class="thumbnail-related-asset-widget flex flex-col rounded-md border border-transparent p-1 no-underline hover:no-underline w-24"
           :class="{

--- a/src/helpers/hasWidgetContent.test.ts
+++ b/src/helpers/hasWidgetContent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { hasUploadContent } from "./hasWidgetContent";
+import { hasUploadContent, hasDateContent } from "./hasWidgetContent";
 
 describe("hasUploadContent", () => {
   // Reproduces #554. A CSV-imported file can carry fileDescription: null
@@ -29,5 +29,22 @@ describe("hasUploadContent", () => {
     ];
 
     expect(hasUploadContent(contents)).toBe(false);
+  });
+});
+
+describe("hasDateContent", () => {
+  // A date with real start/end dates is content even when its label is null,
+  // like a required date field that was never given a label.
+  it("counts a date with a null label but a valid start date as content", () => {
+    const contents = [
+      {
+        label: null,
+        start: { text: "2024-01-01", numeric: "1704067200" },
+        end: { text: null, numeric: null },
+        isPrimary: false,
+      },
+    ];
+
+    expect(hasDateContent(contents)).toBe(true);
   });
 });

--- a/src/helpers/hasWidgetContent.test.ts
+++ b/src/helpers/hasWidgetContent.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { hasUploadContent } from "./hasWidgetContent";
+
+describe("hasUploadContent", () => {
+  // Reproduces #554. A CSV-imported file can carry fileDescription: null
+  // instead of "", so the required-field check must key off the file itself,
+  // not its description.
+  it("counts an upload with a null fileDescription as content", () => {
+    const contents = [
+      {
+        fileId: "5892726de758ae8a198b47be",
+        fileType: "jpg",
+        fileDescription: null,
+        isPrimary: false,
+      },
+    ];
+
+    expect(hasUploadContent(contents)).toBe(true);
+  });
+
+  it("does not count an upload with an empty fileId as content", () => {
+    const contents = [
+      {
+        fileId: "",
+        fileType: "",
+        fileDescription: null,
+        isPrimary: false,
+      },
+    ];
+
+    expect(hasUploadContent(contents)).toBe(false);
+  });
+});

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -5,7 +5,7 @@
         <img
           v-if="item.fileId && previewImageUrl"
           :src="previewImageUrl"
-          :alt="`thumbnail for item: ${item.fileDescription}`"
+          :alt="`thumbnail for item: ${item.fileDescription ?? ''}`"
           class="w-full h-full app-object-fit" />
         <div
           v-else

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -21,7 +21,7 @@
         <TextAreaGroup
           :label="isDescriptionVisible ? 'Description / Alt Text' : 'Alt Text'"
           :helpText="descriptionFieldHelp"
-          :modelValue="item.fileDescription"
+          :modelValue="item.fileDescription ?? ''"
           @update:modelValue="handleDescriptionUpdate" />
       </div>
       <div class="col-span-3">

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -77,7 +77,8 @@ export function isDateWidgetContent(
   return (
     isWidgetContent(value) &&
     "label" in value &&
-    typeof (value as DateWidgetContent).label === "string" &&
+    ((value as DateWidgetContent).label === null ||
+      typeof (value as DateWidgetContent).label === "string") &&
     "start" in value &&
     isDateMoment((value as DateWidgetContent).start) &&
     "end" in value &&
@@ -166,7 +167,8 @@ export function isUploadWidgetContent(
     "fileId" in value &&
     typeof (value as UploadWidgetContent).fileId === "string" &&
     "fileDescription" in value &&
-    typeof (value as UploadWidgetContent).fileDescription === "string" &&
+    ((value as UploadWidgetContent).fileDescription === null ||
+      typeof (value as UploadWidgetContent).fileDescription === "string") &&
     "fileType" in value &&
     typeof (value as UploadWidgetContent).fileType === "string"
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -243,7 +243,7 @@ export interface DateMoment {
   numeric: string | null; // unix timestamp, actually a string
 }
 export interface DateWidgetContent extends WidgetContent {
-  label: string;
+  label: string | null;
   start: DateMoment;
   end: DateMoment;
 }
@@ -293,7 +293,7 @@ export interface TextAreaWidgetContent extends WidgetContent {
 
 export interface UploadWidgetContent extends WidgetContent {
   fileId: string; // hash
-  fileDescription: string;
+  fileDescription: string | null;
   fileType: string;
   searchData: string | null;
   loc: LocationObject | null;


### PR DESCRIPTION
- Fixes #554.
- A required upload field whose file has a null `fileDescription` (as CSV import produces) was wrongly flagged empty. It now validates as satisfied when a real file is present.
- The types said `fileDescription` and date's `label` were always `string`, but the data is nullable, and the type guards enforced the wrong type. This widens both to `string | null` and makes validation null-safe.
- Bonus: this fix handles a latent bug where a required date with valid dates but a `null` label was wrongly flagged empty.
- Adds tests for issue.
