### PR TITLE
fix: require admin auth on the instance settings route

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -225,6 +225,10 @@ const router = createRouter({
       props: (route) => ({
         instanceId: parseIntFromParam(route.params.instanceId),
       }),
+      meta: {
+        requiresAuth: true,
+        canAccess: (user: User) => user.isAdmin,
+      },
     },
     {
       name: "search",

--- a/tests/e2e/instance-settings.spec.ts
+++ b/tests/e2e/instance-settings.spec.ts
@@ -435,17 +435,45 @@ test.describe("Instance Settings Page", () => {
       await loginUser({ request, page, workerId, username: "user" });
     });
 
-    test("shows an error state when a non-admin accesses the page", async ({
+    test("shows the forbidden page when a non-admin accesses the page", async ({
       page,
     }) => {
       await page.goto("/instances/edit/1");
 
-      // The API returns 403, so the page should show its error state
+      await expect(page.getByRole("heading", { name: "403" })).toBeVisible();
       await expect(
-        page.getByText("Failed to load instance settings")
+        page.getByRole("heading", { name: "Forbidden" })
       ).toBeVisible();
 
-      // The form should not be rendered
+      // one treatment, not the page's own load failure on top of it
+      await expect(
+        page.getByText("Failed to load instance settings")
+      ).not.toBeVisible();
+      await expect(page.getByLabel("Instance Name")).not.toBeVisible();
+    });
+  });
+
+  test.describe("Without Authentication", () => {
+    test.beforeEach(async ({ page, request }) => {
+      const workerId = test.info().workerIndex.toString();
+      await setupWorkerHTTPHeader({ page, workerId });
+      await refreshDatabase({ request, workerId });
+
+      // Deliberately NOT logging in — user is unauthenticated
+    });
+
+    test("prompts for sign in instead of reporting a load failure", async ({
+      page,
+    }) => {
+      await page.goto("/instances/edit/1");
+
+      await expect(
+        page.locator("#main").getByRole("heading", { name: "Sign In Required" })
+      ).toBeVisible();
+
+      await expect(
+        page.getByText("Failed to load instance settings")
+      ).not.toBeVisible();
       await expect(page.getByLabel("Instance Name")).not.toBeVisible();
     });
   });

--- a/tests/e2e/instance-settings.spec.ts
+++ b/tests/e2e/instance-settings.spec.ts
@@ -440,14 +440,17 @@ test.describe("Instance Settings Page", () => {
     }) => {
       await page.goto("/instances/edit/1");
 
-      await expect(page.getByRole("heading", { name: "403" })).toBeVisible();
+      const main = page.locator("#main");
       await expect(
-        page.getByRole("heading", { name: "Forbidden" })
+        main.getByRole("heading", { name: "403", exact: true })
+      ).toBeVisible();
+      await expect(
+        main.getByRole("heading", { name: "Forbidden" })
       ).toBeVisible();
 
-      // one treatment, not the page's own load failure on top of it
+      // route meta owns this now, so the page never reports its own failure
       await expect(
-        page.getByText("Failed to load instance settings")
+        main.getByText("Failed to load instance settings")
       ).not.toBeVisible();
       await expect(page.getByLabel("Instance Name")).not.toBeVisible();
     });


### PR DESCRIPTION
- Fixes #537
- Visiting the instance settings page while signed out now prompts for sign in, and visiting as a non-admin shows the 403 Forbidden page, instead of the generic "Failed to load instance settings" error.
- Adds the same `requiresAuth` / `canAccess` route meta the other admin routes already use, so the existing layout guard handles both cases before the page loads.