### PR TITLE
fix: 404 sometimes happens during asset file upload

### DIFF
--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -147,10 +147,7 @@ const { previewImageUrl } = usePreviewImage(() => props.item.fileId);
 
 const assetEditor = useAssetEditor();
 
-// The API can only answer for a file once a save has linked it to its asset.
-// A file appears in savedAsset exactly when that link exists, so wait for it
-// rather than asking a question the server will reject.
-const isFileSaved = computed(() =>
+const isFileSavedInWidget = computed(() =>
   hasSavedFileInWidget(
     assetEditor.savedAsset,
     props.widgetDef.fieldTitle,
@@ -159,11 +156,9 @@ const isFileSaved = computed(() =>
 );
 
 const { data: fileMetaData } = useFileMetadataQuery(() => props.item.fileId, {
-  // don't query for file metadata until
-  // the asset has been saved and the file is
-  // is linked. Otherwise, the API will
-  // reject the request with a 404.
-  enabled: isFileSaved,
+  // getMetadataForObject 404s until a save links the file to its asset, and
+  // savedAsset is where that link shows up.
+  enabled: isFileSavedInWidget,
 });
 
 function handleDescriptionUpdate(value: string) {

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -111,6 +111,8 @@ import Button from "@/components/Button/Button.vue";
 import EditUploadWidgetItemSidecars from "./EditUploadWidgetItemSidecars.vue";
 import { usePreviewImage } from "@/helpers/usePreviewImage";
 import { useFileMetadataQuery } from "@/queries/useFileMetadataQuery";
+import { useAssetEditor } from "../../useAssetEditor/useAssetEditor";
+import { hasSavedFileInWidget } from "./hasSavedFileInWidget";
 import { useInstanceStore } from "@/stores/instanceStore";
 import { computed } from "vue";
 import TextAreaGroup from "@/components/TextAreaGroup/TextAreaGroup.vue";
@@ -143,7 +145,22 @@ const emit = defineEmits<{
 // Use the new preview image composable
 const { previewImageUrl } = usePreviewImage(() => props.item.fileId);
 
-const { data: fileMetaData } = useFileMetadataQuery(() => props.item.fileId);
+const assetEditor = useAssetEditor();
+
+// The API can only answer for a file once a save has linked it to its asset.
+// A file appears in savedAsset exactly when that link exists, so wait for it
+// rather than asking a question the server will reject.
+const isFileSaved = computed(() =>
+  hasSavedFileInWidget(
+    assetEditor.savedAsset,
+    props.widgetDef.fieldTitle,
+    props.item.fileId
+  )
+);
+
+const { data: fileMetaData } = useFileMetadataQuery(() => props.item.fileId, {
+  enabled: isFileSaved,
+});
 
 function handleDescriptionUpdate(value: string) {
   emit("update:item", {

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -159,6 +159,10 @@ const isFileSaved = computed(() =>
 );
 
 const { data: fileMetaData } = useFileMetadataQuery(() => props.item.fileId, {
+  // don't query for file metadata until
+  // the asset has been saved and the file is
+  // is linked. Otherwise, the API will
+  // reject the request with a 404.
   enabled: isFileSaved,
 });
 

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.test.ts
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { hasSavedFileInWidget } from "./hasSavedFileInWidget";
+import type { Asset } from "@/types";
+
+function makeAsset(widgetFields: Record<string, unknown>): Asset {
+  return {
+    assetId: "asset_001",
+    templateId: 1,
+    readyForDisplay: true,
+    collectionId: 1,
+    availableAfter: null,
+    modified: {
+      date: "2026-07-24 12:00:00.000000",
+      timezone: "UTC",
+      timezone_type: 3,
+    },
+    modifiedBy: 1,
+    createdBy: 1,
+    deletedBy: null,
+    relatedAssetCache: null,
+    ...widgetFields,
+  } as Asset;
+}
+
+describe("hasSavedFileInWidget", () => {
+  it("finds a file the widget already holds", () => {
+    const asset = makeAsset({
+      images: [{ fileId: "file_abc" }, { fileId: "file_def" }],
+    });
+
+    expect(hasSavedFileInWidget(asset, "images", "file_def")).toBe(true);
+  });
+
+  it("does not find a file the widget does not hold", () => {
+    const asset = makeAsset({ images: [{ fileId: "file_abc" }] });
+
+    expect(hasSavedFileInWidget(asset, "images", "file_def")).toBe(false);
+  });
+
+  it("does not look outside the named widget", () => {
+    const asset = makeAsset({
+      images: [{ fileId: "file_abc" }],
+      attachments: [{ fileId: "file_def" }],
+    });
+
+    expect(hasSavedFileInWidget(asset, "images", "file_def")).toBe(false);
+  });
+
+  // a brand new asset has never been saved, so nothing is linked yet
+  it("returns false when there is no saved asset", () => {
+    expect(hasSavedFileInWidget(null, "images", "file_abc")).toBe(false);
+  });
+
+  it("returns false when the widget has no contents on the saved asset", () => {
+    const asset = makeAsset({});
+
+    expect(hasSavedFileInWidget(asset, "images", "file_abc")).toBe(false);
+  });
+
+  // an upload item exists in the editor before its file finishes uploading
+  it("returns false for an empty file id", () => {
+    const asset = makeAsset({ images: [{ fileId: "" }] });
+
+    expect(hasSavedFileInWidget(asset, "images", "")).toBe(false);
+  });
+});

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.test.ts
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.test.ts
@@ -2,45 +2,33 @@ import { describe, it, expect } from "vitest";
 import { hasSavedFileInWidget } from "./hasSavedFileInWidget";
 import type { Asset } from "@/types";
 
+function makeUploadContent(fileId: string) {
+  return { fileId, fileDescription: null, fileType: "image/jpeg" };
+}
+
 function makeAsset(widgetFields: Record<string, unknown>): Asset {
-  return {
-    assetId: "asset_001",
-    templateId: 1,
-    readyForDisplay: true,
-    collectionId: 1,
-    availableAfter: null,
-    modified: {
-      date: "2026-07-24 12:00:00.000000",
-      timezone: "UTC",
-      timezone_type: 3,
-    },
-    modifiedBy: 1,
-    createdBy: 1,
-    deletedBy: null,
-    relatedAssetCache: null,
-    ...widgetFields,
-  } as Asset;
+  return widgetFields as unknown as Asset;
 }
 
 describe("hasSavedFileInWidget", () => {
   it("finds a file the widget already holds", () => {
     const asset = makeAsset({
-      images: [{ fileId: "file_abc" }, { fileId: "file_def" }],
+      images: [makeUploadContent("file_abc"), makeUploadContent("file_def")],
     });
 
     expect(hasSavedFileInWidget(asset, "images", "file_def")).toBe(true);
   });
 
   it("does not find a file the widget does not hold", () => {
-    const asset = makeAsset({ images: [{ fileId: "file_abc" }] });
+    const asset = makeAsset({ images: [makeUploadContent("file_abc")] });
 
     expect(hasSavedFileInWidget(asset, "images", "file_def")).toBe(false);
   });
 
   it("does not look outside the named widget", () => {
     const asset = makeAsset({
-      images: [{ fileId: "file_abc" }],
-      attachments: [{ fileId: "file_def" }],
+      images: [makeUploadContent("file_abc")],
+      attachments: [makeUploadContent("file_def")],
     });
 
     expect(hasSavedFileInWidget(asset, "images", "file_def")).toBe(false);
@@ -57,9 +45,15 @@ describe("hasSavedFileInWidget", () => {
     expect(hasSavedFileInWidget(asset, "images", "file_abc")).toBe(false);
   });
 
-  // an upload item exists in the editor before its file finishes uploading
+  // a matching fileId is not enough, the entry has to be a real upload content
+  it("ignores contents that are not upload widget contents", () => {
+    const asset = makeAsset({ images: [{ fileId: "file_abc" }] });
+
+    expect(hasSavedFileInWidget(asset, "images", "file_abc")).toBe(false);
+  });
+
   it("returns false for an empty file id", () => {
-    const asset = makeAsset({ images: [{ fileId: "" }] });
+    const asset = makeAsset({ images: [makeUploadContent("")] });
 
     expect(hasSavedFileInWidget(asset, "images", "")).toBe(false);
   });

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.ts
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.ts
@@ -1,11 +1,11 @@
-import type { Asset, UploadWidgetContent } from "@/types";
+import type { Asset } from "@/types";
+import { isUploadWidgetContent } from "@/types/guards";
 
 /**
- * Whether a saved asset already holds this file in the given upload widget.
+ * Whether the server has linked this file to the asset under the given widget.
  *
- * @param savedAsset - The asset as last returned by the server, or null before
- * the first save.
- * @param fieldTitle - The upload widget's field on the asset.
+ * @param savedAsset - As last returned by the server, null before first save.
+ * @param fieldTitle - The widget's field name on the asset.
  */
 export function hasSavedFileInWidget(
   savedAsset: Asset | null,
@@ -22,6 +22,6 @@ export function hasSavedFileInWidget(
   }
 
   return widgetContents.some(
-    (content) => (content as UploadWidgetContent)?.fileId === fileId
+    (content) => isUploadWidgetContent(content) && content.fileId === fileId
   );
 }

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.ts
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.ts
@@ -1,0 +1,36 @@
+import type { Asset, UploadWidgetContent } from "@/types";
+
+/**
+ * Whether a saved asset already holds this file in the given upload widget.
+ *
+ * @param savedAsset - The asset as last returned by the server, or null before
+ * the first save.
+ * @param fieldTitle - The upload widget's field on the asset.
+ *
+ * @example
+ * ```ts
+ * // The metadata API rejects a file the asset has not claimed yet, so wait
+ * // for the save to land before asking about it.
+ * const isFileSaved = computed(() =>
+ *   hasSavedFileInWidget(assetEditor.savedAsset, props.widgetDef.fieldTitle, props.item.fileId)
+ * );
+ * ```
+ */
+export function hasSavedFileInWidget(
+  savedAsset: Asset | null,
+  fieldTitle: string,
+  fileId: string
+): boolean {
+  if (!savedAsset || !fileId) {
+    return false;
+  }
+
+  const widgetContents = savedAsset[fieldTitle];
+  if (!Array.isArray(widgetContents)) {
+    return false;
+  }
+
+  return widgetContents.some(
+    (content) => (content as UploadWidgetContent)?.fileId === fileId
+  );
+}

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.ts
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/hasSavedFileInWidget.ts
@@ -6,15 +6,6 @@ import type { Asset, UploadWidgetContent } from "@/types";
  * @param savedAsset - The asset as last returned by the server, or null before
  * the first save.
  * @param fieldTitle - The upload widget's field on the asset.
- *
- * @example
- * ```ts
- * // The metadata API rejects a file the asset has not claimed yet, so wait
- * // for the save to land before asking about it.
- * const isFileSaved = computed(() =>
- *   hasSavedFileInWidget(assetEditor.savedAsset, props.widgetDef.fieldTitle, props.item.fileId)
- * );
- * ```
  */
 export function hasSavedFileInWidget(
   savedAsset: Asset | null,

--- a/src/queries/useFileMetadataQuery.ts
+++ b/src/queries/useFileMetadataQuery.ts
@@ -8,7 +8,7 @@ export function useFileMetadataQuery(
   { enabled }: { enabled: MaybeRefOrGetter<boolean> }
 ) {
   return useQuery({
-    queryKey: [FILE_METADATA_QUERY_KEY, toValue(fileId)],
+    queryKey: [FILE_METADATA_QUERY_KEY, fileId],
     queryFn: () => fetchers.fetchFileMetaData(toValue(fileId)),
     enabled: () => !!toValue(fileId) && toValue(enabled),
   });

--- a/src/queries/useFileMetadataQuery.ts
+++ b/src/queries/useFileMetadataQuery.ts
@@ -5,11 +5,11 @@ import { FILE_METADATA_QUERY_KEY } from "./queryKeys";
 
 export function useFileMetadataQuery(
   fileId: MaybeRefOrGetter<string>,
-  { enabled }: { enabled?: MaybeRefOrGetter<boolean> } = {}
+  { enabled }: { enabled: MaybeRefOrGetter<boolean> }
 ) {
   return useQuery({
     queryKey: [FILE_METADATA_QUERY_KEY, toValue(fileId)],
     queryFn: () => fetchers.fetchFileMetaData(toValue(fileId)),
-    enabled: () => toValue(enabled) ?? true,
+    enabled: () => !!toValue(fileId) && toValue(enabled),
   });
 }

--- a/src/queries/useFileMetadataQuery.ts
+++ b/src/queries/useFileMetadataQuery.ts
@@ -3,9 +3,13 @@ import * as fetchers from "@/api/fetchers";
 import { toValue, type MaybeRefOrGetter } from "vue";
 import { FILE_METADATA_QUERY_KEY } from "./queryKeys";
 
-export function useFileMetadataQuery(fileId: MaybeRefOrGetter<string>) {
+export function useFileMetadataQuery(
+  fileId: MaybeRefOrGetter<string>,
+  { enabled }: { enabled?: MaybeRefOrGetter<boolean> } = {}
+) {
   return useQuery({
     queryKey: [FILE_METADATA_QUERY_KEY, toValue(fileId)],
     queryFn: () => fetchers.fetchFileMetaData(toValue(fileId)),
+    enabled: () => toValue(enabled) ?? true,
   });
 }

--- a/tests/e2e/upload-file-metadata.spec.ts
+++ b/tests/e2e/upload-file-metadata.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+
+const SUBMISSION_URL_PART = "/assetManager/submission/";
+const FILE_METADATA_URL_PART = "/fileManager/getMetadataForObject/";
+
+test.describe("Upload widget file metadata", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.route("**/arcgis.com/**", (route) => route.abort());
+    await page.route("**/basemaps-api.arcgis.com/**", (route) => route.abort());
+
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+    await page.goto("/assetManager/addAsset");
+  });
+
+  test("does not request file metadata before the asset is saved", async ({
+    page,
+  }) => {
+    // The API can only answer for a file once a save has linked it to its
+    // parent asset. Before that link exists it reports the file as unknown,
+    // so asking early is a request we know the server will reject.
+    let hasSubmissionCompleted = false;
+    const earlyMetadataRequests: string[] = [];
+
+    page.on("response", (response) => {
+      if (response.url().includes(SUBMISSION_URL_PART)) {
+        hasSubmissionCompleted = true;
+      }
+    });
+
+    page.on("request", (request) => {
+      const isMetadataRequest = request
+        .url()
+        .includes(FILE_METADATA_URL_PART);
+
+      if (isMetadataRequest && !hasSubmissionCompleted) {
+        earlyMetadataRequests.push(request.url());
+      }
+    });
+
+    await uploadOneFileToNewAsset(page);
+
+    expect(earlyMetadataRequests).toEqual([]);
+  });
+});
+
+async function uploadOneFileToNewAsset(page: import("@playwright/test").Page) {
+  await page.getByLabel("Template").selectOption({ index: 1 });
+  await page.getByLabel("Collection").selectOption({ index: 1 });
+
+  const continueButton = page.getByRole("button", { name: "Continue" });
+  await expect(continueButton).toBeEnabled({ timeout: 5000 });
+  await continueButton.click();
+
+  await expect(page.getByRole("heading", { name: "Create Asset" })).toBeVisible();
+  await page.getByLabel("Title").first().fill("File metadata test asset");
+
+  const uploadWidget = page
+    .locator("section.edit-widget-layout")
+    .filter({ has: page.getByRole("heading", { name: "Upload" }) })
+    .first();
+  await uploadWidget.scrollIntoViewIfNeeded();
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await uploadWidget.getByRole("button", { name: "browse files" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(
+    path.join(testDir, "..", "fixtures", "test-image.jpg")
+  );
+
+  await expect(uploadWidget.locator(".edit-upload-widget-item")).toHaveCount(1);
+
+  // the save queue holds a 2s cooldown between saves, so the submission this
+  // upload triggers has not necessarily gone out yet
+  await new Promise((resolve) => setTimeout(resolve, 4000));
+  await page.waitForLoadState("networkidle");
+}

--- a/tests/e2e/upload-file-metadata.spec.ts
+++ b/tests/e2e/upload-file-metadata.spec.ts
@@ -7,6 +7,7 @@ const testDir = path.dirname(fileURLToPath(import.meta.url));
 
 const SUBMISSION_URL_PART = "/assetManager/submission/";
 const FILE_METADATA_URL_PART = "/fileManager/getMetadataForObject/";
+const COMPLETE_SOURCE_FILE_URL_PART = "/assetManager/completeSourceFile/";
 
 test.describe("Upload widget file metadata", () => {
   test.beforeEach(async ({ page, request }) => {
@@ -20,32 +21,33 @@ test.describe("Upload widget file metadata", () => {
     await page.goto("/assetManager/addAsset");
   });
 
-  test("does not request file metadata before the asset is saved", async ({
+  test("requests file metadata only after the save that makes it answerable", async ({
     page,
   }) => {
     const metadataRequests = watchMetadataRequestsAroundSave(page);
+    const submission = page.waitForResponse((response) =>
+      response.url().includes(SUBMISSION_URL_PART)
+    );
 
-    await uploadOneFileToNewAsset(page);
+    const uploadedFileId = await uploadOneFileToNewAsset(page);
+    await submission;
 
-    expect(metadataRequests.beforeSave).toEqual([]);
-  });
+    expect(
+      metadataRequests.beforeSave,
+      "no metadata request goes out ahead of the save"
+    ).toEqual([]);
 
-  test("requests file metadata once the asset is saved", async ({ page }) => {
-    const metadataRequests = watchMetadataRequestsAroundSave(page);
-
-    await uploadOneFileToNewAsset(page);
-
-    expect(metadataRequests.afterSave.length).toBeGreaterThan(0);
+    await expect
+      .poll(() => metadataRequests.afterSave, {
+        message: "the gate opens once the save lands",
+      })
+      .toContain(uploadedFileId);
   });
 });
 
 /**
- * Splits file metadata requests by whether the save that authorizes them had
- * already landed.
- *
- * The API can only answer for a file once a save has linked it to its parent
- * asset, so a request in `beforeSave` is one the server was always going to
- * reject. An empty `afterSave` means the widget stopped asking altogether.
+ * Records the file ids asked about, split by whether the save that authorizes
+ * them had already landed.
  */
 function watchMetadataRequestsAroundSave(page: Page): {
   beforeSave: string[];
@@ -66,18 +68,20 @@ function watchMetadataRequestsAroundSave(page: Page): {
       return;
     }
 
+    const requestedFileId = fileIdFromUrl(request.url());
     if (hasSubmissionCompleted) {
-      afterSave.push(request.url());
+      afterSave.push(requestedFileId);
       return;
     }
 
-    beforeSave.push(request.url());
+    beforeSave.push(requestedFileId);
   });
 
   return { beforeSave, afterSave };
 }
 
-async function uploadOneFileToNewAsset(page: Page): Promise<void> {
+/** Returns the id of the file that was uploaded. */
+async function uploadOneFileToNewAsset(page: Page): Promise<string> {
   await page.getByLabel("Template").selectOption({ index: 1 });
   await page.getByLabel("Collection").selectOption({ index: 1 });
 
@@ -96,6 +100,10 @@ async function uploadOneFileToNewAsset(page: Page): Promise<void> {
     .first();
   await uploadWidget.scrollIntoViewIfNeeded();
 
+  const sourceFileCompletion = page.waitForRequest((request) =>
+    request.url().includes(COMPLETE_SOURCE_FILE_URL_PART)
+  );
+
   const fileChooserPromise = page.waitForEvent("filechooser");
   await uploadWidget.getByRole("button", { name: "browse files" }).click();
   const fileChooser = await fileChooserPromise;
@@ -105,8 +113,9 @@ async function uploadOneFileToNewAsset(page: Page): Promise<void> {
 
   await expect(uploadWidget.locator(".edit-upload-widget-item")).toHaveCount(1);
 
-  // the save queue holds a 2s cooldown between saves, so the submission this
-  // upload triggers has not necessarily gone out yet
-  await new Promise((resolve) => setTimeout(resolve, 4000));
-  await page.waitForLoadState("networkidle");
+  return fileIdFromUrl((await sourceFileCompletion).url());
+}
+
+function fileIdFromUrl(url: string): string {
+  return new URL(url).pathname.split("/").filter(Boolean).pop() ?? "";
 }

--- a/tests/e2e/upload-file-metadata.spec.ts
+++ b/tests/e2e/upload-file-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
 import { fileURLToPath } from "url";
 import path from "path";
@@ -23,35 +23,61 @@ test.describe("Upload widget file metadata", () => {
   test("does not request file metadata before the asset is saved", async ({
     page,
   }) => {
-    // The API can only answer for a file once a save has linked it to its
-    // parent asset. Before that link exists it reports the file as unknown,
-    // so asking early is a request we know the server will reject.
-    let hasSubmissionCompleted = false;
-    const earlyMetadataRequests: string[] = [];
-
-    page.on("response", (response) => {
-      if (response.url().includes(SUBMISSION_URL_PART)) {
-        hasSubmissionCompleted = true;
-      }
-    });
-
-    page.on("request", (request) => {
-      const isMetadataRequest = request
-        .url()
-        .includes(FILE_METADATA_URL_PART);
-
-      if (isMetadataRequest && !hasSubmissionCompleted) {
-        earlyMetadataRequests.push(request.url());
-      }
-    });
+    const metadataRequests = watchMetadataRequestsAroundSave(page);
 
     await uploadOneFileToNewAsset(page);
 
-    expect(earlyMetadataRequests).toEqual([]);
+    expect(metadataRequests.beforeSave).toEqual([]);
+  });
+
+  test("requests file metadata once the asset is saved", async ({ page }) => {
+    const metadataRequests = watchMetadataRequestsAroundSave(page);
+
+    await uploadOneFileToNewAsset(page);
+
+    expect(metadataRequests.afterSave.length).toBeGreaterThan(0);
   });
 });
 
-async function uploadOneFileToNewAsset(page: import("@playwright/test").Page) {
+/**
+ * Splits file metadata requests by whether the save that authorizes them had
+ * already landed.
+ *
+ * The API can only answer for a file once a save has linked it to its parent
+ * asset, so a request in `beforeSave` is one the server was always going to
+ * reject. An empty `afterSave` means the widget stopped asking altogether.
+ */
+function watchMetadataRequestsAroundSave(page: Page): {
+  beforeSave: string[];
+  afterSave: string[];
+} {
+  let hasSubmissionCompleted = false;
+  const beforeSave: string[] = [];
+  const afterSave: string[] = [];
+
+  page.on("response", (response) => {
+    if (response.url().includes(SUBMISSION_URL_PART)) {
+      hasSubmissionCompleted = true;
+    }
+  });
+
+  page.on("request", (request) => {
+    if (!request.url().includes(FILE_METADATA_URL_PART)) {
+      return;
+    }
+
+    if (hasSubmissionCompleted) {
+      afterSave.push(request.url());
+      return;
+    }
+
+    beforeSave.push(request.url());
+  });
+
+  return { beforeSave, afterSave };
+}
+
+async function uploadOneFileToNewAsset(page: Page): Promise<void> {
   await page.getByLabel("Template").selectOption({ index: 1 });
   await page.getByLabel("Collection").selectOption({ index: 1 });
 
@@ -59,7 +85,9 @@ async function uploadOneFileToNewAsset(page: import("@playwright/test").Page) {
   await expect(continueButton).toBeEnabled({ timeout: 5000 });
   await continueButton.click();
 
-  await expect(page.getByRole("heading", { name: "Create Asset" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Create Asset" })
+  ).toBeVisible();
   await page.getByLabel("Title").first().fill("File metadata test asset");
 
   const uploadWidget = page


### PR DESCRIPTION
This resolves a 404 flash can sometimes happen during file upload if the client attempts to fetch file metadata before the asset is ready.

- Fixes #503
- An upload widget item no longer asks the server for file metadata before the save that links the file to its asset, so the 404 that flashed an error modal during asset creation is gone.
- The metadata query is enabled only once the file appears in `savedAsset`, which is refetched from the server after every save.