### PR TITLE
Show the admin sidebar on every admin page

### DIFF
--- a/src/components/AdminSidebar/AdminSidebar.vue
+++ b/src/components/AdminSidebar/AdminSidebar.vue
@@ -1,62 +1,79 @@
 <template>
   <nav
-    class="bg-surface text-on-surface border-r border-outline-variant h-full w-60 py-4 px-3"
+    class="bg-surface text-on-surface border-r border-outline-variant w-60"
     aria-label="Admin">
-    <h2
-      class="text-xs uppercase text-on-surface-variant font-bold pl-2 pb-1 tracking-wider">
-      Admin
-    </h2>
-    <ul class="list-none p-0 m-0 flex flex-col gap-0.5">
-      <li>
-        <SidebarNavItem :to="{ name: 'customPagesIndex' }" :icon="FileTextIcon">
-          Pages
-        </SidebarNavItem>
-      </li>
-      <li>
-        <SidebarNavItem :to="{ name: 'adminPermissions' }" :icon="LockIcon">
-          Permissions
-        </SidebarNavItem>
-      </li>
-      <li>
-        <SidebarNavItem
-          :to="{ name: 'templatesIndex' }"
-          :icon="LayoutTemplateIcon">
-          Templates
-        </SidebarNavItem>
-      </li>
-      <li>
-        <SidebarNavItem
-          :to="{ name: 'adminCollections' }"
-          :icon="FolderCogIcon">
-          Collections
-        </SidebarNavItem>
-      </li>
-      <li>
-        <SidebarNavItem :href="`${BASE_URL}/reports`" :icon="BarChartIcon">
-          Reports
-        </SidebarNavItem>
-      </li>
-      <li>
-        <SidebarNavItem
-          :to="{
-            name: 'editInstanceSettingsPage',
-            params: { instanceId: instanceStore.instance.id },
-          }"
-          :icon="SettingsIcon">
-          Instance Settings
-        </SidebarNavItem>
-      </li>
-      <li v-if="currentUser?.isSuperAdmin">
-        <SidebarNavItem :href="`${BASE_URL}/admin`" :icon="ShieldIcon">
-          Super Admin
-        </SidebarNavItem>
-      </li>
-      <li v-if="currentUser?.isSuperAdmin">
-        <SidebarNavItem :href="`${BASE_URL}/admin/logs`" :icon="ScrollTextIcon">
-          Logs
-        </SidebarNavItem>
-      </li>
-    </ul>
+    <!-- The nav column stretches to the full page so its surface and border
+         reach the bottom on any page. Only the list pins, so the links stay
+         reachable down a long page. top-20 matches FormPageLayout's rail,
+         which sits opposite this one on the editor pages. -->
+    <div
+      class="sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto py-4 px-3">
+      <h2
+        class="text-xs uppercase text-on-surface-variant font-bold pl-2 pb-1 tracking-wider">
+        Admin
+      </h2>
+      <ul class="list-none p-0 m-0 flex flex-col gap-0.5">
+        <li>
+          <SidebarNavItem
+            :to="{ name: 'customPagesIndex' }"
+            :icon="FileTextIcon"
+            :activeForRouteNames="['createCustomPage', 'editCustomPage']">
+            Pages
+          </SidebarNavItem>
+        </li>
+        <li>
+          <SidebarNavItem :to="{ name: 'adminPermissions' }" :icon="LockIcon">
+            Permissions
+          </SidebarNavItem>
+        </li>
+        <li>
+          <SidebarNavItem
+            :to="{ name: 'templatesIndex' }"
+            :icon="LayoutTemplateIcon"
+            :activeForRouteNames="['templatesCreate', 'templatesEdit']">
+            Templates
+          </SidebarNavItem>
+        </li>
+        <li>
+          <SidebarNavItem
+            :to="{ name: 'adminCollections' }"
+            :icon="FolderCogIcon"
+            :activeForRouteNames="[
+              'adminCollectionsCreate',
+              'adminCollectionsEdit',
+            ]">
+            Collections
+          </SidebarNavItem>
+        </li>
+        <li>
+          <SidebarNavItem :href="`${BASE_URL}/reports`" :icon="BarChartIcon">
+            Reports
+          </SidebarNavItem>
+        </li>
+        <li>
+          <SidebarNavItem
+            :to="{
+              name: 'editInstanceSettingsPage',
+              params: { instanceId: instanceStore.instance.id },
+            }"
+            :icon="SettingsIcon">
+            Instance Settings
+          </SidebarNavItem>
+        </li>
+        <li v-if="currentUser?.isSuperAdmin">
+          <SidebarNavItem :href="`${BASE_URL}/admin`" :icon="ShieldIcon">
+            Super Admin
+          </SidebarNavItem>
+        </li>
+        <li v-if="currentUser?.isSuperAdmin">
+          <SidebarNavItem
+            :href="`${BASE_URL}/admin/logs`"
+            :icon="ScrollTextIcon">
+            Logs
+          </SidebarNavItem>
+        </li>
+      </ul>
+    </div>
   </nav>
 </template>
 

--- a/src/components/AdminSidebar/AdminSidebar.vue
+++ b/src/components/AdminSidebar/AdminSidebar.vue
@@ -2,10 +2,6 @@
   <nav
     class="bg-surface text-on-surface border-r border-outline-variant w-60"
     aria-label="Admin">
-    <!-- The nav column stretches to the full page so its surface and border
-         reach the bottom on any page. Only the list pins, so the links stay
-         reachable down a long page. top-20 matches FormPageLayout's rail,
-         which sits opposite this one on the editor pages. -->
     <div
       class="sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto py-4 px-3">
       <h2

--- a/src/components/AdminSidebar/SidebarNavItem.vue
+++ b/src/components/AdminSidebar/SidebarNavItem.vue
@@ -3,7 +3,7 @@
     :href="href"
     :to="to"
     class="flex items-center gap-2.5 py-2 px-2.5 rounded-[6px] text-[0.8125rem] font-medium text-[--on-surface-variant] no-underline hover:bg-on-surface-hover hover:text-[--on-surface] [&.is-active]:bg-[--primary-container] [&.is-active]:text-[--on-primary-container] [&.is-active]:font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-[--primary] focus-visible:outline-offset-2"
-    activeClass="is-active"
+    :activeClass="to ? 'is-active' : undefined"
     :class="{ 'is-active': isActiveByRouteName }">
     <component
       :is="icon"

--- a/src/components/AdminSidebar/SidebarNavItem.vue
+++ b/src/components/AdminSidebar/SidebarNavItem.vue
@@ -4,7 +4,8 @@
     :to="to"
     class="flex items-center gap-2.5 py-2 px-2.5 rounded-[6px] text-[0.8125rem] font-medium text-[--on-surface-variant] no-underline hover:bg-on-surface-hover hover:text-[--on-surface] [&.is-active]:bg-[--primary-container] [&.is-active]:text-[--on-primary-container] [&.is-active]:font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-[--primary] focus-visible:outline-offset-2"
     :activeClass="exact ? '' : 'is-active'"
-    exactActiveClass="is-active">
+    exactActiveClass="is-active"
+    :class="{ 'is-active': isActiveByRouteName }">
     <component
       :is="icon"
       v-if="icon"
@@ -18,21 +19,31 @@
 
 <script setup lang="ts">
 import Link from "@/components/Link/Link.vue";
-import type { RouteLocationRaw } from "vue-router";
+import { computed } from "vue";
+import { useRoute, type RouteLocationRaw } from "vue-router";
 import type { Component } from "vue";
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     href?: string;
     to?: RouteLocationRaw;
     icon?: Component;
     exact?: boolean;
+    // Routes that should light this item up but do not sit under its path,
+    // so vue-router's own prefix matching misses them.
+    activeForRouteNames?: string[];
   }>(),
   {
     href: undefined,
     to: undefined,
     icon: undefined,
     exact: false,
+    activeForRouteNames: undefined,
   }
+);
+
+const route = useRoute();
+const isActiveByRouteName = computed((): boolean =>
+  Boolean(props.activeForRouteNames?.includes(String(route.name)))
 );
 </script>

--- a/src/components/AdminSidebar/SidebarNavItem.vue
+++ b/src/components/AdminSidebar/SidebarNavItem.vue
@@ -3,8 +3,7 @@
     :href="href"
     :to="to"
     class="flex items-center gap-2.5 py-2 px-2.5 rounded-[6px] text-[0.8125rem] font-medium text-[--on-surface-variant] no-underline hover:bg-on-surface-hover hover:text-[--on-surface] [&.is-active]:bg-[--primary-container] [&.is-active]:text-[--on-primary-container] [&.is-active]:font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-[--primary] focus-visible:outline-offset-2"
-    :activeClass="exact ? '' : 'is-active'"
-    exactActiveClass="is-active"
+    activeClass="is-active"
     :class="{ 'is-active': isActiveByRouteName }">
     <component
       :is="icon"
@@ -28,16 +27,14 @@ const props = withDefaults(
     href?: string;
     to?: RouteLocationRaw;
     icon?: Component;
-    exact?: boolean;
-    // Routes that should light this item up but do not sit under its path,
-    // so vue-router's own prefix matching misses them.
+    // Routes that should light this item up but are declared as siblings
+    // rather than children, so vue-router's own matching misses them.
     activeForRouteNames?: string[];
   }>(),
   {
     href: undefined,
     to: undefined,
     icon: undefined,
-    exact: false,
     activeForRouteNames: undefined,
   }
 );

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -4,7 +4,7 @@
       <slot name="custom-header" />
     </template>
     <div class="flex flex-1 min-h-0">
-      <AdminSidebar class="hidden lg:block shrink-0" />
+      <AdminSidebar class="hidden xl:block shrink-0" />
       <div class="flex-1 min-w-0">
         <slot />
       </div>

--- a/src/pages/AllCustomPagesPage/AllCustomPagesPage.vue
+++ b/src/pages/AllCustomPagesPage/AllCustomPagesPage.vue
@@ -1,12 +1,13 @@
 <template>
-  <DefaultLayout class="all-custom-pages-page">
-    <div class="max-w-screen-xl w-full py-10 px-4 mx-auto">
-      <div class="flex justify-between items-center">
-        <h1 class="text-4xl font-bold my-8">Custom Pages</h1>
-        <RouterLink :to="{ name: 'createCustomPage' }">
-          <Button variant="primary">Create Page</Button>
-        </RouterLink>
-      </div>
+  <AdminLayout class="all-custom-pages-page">
+    <PageContent class="max-w-screen-lg">
+      <PageHeader title="Custom Pages">
+        <template #actions>
+          <Button variant="primary" :to="{ name: 'createCustomPage' }">
+            Create Page
+          </Button>
+        </template>
+      </PageHeader>
       <Skeleton v-if="isPending" height="10rem" />
       <Notification
         v-else-if="isError"
@@ -16,11 +17,13 @@
       </Notification>
       <p v-else-if="!customPages?.length" class="text-lg">No pages found.</p>
       <CustomPagesTable v-else :columns="columns" :data="customPages" />
-    </div>
-  </DefaultLayout>
+    </PageContent>
+  </AdminLayout>
 </template>
 <script setup lang="ts">
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import AdminLayout from "@/layouts/AdminLayout.vue";
+import PageContent from "@/components/PageContent/PageContent.vue";
+import PageHeader from "@/components/PageHeader/PageHeader.vue";
 import { useAllCustomPagesQuery } from "@/queries/useAllCustomPagesQuery";
 import { useDeleteCustomPageMutation } from "@/queries/useCustomPageQuery";
 import { useToastStore } from "@/stores/toastStore";

--- a/src/pages/AllTemplatesPage/AllTemplatesPage.vue
+++ b/src/pages/AllTemplatesPage/AllTemplatesPage.vue
@@ -1,10 +1,13 @@
 <template>
-  <DefaultLayout class="all-templates-page">
-    <div class="max-w-screen-xl w-full py-10 px-4 mx-auto">
-      <div class="flex justify-between items-center">
-        <h1 class="text-4xl font-bold my-8">Templates</h1>
-        <Button variant="primary" to="/templates/edit">Create Template</Button>
-      </div>
+  <AdminLayout class="all-templates-page">
+    <PageContent class="max-w-screen-lg">
+      <PageHeader title="Templates">
+        <template #actions>
+          <Button variant="primary" to="/templates/edit">
+            Create Template
+          </Button>
+        </template>
+      </PageHeader>
       <Skeleton v-if="isPending" height="10rem" />
       <Notification
         v-else-if="isError"
@@ -55,13 +58,15 @@
           ? This action cannot be undone.
         </p>
       </ConfirmModal>
-    </div>
-  </DefaultLayout>
+    </PageContent>
+  </AdminLayout>
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
 import { useRouter } from "vue-router";
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import AdminLayout from "@/layouts/AdminLayout.vue";
+import PageContent from "@/components/PageContent/PageContent.vue";
+import PageHeader from "@/components/PageHeader/PageHeader.vue";
 import { useToastStore } from "@/stores/toastStore";
 import { createColumns } from "./TemplatesTableColumns";
 import TemplatesTable from "./TemplatesTable.vue";

--- a/src/pages/CreateOrEditTemplatePage/CreateOrEditTemplatePage.vue
+++ b/src/pages/CreateOrEditTemplatePage/CreateOrEditTemplatePage.vue
@@ -1,5 +1,5 @@
 <template>
-  <DefaultLayout>
+  <AdminLayout>
     <div
       v-if="editor.isLoading.value && editor.isEditMode.value"
       class="flex justify-center items-center py-12">
@@ -17,13 +17,13 @@
       v-else
       @save="handleSave"
       @cancel="router.push({ name: 'templatesIndex' })" />
-  </DefaultLayout>
+  </AdminLayout>
 </template>
 
 <script setup lang="ts">
 import { provide } from "vue";
 import { useRouter } from "vue-router";
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import AdminLayout from "@/layouts/AdminLayout.vue";
 import SpinnerIcon from "@/icons/SpinnerIcon.vue";
 import EditTemplateForm from "./EditTemplateForm/EditTemplateForm.vue";
 import {

--- a/src/pages/EditCustomPage/EditCustomPage.vue
+++ b/src/pages/EditCustomPage/EditCustomPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <DefaultLayout>
+  <AdminLayout>
     <FormPageLayout :title="isNewPage ? 'Create Page' : 'Edit Page'">
       <div v-if="isLoading" class="flex justify-center items-center py-12">
         <SpinnerIcon class="w-8 h-8 animate-spin" />
@@ -69,7 +69,7 @@
         <FormToc :sections="tocSections" class="hidden lg:block" />
       </template>
     </FormPageLayout>
-  </DefaultLayout>
+  </AdminLayout>
 </template>
 
 <script setup lang="ts">
@@ -91,7 +91,7 @@ import {
 } from "@/queries/useCustomPageQuery";
 import { useAllCustomPagesQuery } from "@/queries/useAllCustomPagesQuery";
 import type { SelectOption, TocItem } from "@/types";
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import AdminLayout from "@/layouts/AdminLayout.vue";
 
 const props = defineProps<{
   pageId: number | null;

--- a/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
+++ b/src/pages/InstanceSettingsPage/InstanceSettingsPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <DefaultLayout>
+  <AdminLayout>
     <FormPageLayout title="Instance Settings">
       <div v-if="isLoading" class="flex justify-center items-center py-12">
         <SpinnerIcon class="w-8 h-8 animate-spin" />
@@ -296,12 +296,12 @@
         <FormToc :sections="tocSections" class="hidden lg:block" />
       </template>
     </FormPageLayout>
-  </DefaultLayout>
+  </AdminLayout>
 </template>
 
 <script setup lang="tsx">
 import { ref, watch, computed, onUnmounted } from "vue";
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import AdminLayout from "@/layouts/AdminLayout.vue";
 import FormPageLayout from "@/layouts/FormPageLayout.vue";
 import FormSubSection from "@/components/Form/FormSubSection.vue";
 import InputGroup from "@/components/InputGroup/InputGroup.vue";

--- a/tests/e2e/admin-sidebar.spec.ts
+++ b/tests/e2e/admin-sidebar.spec.ts
@@ -18,6 +18,9 @@ const ADMIN_ROUTES = [
 
 const DESKTOP = { width: 1440, height: 900 };
 const BELOW_XL = { width: 1024, height: 900 };
+// Tall enough that seeded rows cannot push an admin page past the fold, so a
+// scrollbar means the sidebar overflowed rather than the content growing.
+const TALLER_THAN_ANY_SEEDED_PAGE = { width: 1440, height: 1400 };
 
 test.describe("Admin sidebar", () => {
   test.beforeEach(async ({ page, request }) => {
@@ -45,6 +48,7 @@ test.describe("Admin sidebar", () => {
   test("the sidebar runs to the bottom of a page shorter than the screen", async ({
     page,
   }) => {
+    await page.setViewportSize(TALLER_THAN_ANY_SEEDED_PAGE);
     await page.goto("/templates");
     await expect(page.getByRole("navigation", { name: "Admin" })).toBeVisible();
 
@@ -65,7 +69,6 @@ test.describe("Admin sidebar", () => {
     expect(measurements.navBottom).toBeGreaterThanOrEqual(
       measurements.viewportHeight - 1
     );
-    // A short page must not have grown a scrollbar to reach the bottom.
     expect(measurements.documentHeight).toBeLessThanOrEqual(
       measurements.viewportHeight + 1
     );

--- a/tests/e2e/admin-sidebar.spec.ts
+++ b/tests/e2e/admin-sidebar.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+
+// Every admin page, with the sidebar item each one should light up.
+const ADMIN_ROUTES = [
+  { path: "/admin/permissions", activeItem: "Permissions" },
+  { path: "/admin/collections", activeItem: "Collections" },
+  { path: "/admin/collections/edit", activeItem: "Collections" },
+  { path: "/admin/collections/edit/1", activeItem: "Collections" },
+  { path: "/templates", activeItem: "Templates" },
+  { path: "/templates/edit", activeItem: "Templates" },
+  { path: "/templates/edit/1", activeItem: "Templates" },
+  { path: "/instances/customPages", activeItem: "Pages" },
+  { path: "/instances/createPage", activeItem: "Pages" },
+  { path: "/instances/editPage/1", activeItem: "Pages" },
+  { path: "/instances/edit/1", activeItem: "Instance Settings" },
+];
+
+// The sidebar is hidden below Tailwind's xl breakpoint, where the AppMenu
+// carries admin navigation instead. 1024 is the interesting width: wide
+// enough to look like a desktop, still too narrow to seat the sidebar
+// beside a form page's action rail.
+const DESKTOP = { width: 1440, height: 900 };
+const BELOW_XL = { width: 1024, height: 900 };
+
+test.describe("Admin sidebar", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "admin" });
+    await page.setViewportSize(DESKTOP);
+  });
+
+  for (const { path, activeItem } of ADMIN_ROUTES) {
+    test(`${path} shows the sidebar with ${activeItem} active`, async ({
+      page,
+    }) => {
+      await page.goto(path);
+
+      const sidebar = page.getByRole("navigation", { name: "Admin" });
+      await expect(sidebar).toBeVisible();
+      await expect(
+        sidebar.getByRole("link", { name: activeItem, exact: true })
+      ).toHaveClass(/is-active/);
+    });
+  }
+
+  test("the sidebar runs to the bottom of a page shorter than the screen", async ({
+    page,
+  }) => {
+    await page.goto("/templates");
+    await expect(page.getByRole("navigation", { name: "Admin" })).toBeVisible();
+
+    const measurements = await page.evaluate(() => {
+      const nav = document.querySelector('nav[aria-label="Admin"]');
+      if (!nav) return null;
+      return {
+        navBottom: nav.getBoundingClientRect().bottom,
+        viewportHeight: window.innerHeight,
+        documentHeight: document.documentElement.scrollHeight,
+      };
+    });
+
+    if (!measurements) throw new Error("Admin sidebar was not in the DOM");
+
+    // Guards the h-full regression: `height: 100%` could not resolve against
+    // a flex-sized parent, so the nav collapsed to its content height.
+    expect(measurements.navBottom).toBeGreaterThanOrEqual(
+      measurements.viewportHeight - 1
+    );
+    // A short page must not have grown a scrollbar to satisfy the above.
+    expect(measurements.documentHeight).toBeLessThanOrEqual(
+      measurements.viewportHeight + 1
+    );
+  });
+
+  test("the nav links stay on screen when a long page scrolls", async ({
+    page,
+  }) => {
+    // Instance Settings is the longest admin page, well past a screenful.
+    await page.goto("/instances/edit/1");
+    const firstLink = page
+      .getByRole("navigation", { name: "Admin" })
+      .getByRole("link")
+      .first();
+    await expect(firstLink).toBeVisible();
+
+    const topBeforeScroll = await firstLink.evaluate(
+      (el) => el.getBoundingClientRect().top
+    );
+
+    await page.evaluate(() => window.scrollTo(0, 1200));
+    await expect
+      .poll(() => page.evaluate(() => Math.round(window.scrollY)))
+      .toBeGreaterThan(0);
+
+    const topAfterScroll = await firstLink.evaluate(
+      (el) => el.getBoundingClientRect().top
+    );
+
+    // Sticky pins the list, so the first link holds its viewport position
+    // instead of scrolling away with the column.
+    expect(topAfterScroll).toBeCloseTo(topBeforeScroll, 0);
+    await expect(firstLink).toBeInViewport();
+  });
+
+  test("the sidebar is hidden below the xl breakpoint", async ({ page }) => {
+    await page.setViewportSize(BELOW_XL);
+    await page.goto("/admin/collections");
+
+    await expect(
+      page.getByRole("heading", { name: "Collections" })
+    ).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Admin" })).toBeHidden();
+  });
+});

--- a/tests/e2e/admin-sidebar.spec.ts
+++ b/tests/e2e/admin-sidebar.spec.ts
@@ -16,10 +16,6 @@ const ADMIN_ROUTES = [
   { path: "/instances/edit/1", activeItem: "Instance Settings" },
 ];
 
-// The sidebar is hidden below Tailwind's xl breakpoint, where the AppMenu
-// carries admin navigation instead. 1024 is the interesting width: wide
-// enough to look like a desktop, still too narrow to seat the sidebar
-// beside a form page's action rail.
 const DESKTOP = { width: 1440, height: 900 };
 const BELOW_XL = { width: 1024, height: 900 };
 
@@ -69,7 +65,7 @@ test.describe("Admin sidebar", () => {
     expect(measurements.navBottom).toBeGreaterThanOrEqual(
       measurements.viewportHeight - 1
     );
-    // A short page must not have grown a scrollbar to satisfy the above.
+    // A short page must not have grown a scrollbar to reach the bottom.
     expect(measurements.documentHeight).toBeLessThanOrEqual(
       measurements.viewportHeight + 1
     );
@@ -99,8 +95,6 @@ test.describe("Admin sidebar", () => {
       (el) => el.getBoundingClientRect().top
     );
 
-    // Sticky pins the list, so the first link holds its viewport position
-    // instead of scrolling away with the column.
     expect(topAfterScroll).toBeCloseTo(topBeforeScroll, 0);
     await expect(firstLink).toBeInViewport();
   });


### PR DESCRIPTION
- Adds the admin sidebar to the admin pages that were missing it, so all are consistent.
- Fixes the sidebar's height: it collapsed to its content instead of running to the bottom of the screen.
- Pins the nav links so they stay on screen down a long page, while the column itself still runs full height.
- The height bug was `h-full` on the nav. Removing it, with nothing in its place, is the whole fix.