### PR TITLE
choose error notification by status

### DIFF
--- a/src/api/chooseErrorNotification.test.ts
+++ b/src/api/chooseErrorNotification.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { chooseErrorNotification } from "./chooseErrorNotification";
+
+describe("chooseErrorNotification", () => {
+  it("blocks with the modal on a network error", () => {
+    expect(chooseErrorNotification(0)).toBe("modal");
+  });
+
+  it("blocks with the modal on server errors", () => {
+    expect(chooseErrorNotification(500)).toBe("modal");
+    expect(chooseErrorNotification(502)).toBe("modal");
+    expect(chooseErrorNotification(599)).toBe("modal");
+  });
+
+  it("toasts on a 404", () => {
+    expect(chooseErrorNotification(404)).toBe("toast");
+  });
+
+  it("toasts on a 403", () => {
+    expect(chooseErrorNotification(403)).toBe("toast");
+  });
+
+  it("toasts on 400 and other 4xx statuses", () => {
+    expect(chooseErrorNotification(400)).toBe("toast");
+    expect(chooseErrorNotification(409)).toBe("toast");
+    expect(chooseErrorNotification(422)).toBe("toast");
+  });
+
+  it("stays silent on a 401", () => {
+    expect(chooseErrorNotification(401)).toBe("none");
+  });
+
+  it("stays silent on a 410", () => {
+    expect(chooseErrorNotification(410)).toBe("none");
+  });
+});

--- a/src/api/chooseErrorNotification.ts
+++ b/src/api/chooseErrorNotification.ts
@@ -1,4 +1,4 @@
-export type ErrorNotification = "modal" | "toast" | "none";
+type ErrorNotification = "modal" | "toast" | "none";
 
 /**
  * Decide how the global interceptor surfaces a failed request.

--- a/src/api/chooseErrorNotification.ts
+++ b/src/api/chooseErrorNotification.ts
@@ -1,0 +1,23 @@
+export type ErrorNotification = "modal" | "toast" | "none";
+
+/**
+ * Decide how the global interceptor surfaces a failed request.
+ *
+ * Network failures (status 0) and 5xx block with the modal, since nothing
+ * works and retrying will not help. 401 and 410 are silent because pages own
+ * those flows: route meta gates sign-in and AssetViewPage renders the
+ * deleted-asset notice. Everything else is scoped to one request and toasts.
+ */
+export function chooseErrorNotification(statusCode: number): ErrorNotification {
+  if (statusCode === 401 || statusCode === 410) {
+    return "none";
+  }
+
+  const isNetworkError = statusCode === 0;
+  const isServerError = statusCode >= 500 && statusCode < 600;
+  if (isNetworkError || isServerError) {
+    return "modal";
+  }
+
+  return "toast";
+}

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -89,7 +89,9 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
     return Promise.reject(err);
   }
 
-  const customConfig = err.config as CustomAxiosRequestConfig;
+  // config is missing when the error came from a request interceptor
+  // rather than a response
+  const customConfig = err.config as CustomAxiosRequestConfig | undefined;
 
   let apiError: ApiError;
 
@@ -107,7 +109,7 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
     apiError = new ApiError(err.message, 0); // Use 0 as the status code to signal a network error.
   }
 
-  if (!customConfig.skipErrorNotifications) {
+  if (!customConfig?.skipErrorNotifications) {
     const notification = chooseErrorNotification(apiError.statusCode);
 
     if (notification === "modal") {

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -77,9 +77,6 @@ const BASE_URL = config.instance.base.url;
 
 axios.defaults.withCredentials = true;
 
-// this interceptor converts failed responses into ApiErrors and notifies
-// the user per chooseErrorNotification: the blocking modal via errorStore,
-// a toast via toastStore, or nothing
 axios.interceptors.response.use(undefined, async (err: AxiosError) => {
   // A request aborted via AbortSignal (e.g. TanStack Query superseding a
   // stale autocomplete fetch) isn't a failure. Reject quietly so it never

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -67,7 +67,10 @@ import { FileMetaData } from "@/types/FileMetaDataTypes";
 import { FileDownloadResponse } from "@/types/FileDownloadTypes";
 import { getExtensionFromFilename } from "@/helpers/getExtensionFromFilename";
 import { ApiError } from "./ApiError";
+import { chooseErrorNotification } from "./chooseErrorNotification";
+import { getErrorMessage } from "./getErrorMessage";
 import { useErrorStore } from "@/stores/errorStore";
+import { useToastStore } from "@/stores/toastStore";
 import { toClickToSearchUrl } from "@/helpers/displayUtils";
 
 const BASE_URL = config.instance.base.url;
@@ -88,7 +91,6 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
 
   const customConfig = err.config as CustomAxiosRequestConfig;
 
-  const errorStore = useErrorStore();
   let apiError: ApiError;
 
   if (err.response) {
@@ -105,13 +107,16 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
     apiError = new ApiError(err.message, 0); // Use 0 as the status code to signal a network error.
   }
 
-  if (
-    !customConfig.skipErrorNotifications &&
-    apiError.statusCode !== 401 &&
-    apiError.statusCode !== 410
-  ) {
-    // Add the ApiError to the errorStore
-    errorStore.setError(apiError);
+  if (!customConfig.skipErrorNotifications) {
+    const notification = chooseErrorNotification(apiError.statusCode);
+
+    if (notification === "modal") {
+      useErrorStore().setError(apiError);
+    }
+
+    if (notification === "toast") {
+      useToastStore().error(getErrorMessage(apiError));
+    }
   }
 
   return Promise.reject(apiError);

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -114,7 +114,17 @@ axios.interceptors.response.use(undefined, async (err: AxiosError) => {
     }
 
     if (notification === "toast") {
-      useToastStore().error(getErrorMessage(apiError));
+      const toastStore = useToastStore();
+      const message = getErrorMessage(apiError);
+      const isMessageAlreadyShowing = toastStore.toasts.some(
+        (toast) => toast.variant === "error" && toast.message === message
+      );
+
+      // A failed query retries, and every attempt lands here, so a message
+      // already on screen means this failure is reported.
+      if (!isMessageAlreadyShowing) {
+        toastStore.error(message);
+      }
     }
   }
 

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -77,9 +77,9 @@ const BASE_URL = config.instance.base.url;
 
 axios.defaults.withCredentials = true;
 
-// this interceptor is used to catch errors from the API
-// convert them into API errors and store them in the error store
-// so that they're displayed to the user
+// this interceptor converts failed responses into ApiErrors and notifies
+// the user per chooseErrorNotification: the blocking modal via errorStore,
+// a toast via toastStore, or nothing
 axios.interceptors.response.use(undefined, async (err: AxiosError) => {
   // A request aborted via AbortSignal (e.g. TanStack Query superseding a
   // stale autocomplete fetch) isn't a failure. Reject quietly so it never

--- a/src/api/getErrorMessage.test.ts
+++ b/src/api/getErrorMessage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { getErrorMessage } from "./getErrorMessage";
+import { ApiError } from "./ApiError";
+
+describe("getErrorMessage", () => {
+  it("maps known statuses to their friendly text", () => {
+    expect(getErrorMessage(new ApiError("nope", 404))).toBe(
+      "We couldn't find this. Please check your link and try again."
+    );
+    expect(getErrorMessage(new ApiError("nope", 0))).toBe(
+      "There was a problem connecting to the server. If the problem persists, please contact support."
+    );
+    expect(getErrorMessage(new ApiError("nope", 403))).toBe(
+      "You do not have permission to access this."
+    );
+  });
+
+  it("falls back to the 400 message for unmapped 4xx statuses", () => {
+    expect(getErrorMessage(new ApiError("nope", 418))).toBe(
+      "There was a problem with your request. Please check your input and try again."
+    );
+  });
+
+  it("falls back to the 500 message for unmapped 5xx statuses", () => {
+    expect(getErrorMessage(new ApiError("nope", 503))).toBe(
+      "There was a problem on our end. Please contact support if the problem persists."
+    );
+  });
+
+  it("uses the error's own message for statuses outside the maps", () => {
+    expect(getErrorMessage(new ApiError("weird status", 302))).toBe(
+      "weird status"
+    );
+  });
+
+  it("uses a plain Error's own message", () => {
+    expect(getErrorMessage(new Error("route failed"))).toBe("route failed");
+  });
+
+  it("falls back to a generic message when there is no message to show", () => {
+    expect(getErrorMessage(null)).toBe("An unknown error occurred.");
+    expect(getErrorMessage(new Error(""))).toBe("An unknown error occurred.");
+  });
+});

--- a/src/api/getErrorMessage.ts
+++ b/src/api/getErrorMessage.ts
@@ -13,7 +13,8 @@ const messagesByStatus: Record<number, string> = {
  * Map an error to the friendly text shown in the error modal and toasts.
  *
  * Unmapped 4xx and 5xx statuses fall back to the 400 and 500 messages.
- * Anything that is not an ApiError falls back to its own message.
+ * Anything that is not an ApiError falls back to its own message, or a
+ * generic message when there is none.
  */
 export function getErrorMessage(error: unknown): string {
   if (!(error instanceof ApiError)) {

--- a/src/api/getErrorMessage.ts
+++ b/src/api/getErrorMessage.ts
@@ -1,0 +1,41 @@
+import { ApiError } from "./ApiError";
+
+const messagesByStatus: Record<number, string> = {
+  0: "There was a problem connecting to the server. If the problem persists, please contact support.",
+  400: "There was a problem with your request. Please check your input and try again.",
+  401: "You do not have permission to access this.",
+  403: "You do not have permission to access this.",
+  404: "We couldn't find this. Please check your link and try again.",
+  500: "There was a problem on our end. Please contact support if the problem persists.",
+};
+
+/**
+ * Map an error to the friendly text shown in the error modal and toasts.
+ *
+ * Unmapped 4xx and 5xx statuses fall back to the 400 and 500 messages.
+ * Anything that is not an ApiError falls back to its own message.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (!(error instanceof ApiError)) {
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+    return "An unknown error occurred.";
+  }
+
+  const status = error.statusCode;
+
+  if (status in messagesByStatus) {
+    return messagesByStatus[status];
+  }
+
+  if (status >= 400 && status < 500) {
+    return messagesByStatus[400];
+  }
+
+  if (status >= 500 && status < 600) {
+    return messagesByStatus[500];
+  }
+
+  return error.message;
+}

--- a/src/components/ErrorModal/ErrorModal.vue
+++ b/src/components/ErrorModal/ErrorModal.vue
@@ -4,10 +4,7 @@
       <div
         v-if="error"
         class="fixed inset-0 z-40 bg-scrim flex items-center justify-center">
-        <SignInRequiredNotice v-if="isCurrentUserUnauthenticated" />
-
         <Notification
-          v-else
           :title="errorTitle"
           :message="error.name"
           type="danger"
@@ -25,7 +22,7 @@ import { computed } from "vue";
 import { useErrorStore } from "@/stores/errorStore";
 import Notification from "../Notification/Notification.vue";
 import { ApiError } from "@/api/ApiError";
-import SignInRequiredNotice from "@/pages/HomePage/SignInRequiredNotice.vue";
+import { getErrorMessage } from "@/api/getErrorMessage";
 
 const errorStore = useErrorStore();
 
@@ -41,42 +38,7 @@ const errorTitle = computed(() => {
 
   return `Error: ${error.value.statusCode}`;
 });
-const isCurrentUserUnauthenticated = computed(() => {
-  return error.value instanceof ApiError && error.value.statusCode === 401;
-});
 
-const messages: Record<number | string, string> = {
-  0: "There was a problem connecting to the server. If the problem persists, please contact support.",
-  401: "You do not have permission to access this.",
-  403: "You do not have permission to access this.",
-  404: "We couldn't find this. Please check your link and try again.",
-
-  // 4xx errors
-  400: "There was a problem with your request. Please check your input and try again.",
-
-  // 5xx errors
-  500: "There was a problem on our end. Please contact support if the problem persists.",
-};
-
-const message = computed(() => {
-  if (!(error.value instanceof ApiError)) {
-    return error.value?.message || "An unknown error occurred.";
-  }
-
-  const status = error.value.statusCode;
-  if (status in messages) {
-    return messages[status];
-  }
-
-  if (status >= 400 && status < 500) {
-    return messages[400];
-  }
-
-  if (status >= 500 && status < 600) {
-    return messages[500];
-  }
-
-  return error.value.message;
-});
+const message = computed(() => getErrorMessage(error.value));
 </script>
 <style scoped></style>

--- a/src/components/ToastRoot/ToastRoot.test.ts
+++ b/src/components/ToastRoot/ToastRoot.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { useToastStore } from "@/stores/toastStore";
+import ToastRoot from "./ToastRoot.vue";
+
+describe("ToastRoot", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe("the screen reader live region", () => {
+    it("holds the toast messages", () => {
+      const toastStore = useToastStore();
+      toastStore.error("first failure");
+      toastStore.error("second failure");
+
+      const wrapper = mount(ToastRoot);
+      const liveRegion = wrapper.get("[aria-live]");
+
+      expect(liveRegion.findAll(".toast-root__toast")).toHaveLength(2);
+      expect(liveRegion.text()).toContain("first failure");
+      expect(liveRegion.text()).toContain("second failure");
+    });
+
+    it("excludes Clear All, which appears and disappears with the toast count", () => {
+      const toastStore = useToastStore();
+      toastStore.error("first failure");
+      toastStore.error("second failure");
+
+      const wrapper = mount(ToastRoot);
+
+      expect(wrapper.text()).toContain("Clear All");
+      expect(wrapper.get("[aria-live]").text()).not.toContain("Clear All");
+    });
+  });
+});

--- a/src/components/ToastRoot/ToastRoot.vue
+++ b/src/components/ToastRoot/ToastRoot.vue
@@ -1,5 +1,7 @@
 <template>
   <div
+    role="status"
+    aria-live="polite"
     class="toast-root fixed bottom-4 right-0 z-50 p-4 w-full max-w-sm pointer-events-none flex flex-col items-end gap-1">
     <button
       v-if="toastStore.toasts.length > 1"

--- a/src/components/ToastRoot/ToastRoot.vue
+++ b/src/components/ToastRoot/ToastRoot.vue
@@ -1,6 +1,12 @@
 <template>
   <div
     class="toast-root fixed bottom-4 right-0 z-50 p-4 w-full max-w-sm pointer-events-none flex flex-col items-end gap-1">
+    <button
+      v-if="toastStore.toasts.length > 1"
+      class="pointer-events-auto text-xs uppercase py-1 px-2 rounded-md shadow-md bg-inverse-surface text-inverse-on-surface opacity-80 hover:opacity-100"
+      @click="toastStore.clearAll()">
+      Clear All
+    </button>
     <TransitionGroup name="fade">
       <Toast
         v-for="toast in toastStore.toasts"

--- a/src/components/ToastRoot/ToastRoot.vue
+++ b/src/components/ToastRoot/ToastRoot.vue
@@ -1,7 +1,5 @@
 <template>
   <div
-    role="status"
-    aria-live="polite"
     class="toast-root fixed bottom-4 right-0 z-50 p-4 w-full max-w-sm pointer-events-none flex flex-col items-end gap-1">
     <button
       v-if="toastStore.toasts.length > 1"
@@ -9,7 +7,14 @@
       @click="toastStore.clearAll()">
       Clear All
     </button>
-    <TransitionGroup name="fade">
+    <!-- Clear All sits outside the live region: it appears and disappears
+         with the toast count, and each change would be announced. -->
+    <TransitionGroup
+      tag="div"
+      name="fade"
+      role="status"
+      aria-live="polite"
+      class="w-full flex flex-col gap-1">
       <Toast
         v-for="toast in toastStore.toasts"
         :key="toast.id"

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -24,6 +24,10 @@ export const useToastStore = defineStore("toastStore", {
       this.toasts.splice(index, 1);
     },
 
+    clearAll() {
+      this.toasts = [];
+    },
+
     error(
       message: string,
       options?: Omit<Toast, "id" | "message" | "variant">

--- a/tests/e2e/error-notifications.spec.ts
+++ b/tests/e2e/error-notifications.spec.ts
@@ -104,8 +104,8 @@ test.describe("error notifications by status", () => {
     const toasts = page.locator(".toast-root__toast");
     await expect(toasts).toHaveCount(1, { timeout: 10000 });
 
-    await expect(
-      page.getByRole("button", { name: "Clear All" })
-    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Clear All" })).toHaveCount(
+      0
+    );
   });
 });

--- a/tests/e2e/error-notifications.spec.ts
+++ b/tests/e2e/error-notifications.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from "@playwright/test";
+import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
+
+// Asset 1 from the mock db: one saved file in its upload widget, so the edit
+// page issues exactly one getMetadataForObject request we can force to fail.
+const SINGLE_FILE_ASSET_ID = "6875871d4eb080a4880a0f44";
+
+const METADATA_ROUTE = "**/fileManager/getMetadataForObject/**";
+
+// The friendly text getErrorMessage maps each status to.
+const NOT_FOUND_MESSAGE =
+  "We couldn't find this. Please check your link and try again.";
+const SERVER_ERROR_MESSAGE =
+  "There was a problem on our end. Please contact support if the problem persists.";
+
+async function stubMetadataStatus(page: Page, status: number) {
+  await page.route(METADATA_ROUTE, (route) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unknownFile" }),
+    })
+  );
+}
+
+test.describe("error notifications by status", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.route("**/arcgis.com/**", (route) => route.abort());
+    await page.route("**/basemaps-api.arcgis.com/**", (route) => route.abort());
+
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+    await loginUser({ request, page, workerId, username: "curator" });
+  });
+
+  test("a 404 shows a dismissable toast and leaves the page interactive", async ({
+    page,
+  }) => {
+    await stubMetadataStatus(page, 404);
+
+    await page.goto(`/assetManager/editAsset/${SINGLE_FILE_ASSET_ID}`);
+
+    const toastRoot = page.locator(".toast-root");
+    const errorModal = page.locator(".error-modal");
+
+    await expect(toastRoot.getByText(NOT_FOUND_MESSAGE)).toBeVisible({
+      timeout: 10000,
+    });
+
+    // The blocking modal must not appear for a 404.
+    await expect(
+      errorModal.getByRole("heading", { name: "Error: 404" })
+    ).toHaveCount(0);
+
+    // The page behind the toast stays usable: no scrim intercepts input.
+    const titleField = page.getByLabel(/title/i).first();
+    await titleField.fill("Still editable behind the toast");
+    await expect(titleField).toHaveValue("Still editable behind the toast");
+
+    // The toast itself can be dismissed.
+    await toastRoot.getByRole("button", { name: "Close" }).click();
+    await expect(toastRoot.getByText(NOT_FOUND_MESSAGE)).toHaveCount(0);
+  });
+
+  test("a 500 keeps the blocking error modal", async ({ page }) => {
+    await stubMetadataStatus(page, 500);
+
+    await page.goto(`/assetManager/editAsset/${SINGLE_FILE_ASSET_ID}`);
+
+    const errorModal = page.locator(".error-modal");
+
+    await expect(
+      errorModal.getByRole("heading", { name: "Error: 500" })
+    ).toBeVisible({ timeout: 10000 });
+    await expect(errorModal.getByText(SERVER_ERROR_MESSAGE)).toBeVisible();
+  });
+});

--- a/tests/e2e/error-notifications.spec.ts
+++ b/tests/e2e/error-notifications.spec.ts
@@ -5,6 +5,9 @@ import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
 // page issues exactly one getMetadataForObject request we can force to fail.
 const SINGLE_FILE_ASSET_ID = "6875871d4eb080a4880a0f44";
 
+// Five saved files, so a forced 404 yields one error toast per file.
+const MULTI_FILE_ASSET_ID = "glacier_mixed_asset_001";
+
 const METADATA_ROUTE = "**/fileManager/getMetadataForObject/**";
 
 // The friendly text getErrorMessage maps each status to.
@@ -74,5 +77,35 @@ test.describe("error notifications by status", () => {
       errorModal.getByRole("heading", { name: "Error: 500" })
     ).toBeVisible({ timeout: 10000 });
     await expect(errorModal.getByText(SERVER_ERROR_MESSAGE)).toBeVisible();
+  });
+
+  test("Clear All dismisses every toast at once", async ({ page }) => {
+    await stubMetadataStatus(page, 404);
+
+    await page.goto(`/assetManager/editAsset/${MULTI_FILE_ASSET_ID}`);
+
+    const toasts = page.locator(".toast-root__toast");
+    await expect(toasts.nth(1)).toBeVisible({ timeout: 10000 });
+
+    const clearAllButton = page.getByRole("button", { name: "Clear All" });
+    await expect(clearAllButton).toBeVisible();
+
+    await clearAllButton.click();
+
+    await expect(toasts).toHaveCount(0);
+    await expect(clearAllButton).toHaveCount(0);
+  });
+
+  test("Clear All is not offered for a single toast", async ({ page }) => {
+    await stubMetadataStatus(page, 404);
+
+    await page.goto(`/assetManager/editAsset/${SINGLE_FILE_ASSET_ID}`);
+
+    const toasts = page.locator(".toast-root__toast");
+    await expect(toasts).toHaveCount(1, { timeout: 10000 });
+
+    await expect(
+      page.getByRole("button", { name: "Clear All" })
+    ).toHaveCount(0);
   });
 });

--- a/tests/e2e/error-notifications.spec.ts
+++ b/tests/e2e/error-notifications.spec.ts
@@ -5,8 +5,11 @@ import { setupWorkerHTTPHeader, refreshDatabase, loginUser } from "../setup";
 // page issues exactly one getMetadataForObject request we can force to fail.
 const SINGLE_FILE_ASSET_ID = "6875871d4eb080a4880a0f44";
 
-// Five saved files, so a forced 404 yields one error toast per file.
+// Five saved files, so several metadata requests fail from one page load.
 const MULTI_FILE_ASSET_ID = "glacier_mixed_asset_001";
+
+// One of the five files on that asset.
+const FORBIDDEN_FILE_ID = "goldy-M";
 
 const METADATA_ROUTE = "**/fileManager/getMetadataForObject/**";
 
@@ -115,14 +118,24 @@ test.describe("error notifications by status", () => {
   });
 
   test("Clear All dismisses every toast at once", async ({ page }) => {
-    await stubMetadataStatus(page, 404);
+    // goldy-M answers 403 and the other four files 404, so two distinct
+    // messages survive the dedupe and there is more than one toast to clear.
+    await page.route(METADATA_ROUTE, (route) => {
+      const isForbiddenFile = route.request().url().includes(FORBIDDEN_FILE_ID);
+
+      return route.fulfill({
+        status: isForbiddenFile ? 403 : 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "unknownFile" }),
+      });
+    });
 
     await page.goto(`/assetManager/editAsset/${MULTI_FILE_ASSET_ID}`);
 
-    // All five failures must land before clearing, or a straggler toast
+    // Both failures must land before clearing, or a straggler toast
     // arriving after the click would repopulate the list.
     const toasts = page.locator(".toast-root__toast");
-    await expect(toasts).toHaveCount(5, { timeout: 10000 });
+    await expect(toasts).toHaveCount(2, { timeout: 10000 });
 
     const clearAllButton = page.getByRole("button", { name: "Clear All" });
     await expect(clearAllButton).toBeVisible();

--- a/tests/e2e/error-notifications.spec.ts
+++ b/tests/e2e/error-notifications.spec.ts
@@ -51,7 +51,6 @@ test.describe("error notifications by status", () => {
       timeout: 10000,
     });
 
-    // The blocking modal must not appear for a 404.
     await expect(
       errorModal.getByRole("heading", { name: "Error: 404" })
     ).toHaveCount(0);
@@ -61,7 +60,6 @@ test.describe("error notifications by status", () => {
     await titleField.fill("Still editable behind the toast");
     await expect(titleField).toHaveValue("Still editable behind the toast");
 
-    // The toast itself can be dismissed.
     await toastRoot.getByRole("button", { name: "Close" }).click();
     await expect(toastRoot.getByText(NOT_FOUND_MESSAGE)).toHaveCount(0);
   });
@@ -79,13 +77,33 @@ test.describe("error notifications by status", () => {
     await expect(errorModal.getByText(SERVER_ERROR_MESSAGE)).toBeVisible();
   });
 
+  test("a 410 stays silent: no toast, no modal", async ({ page }) => {
+    await stubMetadataStatus(page, 410);
+
+    const metadataFailure = page.waitForResponse((response) =>
+      response.url().includes("/fileManager/getMetadataForObject/")
+    );
+    await page.goto(`/assetManager/editAsset/${SINGLE_FILE_ASSET_ID}`);
+    await metadataFailure;
+
+    // Settle a render before asserting nothing appeared.
+    await expect(page.getByLabel(/title/i).first()).toBeVisible();
+
+    await expect(page.locator(".toast-root__toast")).toHaveCount(0);
+    await expect(page.locator(".error-modal").getByRole("heading")).toHaveCount(
+      0
+    );
+  });
+
   test("Clear All dismisses every toast at once", async ({ page }) => {
     await stubMetadataStatus(page, 404);
 
     await page.goto(`/assetManager/editAsset/${MULTI_FILE_ASSET_ID}`);
 
+    // All five failures must land before clearing, or a straggler toast
+    // arriving after the click would repopulate the list.
     const toasts = page.locator(".toast-root__toast");
-    await expect(toasts.nth(1)).toBeVisible({ timeout: 10000 });
+    await expect(toasts).toHaveCount(5, { timeout: 10000 });
 
     const clearAllButton = page.getByRole("button", { name: "Clear All" });
     await expect(clearAllButton).toBeVisible();

--- a/tests/e2e/error-notifications.spec.ts
+++ b/tests/e2e/error-notifications.spec.ts
@@ -95,6 +95,25 @@ test.describe("error notifications by status", () => {
     );
   });
 
+  test("repeated identical failures show one toast", async ({ page }) => {
+    await stubMetadataStatus(page, 404);
+
+    const failures: string[] = [];
+    page.on("response", (response) => {
+      if (response.url().includes("/fileManager/getMetadataForObject/")) {
+        failures.push(response.url());
+      }
+    });
+
+    await page.goto(`/assetManager/editAsset/${MULTI_FILE_ASSET_ID}`);
+
+    // Wait for every file to fail before counting, so one toast is the
+    // deduped result rather than the others not having arrived yet.
+    await expect.poll(() => failures.length, { timeout: 10000 }).toBe(5);
+
+    await expect(page.locator(".toast-root__toast")).toHaveCount(1);
+  });
+
   test("Clear All dismisses every toast at once", async ({ page }) => {
     await stubMetadataStatus(page, 404);
 


### PR DESCRIPTION
- resolves #490 
- resolves #584 
- Changes to a more systematic approach for showing request errors. Modals only for 5xx errors, or 0 (network errors). 401 and 410 are handled by pages. Others show a toast.
- Adds a "Clear All" button for toasts
- announces errors with `aria-live=polite`

