### PR TITLE
Stop the Permissions page looping on a failed grants request

### DIFF
--- a/mock-server/db/adminGrants.ts
+++ b/mock-server/db/adminGrants.ts
@@ -1,0 +1,94 @@
+import { MockCollectionGrant, MockInstanceGrant } from "../types";
+import { createBaseTable } from "./baseTable";
+
+// Instance Reviewers can search and browse the whole instance.
+// Guest Critics hold no grant on purpose.
+const instanceGrantSeeds: MockInstanceGrant[] = [
+  { id: 401, groupId: 101, permissionLevelId: 4 },
+];
+
+// College of Design views derivatives on the Default Collection.
+const collectionGrantSeeds: MockCollectionGrant[] = [
+  { id: 501, collectionId: 1, groupId: 102, permissionLevelId: 5 },
+];
+
+export function createInstanceGrantsTable() {
+  const baseTable = createBaseTable(
+    (grant: MockInstanceGrant) => grant.id,
+    instanceGrantSeeds
+  );
+  let nextGrantId = 410;
+
+  return {
+    ...baseTable,
+    create: (data: Omit<MockInstanceGrant, "id">): MockInstanceGrant => {
+      const grant: MockInstanceGrant = { id: nextGrantId++, ...data };
+      baseTable.set(grant.id, grant);
+      return grant;
+    },
+    findByGroupId: (groupId: number): MockInstanceGrant | undefined => {
+      return baseTable.find((grant) => grant.groupId === groupId);
+    },
+    // deleting a group cascades to its grants, like the real schema
+    removeByGroupId: (groupId: number): void => {
+      baseTable
+        .filter((grant) => grant.groupId === groupId)
+        .forEach((grant) => baseTable.delete(grant.id));
+    },
+    seed: (): void => {
+      instanceGrantSeeds.forEach((grant) => {
+        baseTable.set(grant.id, structuredClone(grant));
+      });
+    },
+    reset: (): void => {
+      baseTable.reset();
+      nextGrantId = 410;
+    },
+  };
+}
+
+export function createCollectionGrantsTable() {
+  const baseTable = createBaseTable(
+    (grant: MockCollectionGrant) => grant.id,
+    collectionGrantSeeds
+  );
+  let nextGrantId = 510;
+
+  return {
+    ...baseTable,
+    create: (data: Omit<MockCollectionGrant, "id">): MockCollectionGrant => {
+      const grant: MockCollectionGrant = { id: nextGrantId++, ...data };
+      baseTable.set(grant.id, grant);
+      return grant;
+    },
+    findByCollectionAndGroup: (
+      collectionId: number,
+      groupId: number
+    ): MockCollectionGrant | undefined => {
+      return baseTable.find(
+        (grant) =>
+          grant.collectionId === collectionId && grant.groupId === groupId
+      );
+    },
+    // deleting a group cascades to its grants, like the real schema
+    removeByGroupId: (groupId: number): void => {
+      baseTable
+        .filter((grant) => grant.groupId === groupId)
+        .forEach((grant) => baseTable.delete(grant.id));
+    },
+    seed: (): void => {
+      collectionGrantSeeds.forEach((grant) => {
+        baseTable.set(grant.id, structuredClone(grant));
+      });
+    },
+    reset: (): void => {
+      baseTable.reset();
+      nextGrantId = 510;
+    },
+  };
+}
+
+export type InstanceGrantsTable = ReturnType<typeof createInstanceGrantsTable>;
+export type CollectionGrantsTable = ReturnType<
+  typeof createCollectionGrantsTable
+>;

--- a/mock-server/db/adminGroups.ts
+++ b/mock-server/db/adminGroups.ts
@@ -1,0 +1,66 @@
+import { MockAdminGroup } from "../types";
+import { PermissionsGroupEntry } from "../../src/types";
+import { createBaseTable } from "./baseTable";
+
+const adminGroupSeeds: MockAdminGroup[] = [
+  {
+    id: 101,
+    type: "User",
+    label: "Instance Reviewers",
+    // curator's user id
+    entries: [{ id: 8001, value: "3" }],
+  },
+  {
+    id: 102,
+    type: "Unit",
+    label: "College of Design",
+    entries: [{ id: 8002, value: "DSGN" }],
+  },
+  // holds no grant, so the page's Unassigned Groups section has content
+  {
+    id: 103,
+    type: "User",
+    label: "Guest Critics",
+    entries: [],
+  },
+];
+
+export function createAdminGroupsTable() {
+  const baseTable = createBaseTable(
+    (group: MockAdminGroup) => group.id,
+    adminGroupSeeds
+  );
+  let nextGroupId = 110;
+  let nextEntryId = 8100;
+
+  return {
+    ...baseTable,
+    create: (data: Pick<MockAdminGroup, "type" | "label">): MockAdminGroup => {
+      const group: MockAdminGroup = { id: nextGroupId++, entries: [], ...data };
+      baseTable.set(group.id, group);
+      return group;
+    },
+    addEntry: (group: MockAdminGroup, value: string): PermissionsGroupEntry => {
+      const entry: PermissionsGroupEntry = { id: nextEntryId++, value };
+      group.entries.push(entry);
+      return entry;
+    },
+    removeEntry: (group: MockAdminGroup, entryId: number): void => {
+      group.entries = group.entries.filter((entry) => entry.id !== entryId);
+    },
+    // Tests mutate a group's entries in place, so seed clones to keep the
+    // seed objects pristine for the next refresh.
+    seed: (): void => {
+      adminGroupSeeds.forEach((group) => {
+        baseTable.set(group.id, structuredClone(group));
+      });
+    },
+    reset: (): void => {
+      baseTable.reset();
+      nextGroupId = 110;
+      nextEntryId = 8100;
+    },
+  };
+}
+
+export type AdminGroupsTable = ReturnType<typeof createAdminGroupsTable>;

--- a/mock-server/db/directoryPeople.ts
+++ b/mock-server/db/directoryPeople.ts
@@ -1,0 +1,10 @@
+// People the directory knows but who have no local account yet, for the
+// autocomplete's provision-a-remote-user path.
+export const DIRECTORY_ONLY_MATCHES = [
+  {
+    name: "Directory Dana",
+    email: "dana007@example.edu",
+    localUserId: null,
+    username: "dana007",
+  },
+];

--- a/mock-server/db/groupTypes.ts
+++ b/mock-server/db/groupTypes.ts
@@ -1,0 +1,44 @@
+// One catalog serves /adminPermissions/groupTypes and
+// /drawerPermissions/groupTypes, so the two surfaces cannot drift.
+export const USER_TYPE = "User";
+
+export const GROUP_TYPES = [
+  {
+    type: "All",
+    label: "All",
+    description: "Everyone, including signed-out visitors.",
+    entryHints: [],
+    adminOnly: true,
+  },
+  {
+    type: "Authed",
+    label: "Authenticated Users",
+    description: "Anyone signed in, by any login method.",
+    entryHints: [],
+    adminOnly: true,
+  },
+  {
+    type: "Authed_remote",
+    label: "Centrally Authenticated Users",
+    description: "Users signed in through central single sign-on (SSO).",
+    entryHints: [],
+    adminOnly: true,
+  },
+  {
+    type: USER_TYPE,
+    label: "Specific People",
+    description: "Specific people you choose. Add by name, email, or username.",
+    entryHints: [],
+    adminOnly: false,
+  },
+  {
+    type: "Unit",
+    label: "University Unit",
+    description: "Everyone in a university unit.",
+    entryHints: [
+      { value: "LIBR", label: "University Libraries" },
+      { value: "DSGN", label: "College of Design" },
+    ],
+    adminOnly: false,
+  },
+];

--- a/mock-server/db/index.ts
+++ b/mock-server/db/index.ts
@@ -1,3 +1,8 @@
+import {
+  createCollectionGrantsTable,
+  createInstanceGrantsTable,
+} from "./adminGrants";
+import { createAdminGroupsTable } from "./adminGroups";
 import { createAssetsTable } from "./assets";
 import { createCollectionsTable } from "./collections";
 import { createCustomPagesTable } from "./customPages";
@@ -28,6 +33,9 @@ const makeDb = () => {
     drawers: createDrawersTable(),
     drawerGroups: createDrawerGroupsTable(),
     drawerGrants: createDrawerGrantsTable(),
+    adminGroups: createAdminGroupsTable(),
+    instanceGrants: createInstanceGrantsTable(),
+    collectionGrants: createCollectionGrantsTable(),
     uploads: createUploadsTable(),
   };
 

--- a/mock-server/routes/adminPermissions.ts
+++ b/mock-server/routes/adminPermissions.ts
@@ -1,13 +1,6 @@
 import { Hono } from "hono";
-import type { Context } from "hono";
 import { delay } from "../utils/index";
-import type {
-  MockDrawerGrant,
-  MockDrawerGroup,
-  MockServerContext,
-  MockUser,
-} from "../types";
-import type { DB } from "../db/index";
+import type { MockAdminGroup, MockServerContext, MockUser } from "../types";
 import { findPermissionLevel } from "../db/permissionLevels";
 import { GROUP_TYPES, USER_TYPE } from "../db/groupTypes";
 import { DIRECTORY_ONLY_MATCHES } from "../db/directoryPeople";
@@ -15,47 +8,7 @@ import { isAuthHelperGroupType } from "../../src/types";
 
 const app = new Hono<MockServerContext>();
 
-function isAdmin(user: MockUser): boolean {
-  return user.isInstanceAdmin || user.isSuperAdmin;
-}
-
-// Admins manage every drawer. Everyone else manages the drawers they
-// own, the mock's stand-in for the real per-drawer permission map.
-function getManageableDrawers(db: DB, user: MockUser) {
-  return isAdmin(user) ? db.drawers.getAll() : db.drawers.getByUserId(user.id);
-}
-
-function canManageDrawer(db: DB, user: MockUser, drawerId: number): boolean {
-  return getManageableDrawers(db, user).some(
-    (drawer) => drawer.id === drawerId
-  );
-}
-
-function toGrantPayload(db: DB, grant: MockDrawerGrant, currentUser: MockUser) {
-  // deleting a group cascades to its grants, so a grant's group always exists
-  const group = db.drawerGroups.get(grant.groupId);
-  if (!group) {
-    throw new Error(`grant ${grant.id} references a missing group`);
-  }
-
-  const owner = db.users.get(group.userId);
-
-  return {
-    id: grant.id,
-    drawerId: grant.drawerId,
-    permissionLevelId: grant.permissionLevelId,
-    group: {
-      id: group.id,
-      label: group.label,
-      type: group.type,
-      ownedByCurrentUser: group.userId === currentUser.id,
-      ownerName: owner?.displayName ?? null,
-      entries_count: group.entries.length,
-    },
-  };
-}
-
-function toGroupPayload(group: MockDrawerGroup) {
+function toGroupPayload(group: MockAdminGroup) {
   return {
     id: group.id,
     type: group.type,
@@ -76,35 +29,13 @@ function toMemberPayload(user: MockUser) {
   };
 }
 
-// The auth middleware guarantees a user on every route, so a missing one
-// here is a programming error rather than a request error.
-function requireUser(c: Context<MockServerContext>): MockUser {
-  const user = c.get("user");
-  if (!user) {
-    throw new Error("requireUser called outside the auth middleware");
-  }
-  return user;
-}
-
-function findOwnGroup(
-  db: DB,
-  user: MockUser,
-  groupId: number
-): MockDrawerGroup | undefined {
-  const group = db.drawerGroups.get(groupId);
-  return group?.userId === user.id ? group : undefined;
-}
-
-// every route requires a signed-in user with drawer-management rights
+// every route requires a signed-in instance admin
 app.use("*", async (c, next) => {
   const user = c.get("user");
   if (!user) {
     return c.json({ error: "Not Authenticated" }, 401);
   }
-
-  const canManageDrawers =
-    isAdmin(user) || Boolean(user.permissions.canCreateDrawers);
-  if (!canManageDrawers) {
+  if (!user.isInstanceAdmin && !user.isSuperAdmin) {
     return c.json({ error: "Forbidden" }, 403);
   }
 
@@ -144,140 +75,187 @@ app.get("/userAutocomplete", async (c) => {
   return c.json({ matches: [...localMatches, ...directoryMatches] });
 });
 
-app.get("/manageableDrawers", async (c) => {
+app.get("/instanceGrants", async (c) => {
   await delay(100);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const manageableDrawers = getManageableDrawers(db, user)
-    .map((drawer) => ({ id: drawer.id, title: drawer.name }))
-    .sort((a, b) => a.title.localeCompare(b.title));
-
-  return c.json({ manageableDrawers });
+  return c.json({ instanceGrants: db.instanceGrants.getAll() });
 });
 
-app.get("/grants", async (c) => {
-  await delay(100);
-  const db = c.get("db");
-  const user = requireUser(c);
-
-  const manageableDrawerIds = new Set(
-    getManageableDrawers(db, user).map((drawer) => drawer.id)
-  );
-  const grants = db.drawerGrants
-    .filter((grant) => manageableDrawerIds.has(grant.drawerId))
-    .map((grant) => toGrantPayload(db, grant, user));
-
-  return c.json({ grants });
-});
-
-app.post("/grants", async (c) => {
+app.post("/instanceGrants", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
   const body = await c.req.parseBody();
 
-  const drawerId = Number(body.drawerId);
-  const drawerGroupId = Number(body.drawerGroupId);
+  const groupId = Number(body.groupId);
   const permissionLevelId = Number(body.permissionLevelId);
 
-  const drawer = db.drawers.get(drawerId);
-  if (!drawer) {
-    return c.json({ error: "Drawer not found" }, 404);
-  }
-  if (!canManageDrawer(db, user, drawerId)) {
-    return c.json({ error: "Forbidden" }, 403);
-  }
-
-  // sharing is limited to the caller's own groups
-  const group = findOwnGroup(db, user, drawerGroupId);
-  if (!group) {
+  if (!db.adminGroups.get(groupId)) {
     return c.json({ error: "Group not found" }, 422);
   }
-
   if (!findPermissionLevel(permissionLevelId)) {
     return c.json({ error: "Permission level not found" }, 422);
   }
 
-  const existing = db.drawerGrants.findByDrawerAndGroup(drawerId, group.id);
+  const existing = db.instanceGrants.findByGroupId(groupId);
   if (existing) {
     return c.json(
       {
-        error: "Group already has a grant on this drawer",
+        error: "Group already has an instance grant",
         existingGrantId: existing.id,
       },
       409
     );
   }
 
-  const grant = db.drawerGrants.create({
-    drawerId,
-    groupId: group.id,
-    permissionLevelId,
-  });
+  const grant = db.instanceGrants.create({ groupId, permissionLevelId });
 
-  return c.json({ grant: toGrantPayload(db, grant, user) }, 201);
+  return c.json({ instanceGrant: grant }, 201);
 });
 
-// Re-level only. Drawer manage access is the whole gate, so another
-// owner's grant is editable.
-app.put("/grants/:grantId", async (c) => {
+// PUT replaces the whole grant, so the group id is writable too.
+app.put("/instanceGrants/:grantId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const grant = db.drawerGrants.get(Number(c.req.param("grantId")));
+  const grant = db.instanceGrants.get(Number(c.req.param("grantId")));
   if (!grant) {
     return c.json({ error: "Grant not found" }, 404);
   }
-  if (!canManageDrawer(db, user, grant.drawerId)) {
-    return c.json({ error: "Forbidden" }, 403);
-  }
 
   const body = await c.req.parseBody();
+  const groupId = Number(body.groupId);
   const permissionLevelId = Number(body.permissionLevelId);
+
+  if (!db.adminGroups.get(groupId)) {
+    return c.json({ error: "Group not found" }, 422);
+  }
   if (!findPermissionLevel(permissionLevelId)) {
     return c.json({ error: "Permission level not found" }, 422);
   }
 
+  grant.groupId = groupId;
   grant.permissionLevelId = permissionLevelId;
 
-  return c.json({ grant: toGrantPayload(db, grant, user) });
+  return c.json({ instanceGrant: grant });
 });
 
-// Unlike update, a manager can only delete grants on their own
-// groups. Admins can delete any.
-app.delete("/grants/:grantId", async (c) => {
+app.delete("/instanceGrants/:grantId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const grant = db.drawerGrants.get(Number(c.req.param("grantId")));
+  const grant = db.instanceGrants.get(Number(c.req.param("grantId")));
   if (!grant) {
     return c.json({ error: "Grant not found" }, 404);
   }
-  if (!canManageDrawer(db, user, grant.drawerId)) {
-    return c.json({ error: "Forbidden" }, 403);
-  }
 
-  const group = db.drawerGroups.get(grant.groupId);
-  const isAnotherOwnersGrant = group !== undefined && group.userId !== user.id;
-  if (isAnotherOwnersGrant && !isAdmin(user)) {
-    return c.json({ error: "Cannot delete another owner's grant" }, 403);
-  }
-
-  db.drawerGrants.delete(grant.id);
+  db.instanceGrants.delete(grant.id);
 
   return c.json({ removed: grant.id });
 });
 
-// the caller's own groups
+app.get("/collectionGrants", async (c) => {
+  await delay(100);
+  const db = c.get("db");
+
+  return c.json({ collectionGrants: db.collectionGrants.getAll() });
+});
+
+// Collection ids come from the nav's nested tree, which the mock does
+// not re-walk, so collectionId is taken as sent.
+app.post("/collectionGrants", async (c) => {
+  await delay(150);
+  const db = c.get("db");
+  const body = await c.req.parseBody();
+
+  const collectionId = Number(body.collectionId);
+  const groupId = Number(body.groupId);
+  const permissionLevelId = Number(body.permissionLevelId);
+
+  if (!Number.isInteger(collectionId) || collectionId <= 0) {
+    return c.json({ error: "Collection not found" }, 422);
+  }
+  if (!db.adminGroups.get(groupId)) {
+    return c.json({ error: "Group not found" }, 422);
+  }
+  if (!findPermissionLevel(permissionLevelId)) {
+    return c.json({ error: "Permission level not found" }, 422);
+  }
+
+  const existing = db.collectionGrants.findByCollectionAndGroup(
+    collectionId,
+    groupId
+  );
+  if (existing) {
+    return c.json(
+      {
+        error: "Group already has a grant on this collection",
+        existingGrantId: existing.id,
+      },
+      409
+    );
+  }
+
+  const grant = db.collectionGrants.create({
+    collectionId,
+    groupId,
+    permissionLevelId,
+  });
+
+  return c.json({ collectionGrant: grant }, 201);
+});
+
+// PUT replaces the whole grant, so every id is writable.
+app.put("/collectionGrants/:grantId", async (c) => {
+  await delay(150);
+  const db = c.get("db");
+
+  const grant = db.collectionGrants.get(Number(c.req.param("grantId")));
+  if (!grant) {
+    return c.json({ error: "Grant not found" }, 404);
+  }
+
+  const body = await c.req.parseBody();
+  const collectionId = Number(body.collectionId);
+  const groupId = Number(body.groupId);
+  const permissionLevelId = Number(body.permissionLevelId);
+
+  if (!Number.isInteger(collectionId) || collectionId <= 0) {
+    return c.json({ error: "Collection not found" }, 422);
+  }
+  if (!db.adminGroups.get(groupId)) {
+    return c.json({ error: "Group not found" }, 422);
+  }
+  if (!findPermissionLevel(permissionLevelId)) {
+    return c.json({ error: "Permission level not found" }, 422);
+  }
+
+  grant.collectionId = collectionId;
+  grant.groupId = groupId;
+  grant.permissionLevelId = permissionLevelId;
+
+  return c.json({ collectionGrant: grant });
+});
+
+app.delete("/collectionGrants/:grantId", async (c) => {
+  await delay(150);
+  const db = c.get("db");
+
+  const grant = db.collectionGrants.get(Number(c.req.param("grantId")));
+  if (!grant) {
+    return c.json({ error: "Grant not found" }, 404);
+  }
+
+  db.collectionGrants.delete(grant.id);
+
+  return c.json({ removed: grant.id });
+});
+
 app.get("/groups", async (c) => {
   await delay(100);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const groups = db.drawerGroups.getByUserId(user.id).map(toGroupPayload);
+  const groups = db.adminGroups.getAll().map(toGroupPayload);
 
   return c.json({ groups });
 });
@@ -285,7 +263,6 @@ app.get("/groups", async (c) => {
 app.post("/groups", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
   const body = await c.req.parseBody();
 
   const label = String(body.label ?? "").trim();
@@ -295,36 +272,37 @@ app.post("/groups", async (c) => {
   if (label === "" || !typeDetails) {
     return c.json({ errors: { label: ["Label and type are required"] } }, 422);
   }
-  if (typeDetails.adminOnly && !isAdmin(user)) {
-    return c.json(
-      { error: "Only instance admins can use instance-wide group types" },
-      403
-    );
-  }
 
-  const group = db.drawerGroups.create({ userId: user.id, type, label });
+  const group = db.adminGroups.create({ type, label });
 
   return c.json({ group: toGroupPayload(group) }, 201);
 });
 
-// Rename only, the type is fixed at creation.
 app.put("/groups/:groupId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
 
   const body = await c.req.parseBody();
   const label = String(body.label ?? "").trim();
-  if (label === "") {
-    return c.json({ errors: { label: ["Label is required"] } }, 422);
+  const type = String(body.type ?? "");
+
+  const typeDetails = GROUP_TYPES.find((details) => details.type === type);
+  if (label === "" || !typeDetails) {
+    return c.json({ errors: { label: ["Label and type are required"] } }, 422);
+  }
+
+  // a type change invalidates the members the old type held
+  if (type !== group.type) {
+    group.entries = [];
   }
 
   group.label = label;
+  group.type = type;
 
   return c.json({ group: toGroupPayload(group) });
 });
@@ -332,15 +310,15 @@ app.put("/groups/:groupId", async (c) => {
 app.delete("/groups/:groupId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
 
-  db.drawerGrants.removeByGroupId(group.id);
-  db.drawerGroups.delete(group.id);
+  db.instanceGrants.removeByGroupId(group.id);
+  db.collectionGrants.removeByGroupId(group.id);
+  db.adminGroups.delete(group.id);
 
   return c.json({ deleted: group.id });
 });
@@ -348,9 +326,8 @@ app.delete("/groups/:groupId", async (c) => {
 app.get("/groups/:groupId/members", async (c) => {
   await delay(100);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -375,9 +352,8 @@ app.get("/groups/:groupId/members", async (c) => {
 app.post("/groups/:groupId/members", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -435,7 +411,7 @@ app.post("/groups/:groupId/members", async (c) => {
     return c.json({ error: "User is already a member" }, 409);
   }
 
-  db.drawerGroups.addEntry(group, String(memberId));
+  db.adminGroups.addEntry(group, String(memberId));
 
   return c.json({ member: toMemberPayload(member) }, 201);
 });
@@ -443,9 +419,8 @@ app.post("/groups/:groupId/members", async (c) => {
 app.delete("/groups/:groupId/members/:userId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -461,7 +436,7 @@ app.delete("/groups/:groupId/members/:userId", async (c) => {
     return c.json({ error: "User is not a member" }, 404);
   }
 
-  db.drawerGroups.removeEntry(group, entry.id);
+  db.adminGroups.removeEntry(group, entry.id);
 
   return c.json({ removed: memberId });
 });
@@ -469,9 +444,8 @@ app.delete("/groups/:groupId/members/:userId", async (c) => {
 app.get("/groups/:groupId/entries", async (c) => {
   await delay(100);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -485,9 +459,8 @@ app.get("/groups/:groupId/entries", async (c) => {
 app.post("/groups/:groupId/entries", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -501,7 +474,7 @@ app.post("/groups/:groupId/entries", async (c) => {
     return c.json({ errors: { value: ["Value is required"] } }, 422);
   }
 
-  const entry = db.drawerGroups.addEntry(group, value);
+  const entry = db.adminGroups.addEntry(group, value);
 
   return c.json({ entry }, 201);
 });
@@ -509,9 +482,8 @@ app.post("/groups/:groupId/entries", async (c) => {
 app.put("/groups/:groupId/entries/:entryId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -537,9 +509,8 @@ app.put("/groups/:groupId/entries/:entryId", async (c) => {
 app.delete("/groups/:groupId/entries/:entryId", async (c) => {
   await delay(150);
   const db = c.get("db");
-  const user = requireUser(c);
 
-  const group = findOwnGroup(db, user, Number(c.req.param("groupId")));
+  const group = db.adminGroups.get(Number(c.req.param("groupId")));
   if (!group) {
     return c.json({ error: "Group not found" }, 404);
   }
@@ -550,7 +521,7 @@ app.delete("/groups/:groupId/entries/:entryId", async (c) => {
     return c.json({ error: "Entry not found" }, 404);
   }
 
-  db.drawerGroups.removeEntry(group, entry.id);
+  db.adminGroups.removeEntry(group, entry.id);
 
   return c.json({ removed: entryId });
 });

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -7,6 +7,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import type { MockServerContext } from "./types";
 import { db, getOrCreateWorkerDb } from "./db/index";
 
+import adminPermissionsRoutes from "./routes/adminPermissions";
 import assetRoutes from "./routes/assets";
 import collectionRoutes from "./routes/collections";
 import searchRoutes from "./routes/search";
@@ -90,6 +91,7 @@ app.route("/defaultinstance/collections", collectionRoutes);
 app.route("/defaultinstance/search", searchRoutes);
 app.route("/defaultinstance/drawers", drawerRoutes);
 app.route("/defaultinstance/drawerPermissions", drawerPermissionsRoutes);
+app.route("/defaultinstance/adminPermissions", adminPermissionsRoutes);
 app.route("/defaultinstance/permissions", permissionsRoutes);
 app.route("/defaultinstance/loginManager", authRoutes);
 app.route("/defaultinstance/fileManager", fileRoutes);

--- a/mock-server/types.ts
+++ b/mock-server/types.ts
@@ -26,6 +26,30 @@ export interface MockDrawerGroup {
   entries: PermissionsGroupEntry[];
 }
 
+// An instance-level permission group. Unlike drawer groups these belong
+// to the instance, not a user, so there is no owner id.
+export interface MockAdminGroup {
+  id: number;
+  type: string;
+  label: string;
+  entries: PermissionsGroupEntry[];
+}
+
+// One group's permission level on the whole instance
+export interface MockInstanceGrant {
+  id: number;
+  groupId: number;
+  permissionLevelId: number;
+}
+
+// One group's permission level on one collection
+export interface MockCollectionGrant {
+  id: number;
+  collectionId: number;
+  groupId: number;
+  permissionLevelId: number;
+}
+
 // One group's permission level on one drawer (the backend's DrawerPermission)
 export interface MockDrawerGrant {
   id: number;

--- a/src/pages/AdminPermissionsPage/PermissionsTable.vue
+++ b/src/pages/AdminPermissionsPage/PermissionsTable.vue
@@ -89,15 +89,13 @@
         </TableHeader>
         <TableBody>
           <template v-if="isLoading">
-            <TableRow
-              v-for="row in SKELETON_ROW_COUNT"
-              :key="`skeleton-${row}`">
+            <TableRow>
               <TableCell v-for="(_, index) in permissionColumns" :key="index">
                 <Skeleton height="1rem" width="70%" />
               </TableCell>
             </TableRow>
           </template>
-          <template v-else>
+          <template v-else-if="isSuccess">
             <template v-for="row in table.getRowModel().rows" :key="row.id">
               <TableRow
                 :data-permission-row="row.original.key"
@@ -145,31 +143,46 @@
             <TableRow v-if="!table.getRowModel().rows.length">
               <TableCell
                 :colspan="permissionColumns.length"
-                class="h-16 text-center text-sm"
-                :class="isError ? 'text-error' : 'text-on-surface-variant'">
+                class="h-16 text-center text-sm text-on-surface-variant">
                 {{ emptyMessage }}
               </TableCell>
             </TableRow>
-
-            <AddPermissionRow
-              v-model:open="isAddingPermission"
-              :prefillGroup="prefillGroup"
-              :prefillCollectionId="collectionFilterId"
-              :colspan="permissionColumns.length"
-              @created="revealSavedPermission" />
-            <AddRowButton
-              v-if="!isAddingPermission"
-              :colspan="permissionColumns.length"
-              label="Add Permission"
-              @click="openAddPermission()" />
           </template>
+          <template v-else>
+            <TableRow>
+              <TableCell
+                :colspan="permissionColumns.length"
+                class="h-16 text-center text-sm text-error">
+                Could not load permissions.
+              </TableCell>
+            </TableRow>
+          </template>
+
+          <!--
+            AddPermissionRow subscribes to the same six queries the
+            branches key on, and mounting a subscriber to a query with no
+            data refetches it. Keeping it outside the branches means no
+            predicate here can trigger that, whatever the predicate says.
+            AddRowButton fetches nothing, so gating it is safe.
+          -->
+          <AddPermissionRow
+            v-model:open="isAddingPermission"
+            :prefillGroup="prefillGroup"
+            :prefillCollectionId="collectionFilterId"
+            :colspan="permissionColumns.length"
+            @created="revealSavedPermission" />
+          <AddRowButton
+            v-if="isSuccess && !isAddingPermission"
+            :colspan="permissionColumns.length"
+            label="Add Permission"
+            @click="openAddPermission()" />
         </TableBody>
       </Table>
     </div>
 
     <section
       v-if="
-        !isLoading && unassignedGroupRows.length && collectionFilterId === null
+        isSuccess && unassignedGroupRows.length && collectionFilterId === null
       "
       class="mt-8">
       <h2 class="text-base font-medium text-on-surface">Unassigned Groups</h2>
@@ -296,52 +309,42 @@ const SKELETON_ROW_COUNT = 3;
 
 const toastStore = useToastStore();
 
-const {
-  data: instanceGrants,
-  isLoading: isLoadingInstanceGrants,
-  isError: isInstanceGrantsError,
-} = useQuery(instanceGrantsQuery());
-const {
-  data: collectionGrants,
-  isLoading: isLoadingCollectionGrants,
-  isError: isCollectionGrantsError,
-} = useQuery(collectionGrantsQuery());
-const {
-  data: groups,
-  isLoading: isLoadingGroups,
-  isError: isGroupsError,
-} = useQuery(groupsQuery());
-const {
-  data: groupTypes,
-  isLoading: isLoadingTypes,
-  isError: isTypesError,
-} = useQuery(groupTypesQuery());
-const {
-  data: permissionLevels,
-  isLoading: isLoadingLevels,
-  isError: isLevelsError,
-} = useQuery(permissionLevelsQuery());
-const { data: instanceNav, isLoading: isLoadingNav } = useInstanceQuery();
+const instanceGrantsResult = useQuery(instanceGrantsQuery());
+const collectionGrantsResult = useQuery(collectionGrantsQuery());
+const groupsResult = useQuery(groupsQuery());
+const groupTypesResult = useQuery(groupTypesQuery());
+const permissionLevelsResult = useQuery(permissionLevelsQuery());
+const instanceNavResult = useInstanceQuery();
+
+// the one list every table-wide state derives from, so a query added here
+// cannot reach isLoading while missing from isSuccess
+const tableQueries = [
+  instanceGrantsResult,
+  collectionGrantsResult,
+  groupsResult,
+  groupTypesResult,
+  permissionLevelsResult,
+  instanceNavResult,
+];
+
+const { data: instanceGrants } = instanceGrantsResult;
+const { data: collectionGrants } = collectionGrantsResult;
+const { data: groups } = groupsResult;
+const { data: groupTypes } = groupTypesResult;
+const { data: permissionLevels } = permissionLevelsResult;
+const { data: instanceNav } = instanceNavResult;
 
 // rows join every source, so any one still loading means no rows yet
-const isLoading = computed(
-  () =>
-    isLoadingInstanceGrants.value ||
-    isLoadingCollectionGrants.value ||
-    isLoadingGroups.value ||
-    isLoadingTypes.value ||
-    isLoadingLevels.value ||
-    isLoadingNav.value
+const isLoading = computed(() =>
+  tableQueries.some((query) => query.isLoading.value)
 );
 
-// each source falls back to [], so one failing looks identical to no rows
-const isError = computed(
-  () =>
-    isInstanceGrantsError.value ||
-    isCollectionGrantsError.value ||
-    isGroupsError.value ||
-    isTypesError.value ||
-    isLevelsError.value
+// `success` is the only status that guarantees data, so the rows branch
+// asks for it positively. Every other state, including an offline pause
+// that leaves isLoading and isError both false, falls through to the
+// error branch, which subscribes to nothing and cannot restart the loop.
+const isSuccess = computed(() =>
+  tableQueries.every((query) => query.isSuccess.value)
 );
 
 const flatCollections = computed(() =>
@@ -413,7 +416,6 @@ const visiblePermissionRows = computed((): PermissionRow[] => {
 });
 
 const emptyMessage = computed((): string => {
-  if (isError.value) return "Could not load permissions.";
   // the table renders this only when no row is visible, so rows that
   // exist are rows the search hid
   if (visiblePermissionRows.value.length > 0) {

--- a/src/pages/AdminPermissionsPage/PermissionsTable.vue
+++ b/src/pages/AdminPermissionsPage/PermissionsTable.vue
@@ -89,7 +89,9 @@
         </TableHeader>
         <TableBody>
           <template v-if="isLoading">
-            <TableRow>
+            <TableRow
+              v-for="row in SKELETON_ROW_COUNT"
+              :key="`skeleton-${row}`">
               <TableCell v-for="(_, index) in permissionColumns" :key="index">
                 <Skeleton height="1rem" width="70%" />
               </TableCell>
@@ -149,6 +151,7 @@
             </TableRow>
           </template>
           <template v-else>
+            <!-- query subscribers refetch on mount, so none belong here -->
             <TableRow>
               <TableCell
                 :colspan="permissionColumns.length"
@@ -159,11 +162,11 @@
           </template>
 
           <!--
-            AddPermissionRow subscribes to the same six queries the
-            branches key on, and mounting a subscriber to a query with no
-            data refetches it. Keeping it outside the branches means no
-            predicate here can trigger that, whatever the predicate says.
-            AddRowButton fetches nothing, so gating it is safe.
+            AddPermissionRow subscribes to the same queries the branches
+            key on, and mounting a subscriber to a query with no data
+            refetches it. Keeping AddPermissionRow outside the branches
+            means no predicate here can trigger that, whatever the
+            predicate says.
           -->
           <AddPermissionRow
             v-model:open="isAddingPermission"
@@ -171,6 +174,7 @@
             :prefillCollectionId="collectionFilterId"
             :colspan="permissionColumns.length"
             @created="revealSavedPermission" />
+          <!-- AddRowButton fetches nothing, so gating it is safe -->
           <AddRowButton
             v-if="isSuccess && !isAddingPermission"
             :colspan="permissionColumns.length"
@@ -342,7 +346,7 @@ const isLoading = computed(() =>
 // `success` is the only status that guarantees data, so the rows branch
 // asks for it positively. Every other state, including an offline pause
 // that leaves isLoading and isError both false, falls through to the
-// error branch, which subscribes to nothing and cannot restart the loop.
+// error branch.
 const isSuccess = computed(() =>
   tableQueries.every((query) => query.isSuccess.value)
 );

--- a/src/pages/DrawerManagementPage/GroupAccessTable.vue
+++ b/src/pages/DrawerManagementPage/GroupAccessTable.vue
@@ -75,7 +75,7 @@
               </TableCell>
             </TableRow>
           </template>
-          <template v-else>
+          <template v-else-if="isSuccess">
             <template v-for="row in table.getRowModel().rows" :key="row.id">
               <TableRow
                 :data-group-row="row.original.id"
@@ -124,23 +124,38 @@
             <TableRow v-if="!table.getRowModel().rows.length">
               <TableCell
                 :colspan="groupAccessColumns.length"
-                class="h-16 text-center text-sm"
-                :class="isError ? 'text-error' : 'text-on-surface-variant'">
+                class="h-16 text-center text-sm text-on-surface-variant">
                 {{ emptyMessage }}
               </TableCell>
             </TableRow>
-
-            <AddGroupRow
-              v-model:open="isAddingGroup"
-              :drawerId="drawerId"
-              :colspan="groupAccessColumns.length"
-              @created="revealNewGroup" />
-            <AddRowButton
-              v-if="!isAddingGroup"
-              :colspan="groupAccessColumns.length"
-              label="New Group"
-              @click="openAddGroupForm" />
           </template>
+          <template v-else>
+            <TableRow>
+              <TableCell
+                :colspan="groupAccessColumns.length"
+                class="h-16 text-center text-sm text-error">
+                Could not load groups.
+              </TableCell>
+            </TableRow>
+          </template>
+
+          <!--
+            AddGroupRow subscribes to the same queries the branches key
+            on, and mounting a subscriber to a query with no data
+            refetches it. Keeping it outside the branches means no
+            predicate here can trigger that, whatever the predicate says.
+            AddRowButton fetches nothing, so gating it is safe.
+          -->
+          <AddGroupRow
+            v-model:open="isAddingGroup"
+            :drawerId="drawerId"
+            :colspan="groupAccessColumns.length"
+            @created="revealNewGroup" />
+          <AddRowButton
+            v-if="isSuccess && !isAddingGroup"
+            :colspan="groupAccessColumns.length"
+            label="New Group"
+            @click="openAddGroupForm" />
         </TableBody>
       </Table>
     </div>
@@ -223,43 +238,36 @@ const props = defineProps<{ drawerId: number }>();
 
 const toastStore = useToastStore();
 
-const {
-  data: grants,
-  isLoading: isLoadingGrants,
-  isError: isGrantsError,
-} = useQuery(drawerGrantsQuery());
-const {
-  data: groups,
-  isLoading: isLoadingGroups,
-  isError: isGroupsError,
-} = useQuery(drawerGroupsQuery());
-const {
-  data: groupTypes,
-  isLoading: isLoadingTypes,
-  isError: isTypesError,
-} = useQuery(drawerGroupTypesQuery());
-const {
-  data: permissionLevels,
-  isLoading: isLoadingLevels,
-  isError: isLevelsError,
-} = useQuery(permissionLevelsQuery());
+const grantsResult = useQuery(drawerGrantsQuery());
+const groupsResult = useQuery(drawerGroupsQuery());
+const groupTypesResult = useQuery(drawerGroupTypesQuery());
+const permissionLevelsResult = useQuery(permissionLevelsQuery());
+
+// the one list every table-wide state derives from, so a query added here
+// cannot reach isLoading while missing from isSuccess
+const tableQueries = [
+  grantsResult,
+  groupsResult,
+  groupTypesResult,
+  permissionLevelsResult,
+];
+
+const { data: grants } = grantsResult;
+const { data: groups } = groupsResult;
+const { data: groupTypes } = groupTypesResult;
+const { data: permissionLevels } = permissionLevelsResult;
 
 // rows join all four sources, so any one still loading means no rows yet
-const isLoading = computed(
-  () =>
-    isLoadingGrants.value ||
-    isLoadingGroups.value ||
-    isLoadingTypes.value ||
-    isLoadingLevels.value
+const isLoading = computed(() =>
+  tableQueries.some((query) => query.isLoading.value)
 );
 
-// each source falls back to [], so one failing looks identical to no groups
-const isError = computed(
-  () =>
-    isGrantsError.value ||
-    isGroupsError.value ||
-    isTypesError.value ||
-    isLevelsError.value
+// `success` is the only status that guarantees data, so the rows branch
+// asks for it positively. Every other state, including an offline pause
+// that leaves isLoading and isError both false, falls through to the
+// error branch, which subscribes to nothing and cannot restart the loop.
+const isSuccess = computed(() =>
+  tableQueries.every((query) => query.isSuccess.value)
 );
 
 const groupRows = computed(() =>
@@ -273,7 +281,6 @@ const groupRows = computed(() =>
 );
 
 const emptyMessage = computed((): string => {
-  if (isError.value) return "Could not load groups.";
   // the table renders this only when no row is visible, so groups that
   // exist are groups the search hid
   if (groupRows.value.length > 0) return "No groups match your search.";

--- a/src/pages/DrawerManagementPage/GroupAccessTable.vue
+++ b/src/pages/DrawerManagementPage/GroupAccessTable.vue
@@ -130,6 +130,7 @@
             </TableRow>
           </template>
           <template v-else>
+            <!-- query subscribers refetch on mount, so none belong here -->
             <TableRow>
               <TableCell
                 :colspan="groupAccessColumns.length"
@@ -142,15 +143,16 @@
           <!--
             AddGroupRow subscribes to the same queries the branches key
             on, and mounting a subscriber to a query with no data
-            refetches it. Keeping it outside the branches means no
-            predicate here can trigger that, whatever the predicate says.
-            AddRowButton fetches nothing, so gating it is safe.
+            refetches it. Keeping AddGroupRow outside the branches means
+            no predicate here can trigger that, whatever the predicate
+            says.
           -->
           <AddGroupRow
             v-model:open="isAddingGroup"
             :drawerId="drawerId"
             :colspan="groupAccessColumns.length"
             @created="revealNewGroup" />
+          <!-- AddRowButton fetches nothing, so gating it is safe -->
           <AddRowButton
             v-if="isSuccess && !isAddingGroup"
             :colspan="groupAccessColumns.length"
@@ -265,7 +267,7 @@ const isLoading = computed(() =>
 // `success` is the only status that guarantees data, so the rows branch
 // asks for it positively. Every other state, including an offline pause
 // that leaves isLoading and isError both false, falls through to the
-// error branch, which subscribes to nothing and cannot restart the loop.
+// error branch.
 const isSuccess = computed(() =>
   tableQueries.every((query) => query.isSuccess.value)
 );

--- a/tests/e2e/permissions-refetch-loop.spec.ts
+++ b/tests/e2e/permissions-refetch-loop.spec.ts
@@ -7,7 +7,7 @@ import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
 const OBSERVATION_MS = 2000;
 
 // A settled page asks for each endpoint once. The bound sits well above
-// that and far below a loop, so it does not depend on timing.
+// that and far below a loop, so the assertion does not depend on timing.
 const MAX_REQUESTS_PER_ENDPOINT = 10;
 
 const GRANT_ENDPOINTS = [
@@ -29,8 +29,8 @@ test.describe("Permissions page against a failing grants endpoint", () => {
     // 404 rather than 500 on purpose: queryClient treats 404 as
     // non-retryable, so each attempt settles immediately. A retryable
     // status would let backoff hide the loop behind its delays.
-    // Forcing the failure rather than relying on the mock server having no
-    // adminPermissions routes keeps this meaningful once those routes exist.
+    // Forcing the failure keeps the test independent of which
+    // adminPermissions routes the mock server defines.
     await page.route("**/adminPermissions/**", (route) =>
       route.fulfill({
         status: 404,
@@ -45,10 +45,8 @@ test.describe("Permissions page against a failing grants endpoint", () => {
         req.url().includes(`/adminPermissions/${name}`)
       );
       if (!endpoint) return;
-      requestsByEndpoint.set(
-        endpoint,
-        (requestsByEndpoint.get(endpoint) ?? 0) + 1
-      );
+      const previousCount = requestsByEndpoint.get(endpoint) ?? 0;
+      requestsByEndpoint.set(endpoint, previousCount + 1);
     });
 
     await page.goto("/admin/permissions");
@@ -57,7 +55,8 @@ test.describe("Permissions page against a failing grants endpoint", () => {
     for (const endpoint of GRANT_ENDPOINTS) {
       const count = requestsByEndpoint.get(endpoint) ?? 0;
       // A count of zero means the page never got far enough to ask, so
-      // the bound below would pass for the wrong reason.
+      // the MAX_REQUESTS_PER_ENDPOINT check would pass for the wrong
+      // reason.
       expect(count, `${endpoint} was never requested`).toBeGreaterThan(0);
       expect(
         count,
@@ -67,26 +66,19 @@ test.describe("Permissions page against a failing grants endpoint", () => {
   });
 
   test("still loads normally when the endpoints succeed", async ({ page }) => {
-    // The mock server has no adminPermissions routes yet, so the healthy
-    // path has to be stubbed to be tested at all.
-    for (const endpoint of GRANT_ENDPOINTS) {
-      await page.route(`**/adminPermissions/${endpoint}`, (route) =>
-        route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ [endpoint]: [] }),
-        })
-      );
-    }
-
     await page.goto("/admin/permissions");
 
     await expect(
       page.getByRole("heading", { name: "Permissions" })
     ).toBeVisible();
-    // The skeletons clear and the empty table settles.
+    // a seeded permission row proves the success branch rendered
     await expect(
-      page.getByRole("button", { name: "Add Permission" }).first()
+      page.getByRole("row", { name: /Instance Reviewers/ })
+    ).toBeVisible();
+    // The toolbar has an Add Permission button of its own, so scope to
+    // the table: its add button renders only when every query succeeded.
+    await expect(
+      page.locator("tbody").getByRole("button", { name: "Add Permission" })
     ).toBeVisible();
     await expect(page.locator("[data-add-permission-form]")).toHaveCount(0);
   });

--- a/tests/e2e/permissions-refetch-loop.spec.ts
+++ b/tests/e2e/permissions-refetch-loop.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+
+// Long enough that a loop racks up hundreds of requests, short enough to
+// keep the suite quick. The looping bug ran at roughly 240 per second per
+// endpoint.
+const OBSERVATION_MS = 2000;
+
+// A settled page asks for each endpoint once. The bound sits well above
+// that and far below a loop, so it does not depend on timing.
+const MAX_REQUESTS_PER_ENDPOINT = 10;
+
+const GRANT_ENDPOINTS = [
+  "groups",
+  "groupTypes",
+  "instanceGrants",
+  "collectionGrants",
+];
+
+test.describe("Permissions page against a failing grants endpoint", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "admin" });
+  });
+
+  test("stops requesting after the endpoints fail", async ({ page }) => {
+    // 404 rather than 500 on purpose: queryClient treats 404 as
+    // non-retryable, so each attempt settles immediately. A retryable
+    // status would let backoff hide the loop behind its delays.
+    // Forcing the failure rather than relying on the mock server having no
+    // adminPermissions routes keeps this meaningful once those routes exist.
+    await page.route("**/adminPermissions/**", (route) =>
+      route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Simulated failure" }),
+      })
+    );
+
+    const requestsByEndpoint = new Map<string, number>();
+    page.on("request", (req) => {
+      const endpoint = GRANT_ENDPOINTS.find((name) =>
+        req.url().includes(`/adminPermissions/${name}`)
+      );
+      if (!endpoint) return;
+      requestsByEndpoint.set(
+        endpoint,
+        (requestsByEndpoint.get(endpoint) ?? 0) + 1
+      );
+    });
+
+    await page.goto("/admin/permissions");
+    await page.waitForTimeout(OBSERVATION_MS);
+
+    for (const endpoint of GRANT_ENDPOINTS) {
+      const count = requestsByEndpoint.get(endpoint) ?? 0;
+      // A count of zero means the page never got far enough to ask, so
+      // the bound below would pass for the wrong reason.
+      expect(count, `${endpoint} was never requested`).toBeGreaterThan(0);
+      expect(
+        count,
+        `${endpoint} was requested too many times`
+      ).toBeLessThanOrEqual(MAX_REQUESTS_PER_ENDPOINT);
+    }
+  });
+
+  test("still loads normally when the endpoints succeed", async ({ page }) => {
+    // The mock server has no adminPermissions routes yet, so the healthy
+    // path has to be stubbed to be tested at all.
+    for (const endpoint of GRANT_ENDPOINTS) {
+      await page.route(`**/adminPermissions/${endpoint}`, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ [endpoint]: [] }),
+        })
+      );
+    }
+
+    await page.goto("/admin/permissions");
+
+    await expect(
+      page.getByRole("heading", { name: "Permissions" })
+    ).toBeVisible();
+    // The skeletons clear and the empty table settles.
+    await expect(
+      page.getByRole("button", { name: "Add Permission" }).first()
+    ).toBeVisible();
+    await expect(page.locator("[data-add-permission-form]")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
This fixes a runaway request loop on `/admin/permissions` when the `/adminPermissions/*` endpoints fail.  (These requests would fail because of a missing mock admin permissions endpoint).

For example:
<img width="800"  alt="CleanShot 2026-07-27 at 12 40 24@2x" src="https://github.com/user-attachments/assets/f9825e38-822c-4b12-b99c-dae07d0da491" />


The cause: we were using `v-if="isLoading"` to render the skeleton, and `v-else` to render the table. Once the request(s) were no longer pending, the table attempted to render, which — since we didn't have any data — triggered another request, putting us back in `isPending`. The flapping between `isLoading` and not loading triggered hundreds of requests per second.

The fix is to account for the error state: `loading` shows skeleton, `success` builds table, and `error` shows error (which avoids retriggering queries).


So, fixes all together:
- Implements the `/adminPermissions/*` mock server routes whose absence caused the 404s in dev, so the page now works locally and the healthy-path e2e test runs against real seeded data.
- Handle error state
- Include missing instanceNav query
- move `AddPermissionRow` outside of the main table, to avoid retriggering queries.
- similar fixes for Group Access table.