### PR TITLE
Make form controls follow the active theme

### DIFF
--- a/src/components/AddToDrawerButton/AddExcerptToDrawerSection.vue
+++ b/src/components/AddToDrawerButton/AddExcerptToDrawerSection.vue
@@ -25,12 +25,9 @@
         label="Excerpt Name"
         placeholder="Excerpt Name"
         class="flex-1 text-sm"
-        :inputClass="[
-          '!bg-surface-container border !border-outline-variant',
-          {
-            '!border !border-error': !excerptName && isNameTouched,
-          },
-        ]"
+        :inputClass="{
+          '!border-error': !excerptName && isNameTouched,
+        }"
         @update:modelValue="
           (val) => {
             isNameTouched = true;
@@ -46,13 +43,9 @@
           placeholder="00:00"
           type="text"
           class="flex-1 text-sm"
-          :inputClass="
-            cn([
-              {
-                '!border-error': isStartTimeTouched && !startTimeString,
-              },
-            ])
-          "
+          :inputClass="{
+            '!border-error': isStartTimeTouched && !startTimeString,
+          }"
           @update:modelValue="
             (str) => {
               isStartTimeTouched = true;
@@ -81,11 +74,9 @@
           placeholder="00:00"
           type="text"
           class="flex-1 text-sm"
-          :inputClass="[
-            {
-              '!border-error': isEndTimeTouched && !endTimeString,
-            },
-          ]"
+          :inputClass="{
+            '!border-error': isEndTimeTouched && !endTimeString,
+          }"
           @update:modelValue="
             (str) => {
               isEndTimeTouched = true;
@@ -127,7 +118,6 @@ import {
   timeStringToSeconds,
 } from "@/helpers/excerptHelpers";
 import ExcerptableIframe from "../ExcerptableIframe/ExcerptableIframe.vue";
-import { cn } from "@/lib/utils.js";
 
 const props = defineProps<{
   isAddingExcerpt: boolean;

--- a/src/components/AddToDrawerButton/AddExcerptToDrawerSection.vue
+++ b/src/components/AddToDrawerButton/AddExcerptToDrawerSection.vue
@@ -46,12 +46,13 @@
           placeholder="00:00"
           type="text"
           class="flex-1 text-sm"
-          :inputClass="[
-            '!bg-white border !border-outline-variant',
-            {
-              '!border !border-error': isStartTimeTouched && !startTimeString,
-            },
-          ]"
+          :inputClass="
+            cn([
+              {
+                '!border-error': isStartTimeTouched && !startTimeString,
+              },
+            ])
+          "
           @update:modelValue="
             (str) => {
               isStartTimeTouched = true;
@@ -81,9 +82,8 @@
           type="text"
           class="flex-1 text-sm"
           :inputClass="[
-            '!bg-white border !border-outline-variant',
             {
-              '!border !border-error': isEndTimeTouched && !endTimeString,
+              '!border-error': isEndTimeTouched && !endTimeString,
             },
           ]"
           @update:modelValue="
@@ -127,6 +127,7 @@ import {
   timeStringToSeconds,
 } from "@/helpers/excerptHelpers";
 import ExcerptableIframe from "../ExcerptableIframe/ExcerptableIframe.vue";
+import { cn } from "@/lib/utils.js";
 
 const props = defineProps<{
   isAddingExcerpt: boolean;

--- a/src/components/AddToDrawerButton/AddToDrawerButton.vue
+++ b/src/components/AddToDrawerButton/AddToDrawerButton.vue
@@ -35,8 +35,11 @@
             }"
             @update:modelValue="isSelectDrawerTouched = true" />
 
-          <label class="text-xs uppercase font-medium">Existing Drawer</label>
+          <label :for="existingDrawerSelectId" class="text-xs uppercase font-medium">
+            Existing Drawer
+          </label>
           <select
+            :id="existingDrawerSelectId"
             v-model="selectedDrawer"
             class="border border-outline-variant rounded w-full text-sm bg-surface-container-low"
             :class="{
@@ -108,7 +111,7 @@
   </Modal>
 </template>
 <script setup lang="ts">
-import { ref, computed, reactive, watch, onMounted, Ref } from "vue";
+import { ref, computed, reactive, watch, onMounted, Ref, useId } from "vue";
 import Button from "@/components/Button/Button.vue";
 import Modal from "@/components/Modal/Modal.vue";
 import { useDrawerStore } from "@/stores/drawerStore";
@@ -128,6 +131,7 @@ const props = defineProps<{
 
 const isModalOpen = ref(false);
 const selectedDrawer = ref("");
+const existingDrawerSelectId = useId();
 const newDrawerName = ref("");
 const fetchStatus = ref<FetchStatus>("idle");
 const isAddingExcerpt = ref(false);

--- a/src/components/AddToDrawerButton/AddToDrawerButton.vue
+++ b/src/components/AddToDrawerButton/AddToDrawerButton.vue
@@ -34,27 +34,6 @@
                 !exactlyOneDrawerIsChosen && isSelectDrawerTouched,
             }"
             @update:modelValue="isSelectDrawerTouched = true" />
-
-          <label :for="existingDrawerSelectId" class="text-xs uppercase font-medium">
-            Existing Drawer
-          </label>
-          <select
-            :id="existingDrawerSelectId"
-            v-model="selectedDrawer"
-            class="border border-outline-variant rounded w-full text-sm bg-surface-container-low"
-            :class="{
-              ' !border-error text-error':
-                !exactlyOneDrawerIsChosen && isSelectDrawerTouched,
-            }"
-            @update:modelValue="isSelectDrawerTouched = true">
-            <option value="">-</option>
-            <option
-              v-for="drawer in drawerStore.drawers"
-              :key="drawer.id"
-              :value="drawer.id">
-              {{ drawer.title }}
-            </option>
-          </select>
         </div>
 
         <p
@@ -111,7 +90,7 @@
   </Modal>
 </template>
 <script setup lang="ts">
-import { ref, computed, reactive, watch, onMounted, Ref, useId } from "vue";
+import { ref, computed, reactive, watch, onMounted, Ref } from "vue";
 import Button from "@/components/Button/Button.vue";
 import Modal from "@/components/Modal/Modal.vue";
 import { useDrawerStore } from "@/stores/drawerStore";
@@ -131,7 +110,6 @@ const props = defineProps<{
 
 const isModalOpen = ref(false);
 const selectedDrawer = ref("");
-const existingDrawerSelectId = useId();
 const newDrawerName = ref("");
 const fetchStatus = ref<FetchStatus>("idle");
 const isAddingExcerpt = ref(false);

--- a/src/components/AddToDrawerButton/AddToDrawerButton.vue
+++ b/src/components/AddToDrawerButton/AddToDrawerButton.vue
@@ -67,7 +67,7 @@
           class="flex-1"
           label="New Drawer"
           :inputClass="[
-            'bg-surface placeholder-on-surface-variant border border-outline-variant rounded border-solid',
+            'bg-surface border border-outline-variant rounded border-solid',
             {
               '!border !border-error !text-error':
                 !exactlyOneDrawerIsChosen && isSelectDrawerTouched,

--- a/src/components/AdvancedSearchForm/CheckboxFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/CheckboxFieldOptions.vue
@@ -2,7 +2,7 @@
   <select
     :value="selectedOption"
     :aria-label="valueSelectLabel"
-    class="select-group__select"
+    class="themed-select"
     @change="handleSelectChange">
     <option value="boolean_true">{{ trueLabel }}</option>
     <option value="boolean_false">{{ falseLabel }}</option>
@@ -36,7 +36,7 @@ const field = computed(() => {
   );
 });
 
-const valueSelectLabel = computed(() =>
+const valueSelectLabel = computed((): string =>
   field.value ? `${field.value.label} value` : "Field value"
 );
 

--- a/src/components/AdvancedSearchForm/CheckboxFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/CheckboxFieldOptions.vue
@@ -1,6 +1,7 @@
 <template>
   <select
     :value="selectedOption"
+    :aria-label="valueSelectLabel"
     class="select-group__select"
     @change="handleSelectChange">
     <option value="boolean_true">{{ trueLabel }}</option>
@@ -34,6 +35,10 @@ const field = computed(() => {
     props.filter.fieldId
   );
 });
+
+const valueSelectLabel = computed(() =>
+  field.value ? `${field.value.label} value` : "Field value"
+);
 
 function handleSelectChange(event: Event) {
   const target = event.target as HTMLSelectElement;

--- a/src/components/AdvancedSearchForm/CheckboxFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/CheckboxFieldOptions.vue
@@ -1,7 +1,7 @@
 <template>
   <select
     :value="selectedOption"
-    class="rounded-md border-outline"
+    class="select-group__select"
     @change="handleSelectChange">
     <option value="boolean_true">{{ trueLabel }}</option>
     <option value="boolean_false">{{ falseLabel }}</option>

--- a/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalDateRow.vue
@@ -9,7 +9,6 @@
         id="filter-by-date-range-start-date"
         v-model="searchStore.filterBy.globalDateRange.startDate"
         class="text-sm"
-        inputClass="!bg-white !border !border-outline"
         label="Start Date"
         :labelHidden="true"
         placeholder="Start Date" />
@@ -18,7 +17,6 @@
         id="filter-by-date-range-end-date"
         v-model="searchStore.filterBy.globalDateRange.endDate"
         class="text-sm"
-        inputClass="!bg-white !border !border-outline"
         label="End Date"
         :labelHidden="true"
         :placeholder="`End Date`" />

--- a/src/components/AdvancedSearchForm/FilterByGlobalFileTypeRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalFileTypeRow.vue
@@ -6,7 +6,8 @@
     <select
       v-if="searchStore.filterBy.globalFileType"
       v-model="searchStore.filterBy.globalFileType.fileType"
-      class="select-group__select">
+      aria-label="File type"
+      class="themed-select">
       <option value="">All</option>
       <option v-for="opt in sortedOptions" :key="opt.label" :value="opt.value">
         {{ opt.label }}
@@ -81,4 +82,3 @@ const sortedOptions = [...fileTypeOptions].sort((a, b) =>
   a.label.localeCompare(b.label)
 ) as FileTypeOption[];
 </script>
-<style scoped></style>

--- a/src/components/AdvancedSearchForm/FilterByGlobalFileTypeRow.vue
+++ b/src/components/AdvancedSearchForm/FilterByGlobalFileTypeRow.vue
@@ -6,7 +6,7 @@
     <select
       v-if="searchStore.filterBy.globalFileType"
       v-model="searchStore.filterBy.globalFileType.fileType"
-      class="rounded-md w-full text-sm">
+      class="select-group__select">
       <option value="">All</option>
       <option v-for="opt in sortedOptions" :key="opt.label" :value="opt.value">
         {{ opt.label }}
@@ -81,13 +81,4 @@ const sortedOptions = [...fileTypeOptions].sort((a, b) =>
   a.label.localeCompare(b.label)
 ) as FileTypeOption[];
 </script>
-<style scoped>
-select {
-  background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23111' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5' /%3E%3C/svg%3E");
-  background-position: right 0.75rem center;
-  background-repeat: no-repeat;
-  background-size: 1rem;
-  padding-right: 2.5rem;
-  border-color: #e5e5e5;
-}
-</style>
+<style scoped></style>

--- a/src/components/AdvancedSearchForm/FilterBySpecificFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterBySpecificFieldsRow.vue
@@ -2,7 +2,7 @@
   <BaseFilterRow :rowIndex="rowIndex" @remove="handleRemoveFilter">
     <template #label>
       <select
-        class="rounded-md text-sm filter-row__name w-full border-outline bg-transparent"
+        class="select-group__select filter-row__name"
         :value="currentField.id"
         @change="handleFieldChange">
         <option

--- a/src/components/AdvancedSearchForm/FilterBySpecificFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterBySpecificFieldsRow.vue
@@ -3,7 +3,7 @@
     <template #label>
       <select
         aria-label="Filter field"
-        class="select-group__select filter-row__name"
+        class="themed-select filter-row__name"
         :value="currentField.id"
         @change="handleFieldChange">
         <option

--- a/src/components/AdvancedSearchForm/FilterBySpecificFieldsRow.vue
+++ b/src/components/AdvancedSearchForm/FilterBySpecificFieldsRow.vue
@@ -2,6 +2,7 @@
   <BaseFilterRow :rowIndex="rowIndex" @remove="handleRemoveFilter">
     <template #label>
       <select
+        aria-label="Filter field"
         class="select-group__select filter-row__name"
         :value="currentField.id"
         @change="handleFieldChange">
@@ -55,7 +56,7 @@
           type="checkbox"
           :checked="filter.isFuzzy"
           @change="handleIsFuzzyChange" />
-        <span aria-label="Fuzzy Search">Fuzzy</span>
+        <span>Fuzzy</span>
       </label>
     </template>
   </BaseFilterRow>

--- a/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/MultiSelectFieldOptions.vue
@@ -6,7 +6,6 @@
       :initialSelectedValues="props.filter.value.split(',')"
       class="!gap-1"
       labelClass="sr-only"
-      selectClass="text-sm border-outline"
       @change="handleCascadeSelectChange" />
   </div>
 </template>

--- a/src/components/AdvancedSearchForm/SelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/SelectFieldOptions.vue
@@ -1,6 +1,7 @@
 <template>
   <select
     :value="selectedOption"
+    :aria-label="valueSelectLabel"
     class="select-group__select"
     @change="handleSelectChange">
     <option v-for="opt in options" :key="opt" :value="opt">
@@ -31,6 +32,10 @@ const field = computed(() => {
     props.filter.fieldId
   );
 });
+
+const valueSelectLabel = computed(() =>
+  field.value ? `${field.value.label} value` : "Field value"
+);
 
 function handleSelectChange(event: Event) {
   const target = event.target as HTMLSelectElement;

--- a/src/components/AdvancedSearchForm/SelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/SelectFieldOptions.vue
@@ -2,7 +2,7 @@
   <select
     :value="selectedOption"
     :aria-label="valueSelectLabel"
-    class="select-group__select"
+    class="themed-select"
     @change="handleSelectChange">
     <option v-for="opt in options" :key="opt" :value="opt">
       {{ opt === "" ? "-" : opt }}
@@ -33,7 +33,7 @@ const field = computed(() => {
   );
 });
 
-const valueSelectLabel = computed(() =>
+const valueSelectLabel = computed((): string =>
   field.value ? `${field.value.label} value` : "Field value"
 );
 

--- a/src/components/AdvancedSearchForm/SelectFieldOptions.vue
+++ b/src/components/AdvancedSearchForm/SelectFieldOptions.vue
@@ -1,7 +1,7 @@
 <template>
   <select
     :value="selectedOption"
-    class="rounded-md w-full border-outline"
+    class="select-group__select"
     @change="handleSelectChange">
     <option v-for="opt in options" :key="opt" :value="opt">
       {{ opt === "" ? "-" : opt }}

--- a/src/components/AutoCompleteInput/AutoCompleteInput.vue
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.vue
@@ -11,7 +11,7 @@
         :placeholder="placeholder"
         :class="
           cn(
-            'block w-full rounded-md border border-outline-variant sm:text-sm py-2 bg-surface-container text-on-surface focus:bg-surface-bright px-4 placeholder:text-on-surface-muted',
+            'block w-full rounded-md border border-outline-variant sm:text-sm py-2 bg-surface-container text-on-surface focus:bg-surface-bright px-4',
             inputClass
           )
         "

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -15,8 +15,8 @@
         <select
           :class="
             cn([
-              'rounded-md text-sm bg-surface-container text-on-surface-container',
-              !selected.value && 'text-on-surface-variant',
+              'select-group__select',
+              !selected.value && 'text-on-surface-muted',
               selectClass,
             ])
           "

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -20,7 +20,6 @@
               selectClass,
             ])
           "
-          :style="{ width: '100%' }"
           :value="selected.value"
           @change="
             handleSelectChange(

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -16,7 +16,7 @@
           :class="
             cn([
               'select-group__select',
-              !selected.value && 'text-on-surface-muted',
+              !selected.value && 'text-on-surface-variant',
               selectClass,
             ])
           "

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -6,6 +6,7 @@
       class="flex flex-col gap-1">
       <div v-if="selected.options.length">
         <label
+          :for="`${selectIdPrefix}-${segmentLevel}`"
           :class="[
             'uppercase text-xs font-medium tracking-wider text-on-surface',
             labelClass,
@@ -13,6 +14,7 @@
           {{ selected.label }}
         </label>
         <select
+          :id="`${selectIdPrefix}-${segmentLevel}`"
           :class="
             cn([
               'select-group__select',
@@ -44,7 +46,7 @@
 <script setup lang="ts">
 import { cn } from "@/lib/utils";
 import { path } from "ramda";
-import { reactive, watch } from "vue";
+import { reactive, watch, useId } from "vue";
 
 export interface CascaderSelectOptions {
   [label: string]: string[] | CascaderSelectOptions;
@@ -60,6 +62,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   (eventName: "change", selectedValues: string[]): void;
 }>();
+
+// one id per segment select, namespaced per component instance
+const selectIdPrefix = useId();
 
 interface SelectedSegment {
   label: string;

--- a/src/components/CascadeSelect/CascadeSelect.vue
+++ b/src/components/CascadeSelect/CascadeSelect.vue
@@ -16,11 +16,7 @@
         <select
           :id="`${selectIdPrefix}-${segmentLevel}`"
           :class="
-            cn([
-              'select-group__select',
-              !selected.value && 'text-on-surface-variant',
-              selectClass,
-            ])
+            cn(['themed-select', !selected.value && 'text-on-surface-variant'])
           "
           :value="selected.value"
           @change="
@@ -54,7 +50,6 @@ export interface CascaderSelectOptions {
 
 const props = defineProps<{
   options: CascaderSelectOptions;
-  selectClass?: Record<string, boolean> | string[] | string;
   labelClass?: Record<string, boolean> | string[] | string;
   initialSelectedValues?: string[];
 }>();
@@ -63,7 +58,6 @@ const emit = defineEmits<{
   (eventName: "change", selectedValues: string[]): void;
 }>();
 
-// one id per segment select, namespaced per component instance
 const selectIdPrefix = useId();
 
 interface SelectedSegment {

--- a/src/components/InputGroup/InputGroup.vue
+++ b/src/components/InputGroup/InputGroup.vue
@@ -23,7 +23,7 @@
         :disabled="disabled"
         :class="
           cn([
-            'block w-full rounded-md border border-outline-variant sm:text-sm py-2 bg-surface-container text-on-surface focus:bg-surface-bright px-4 placeholder:text-on-surface-muted',
+            'block w-full rounded-md border border-outline-variant sm:text-sm py-2 bg-surface-container text-on-surface focus:bg-surface-bright px-4',
             {
               'pl-10': $slots.prepend,
               'pr-10': $slots.append,

--- a/src/components/SearchResultsSortSelect/SearchResultsSortSelect.vue
+++ b/src/components/SearchResultsSortSelect/SearchResultsSortSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="search-results-sort-select flex items-baseline gap-2">
-    <label for="location" class="sr-only">Sort</label>
+    <label for="sort" class="sr-only">Sort</label>
     <select
       id="sort"
       name="sort"

--- a/src/components/SelectGroup/SelectGroup.vue
+++ b/src/components/SelectGroup/SelectGroup.vue
@@ -18,12 +18,7 @@
       :id="id"
       :value="modelValue ?? ''"
       :disabled="disabled"
-      :class="
-        cn([
-          'rounded-md border-outline-variant bg-surface-container text-sm focus-visible:ring-2 disabled:opacity-50',
-          selectClass,
-        ])
-      "
+      :class="cn(['select-group__select', selectClass])"
       readonly
       required
       @change="
@@ -88,4 +83,9 @@ function handleUpdateSelection(value: string) {
   return emit("update:modelValue", value as TModelValue);
 }
 </script>
-<style scoped></style>
+<style>
+/* this is available globally so that other components can use (e.g. cascade select) are styled similarly */
+.select-group__select {
+  @apply rounded-md border-outline-variant bg-surface-container text-on-surface disabled:text-on-surface-muted text-sm focus-visible:ring-2 focus:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed;
+}
+</style>

--- a/src/components/SelectGroup/SelectGroup.vue
+++ b/src/components/SelectGroup/SelectGroup.vue
@@ -18,7 +18,7 @@
       :id="id"
       :value="modelValue ?? ''"
       :disabled="disabled"
-      :class="cn(['select-group__select', selectClass])"
+      :class="cn(['themed-select', selectClass])"
       :required="required"
       @change="
         handleUpdateSelection(($event.target as HTMLSelectElement).value)
@@ -82,9 +82,3 @@ function handleUpdateSelection(value: string) {
   return emit("update:modelValue", value as TModelValue);
 }
 </script>
-<style>
-/* global on purpose: raw selects elsewhere (e.g. CascadeSelect) share this styling */
-.select-group__select {
-  @apply w-full rounded-md border-outline-variant bg-surface-container text-on-surface disabled:text-on-surface-muted text-sm focus-visible:ring-2 focus:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed;
-}
-</style>

--- a/src/components/SelectGroup/SelectGroup.vue
+++ b/src/components/SelectGroup/SelectGroup.vue
@@ -19,12 +19,11 @@
       :value="modelValue ?? ''"
       :disabled="disabled"
       :class="cn(['select-group__select', selectClass])"
-      readonly
-      required
+      :required="required"
       @change="
         handleUpdateSelection(($event.target as HTMLSelectElement).value)
       ">
-      <option value="" disabled selected>{{ placeholder }}</option>
+      <option value="" disabled>{{ placeholder }}</option>
       <option
         v-for="opt in options"
         :key="opt.id"
@@ -84,8 +83,8 @@ function handleUpdateSelection(value: string) {
 }
 </script>
 <style>
-/* this is available globally so that other components can use (e.g. cascade select) are styled similarly */
+/* global on purpose: raw selects elsewhere (e.g. CascadeSelect) share this styling */
 .select-group__select {
-  @apply rounded-md border-outline-variant bg-surface-container text-on-surface disabled:text-on-surface-muted text-sm focus-visible:ring-2 focus:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed;
+  @apply w-full rounded-md border-outline-variant bg-surface-container text-on-surface disabled:text-on-surface-muted text-sm focus-visible:ring-2 focus:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed;
 }
 </style>

--- a/src/components/TextAreaGroup/TextAreaGroup.vue
+++ b/src/components/TextAreaGroup/TextAreaGroup.vue
@@ -33,7 +33,7 @@
         :name="`textarea-${id}`"
         :class="
           cn(
-            'text-area-input block w-full rounded-md border-outline-variant sm:text-sm px-4 py-2 text-on-surface focus:text-on-surface [field-sizing:content] min-h-24 bg-surface-container focus:bg-surface-bright placeholder:text-on-surface-variant',
+            'text-area-input block w-full rounded-md border-outline-variant sm:text-sm px-4 py-2 text-on-surface focus:text-on-surface [field-sizing:content] min-h-24 bg-surface-container focus:bg-surface-bright',
             inputClass
           )
         "

--- a/src/components/ui/combobox/ComboboxInput.vue
+++ b/src/components/ui/combobox/ComboboxInput.vue
@@ -30,7 +30,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
     v-bind="forwarded"
     :class="
       cn(
-        'w-full focus:ring-0 border-0 disabled:cursor-not-allowed disabled:opacity-50 px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground ',
+        'w-full bg-transparent text-on-surface focus:ring-0 border-0 disabled:cursor-not-allowed disabled:opacity-50 px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground',
         props.class
       )
     ">

--- a/src/components/ui/input/Input.vue
+++ b/src/components/ui/input/Input.vue
@@ -24,7 +24,7 @@ const modelValue = useVModel(props, "modelValue", emits, {
     v-model="modelValue"
     :class="
       cn(
-        'flex h-9 w-full rounded-md border border-outline-variant bg-transparent px-3 py-1 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-on-surface-muted disabled:cursor-not-allowed disabled:opacity-50 focus-visible:bg-surface-bright',
+        'flex h-9 w-full rounded-md border border-outline-variant bg-transparent px-3 py-1 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:cursor-not-allowed disabled:opacity-50 focus-visible:bg-surface-bright',
         props.class
       )
     " />

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -16,6 +16,71 @@ body {
   a:hover {
     text-decoration: underline;
   }
+
+  /* @tailwindcss/forms paints bare controls for a light scheme (white fills,
+     gray borders, blue focus rings). Repoint its colors at theme tokens so
+     every control follows the active theme. Selectors mirror the plugin's
+     base rules exactly, so source order decides the tie. */
+  [type="text"],
+  input:where(:not([type])),
+  [type="email"],
+  [type="url"],
+  [type="password"],
+  [type="number"],
+  [type="date"],
+  [type="datetime-local"],
+  [type="month"],
+  [type="search"],
+  [type="tel"],
+  [type="time"],
+  [type="week"],
+  [multiple],
+  textarea,
+  select {
+    background-color: var(--surface-container);
+    border-color: var(--outline-variant);
+    color: var(--on-surface);
+  }
+
+  [type="text"]:focus,
+  input:where(:not([type])):focus,
+  [type="email"]:focus,
+  [type="url"]:focus,
+  [type="password"]:focus,
+  [type="number"]:focus,
+  [type="date"]:focus,
+  [type="datetime-local"]:focus,
+  [type="month"]:focus,
+  [type="search"]:focus,
+  [type="tel"]:focus,
+  [type="time"]:focus,
+  [type="week"]:focus,
+  [multiple]:focus,
+  textarea:focus,
+  select:focus {
+    --tw-ring-color: var(--primary);
+    --tw-ring-offset-color: var(--surface);
+    border-color: var(--primary);
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--on-surface-variant);
+  }
+
+  /* The checked fill is the plugin's `background-color: currentColor` */
+  [type="checkbox"],
+  [type="radio"] {
+    color: var(--primary);
+    background-color: var(--surface-container);
+    border-color: var(--outline);
+  }
+
+  [type="checkbox"]:focus,
+  [type="radio"]:focus {
+    --tw-ring-color: var(--primary);
+    --tw-ring-offset-color: var(--surface);
+  }
 }
 
 @layer utilities {
@@ -106,11 +171,7 @@ body {
 .prose img,
 .prose iframe {
   border: 1px solid var(--outline-variant);
-
-  /* the border is chrome, so it follows the theme, but this backdrop shows
-   * only through transparent images, where dark line art assumes a light
-   * background, so it stays light in every theme */
-  background: #eee;
+  background: var(--surface-container);
   border-radius: 0.5rem;
 }
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -68,9 +68,9 @@ body {
     color: var(--on-surface-variant);
   }
 
-  /* The checked fill is the plugin's `background-color: currentColor` */
   [type="checkbox"],
   [type="radio"] {
+    /* the plugin's :checked fill is currentColor, so color sets the check */
     color: var(--primary);
     background-color: var(--surface-container);
     border-color: var(--outline);
@@ -80,6 +80,13 @@ body {
   [type="radio"]:focus {
     --tw-ring-color: var(--primary);
     --tw-ring-offset-color: var(--surface);
+  }
+}
+
+@layer components {
+  /* the app-wide select style, used by SelectGroup and raw selects alike */
+  .themed-select {
+    @apply w-full rounded-md border-outline-variant bg-surface-container text-on-surface disabled:text-on-surface-muted text-sm focus-visible:ring-2 focus:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed;
   }
 }
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -178,7 +178,10 @@ body {
 .prose img,
 .prose iframe {
   border: 1px solid var(--outline-variant);
-  background: var(--surface-container);
+
+  /* transparent images often hold dark line art that assumes a light page,
+   * so this backdrop stays light even on dark themes */
+  background: #eee;
   border-radius: 0.5rem;
 }
 

--- a/src/css/themes/construction.css
+++ b/src/css/themes/construction.css
@@ -15,6 +15,7 @@
 @import "@fontsource/barlow/700.css";
 
 [data-theme="construction"] {
+  color-scheme: dark;
   /* Surface — dark asphalt gray */
   --surface: oklch(20% 0.01 80);
   --surface-dim: oklch(15% 0.01 80);

--- a/src/css/themes/hotrod.css
+++ b/src/css/themes/hotrod.css
@@ -12,6 +12,7 @@
 @import "@fontsource/chakra-petch/700.css";
 
 [data-theme="hotrod"] {
+  color-scheme: dark;
   /* Surface — glossy black paint */
   --surface: oklch(12% 0.01 30);
   --surface-dim: oklch(8% 0.01 30);

--- a/src/css/themes/matrix.css
+++ b/src/css/themes/matrix.css
@@ -13,6 +13,7 @@
 @import "@fontsource/source-code-pro/700.css";
 
 [data-theme="matrix"] {
+  color-scheme: dark;
   /* Surface — pure black void */
   --surface: oklch(5% 0.01 145);
   --surface-dim: oklch(3% 0 0);

--- a/src/css/themes/nord-dark.css
+++ b/src/css/themes/nord-dark.css
@@ -15,6 +15,7 @@
 @import "@fontsource/jetbrains-mono/600.css";
 
 [data-theme="nord-dark"] {
+  color-scheme: dark;
   /* Surface — Nord Polar Night (#2e3440 → #4c566a) */
   --surface: oklch(26% 0.02 245);
   --surface-dim: oklch(22% 0.02 245);

--- a/src/css/themes/tron.css
+++ b/src/css/themes/tron.css
@@ -17,6 +17,7 @@
 @import "@fontsource/exo-2/700.css";
 
 [data-theme="tron"] {
+  color-scheme: dark;
   /* Surface — near-black with blue undertone */
   --surface: oklch(8% 0.02 240);
   --surface-dim: oklch(5% 0.01 240);

--- a/src/css/themes/vaporwave.css
+++ b/src/css/themes/vaporwave.css
@@ -13,6 +13,7 @@
 @import "@fontsource/quicksand/700.css";
 
 [data-theme="vaporwave"] {
+  color-scheme: dark;
   /* Surface — deep purple-blue twilight */
   --surface: oklch(18% 0.06 290);
   --surface-dim: oklch(14% 0.05 290);

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/EditUploadWidgetItem.vue
@@ -70,7 +70,6 @@
             <input
               type="checkbox"
               :checked="item.regenerate === 'On'"
-              class="form-checkbox"
               @change="handleRegenerateToggle" />
             Regenerate Derivatives
           </label>

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/AudioHandlerSidecar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/AudioHandlerSidecar.vue
@@ -9,7 +9,7 @@
       <select
         :id="languageId"
         :value="sidecars.language ?? ''"
-        class="rounded-md border-outline-variant bg-surface-container text-sm focus-visible:ring-2"
+        class="select-group__select"
         @change="
           $emit('update:sidecars', {
             ...sidecars,

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/AudioHandlerSidecar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/AudioHandlerSidecar.vue
@@ -9,7 +9,7 @@
       <select
         :id="languageId"
         :value="sidecars.language ?? ''"
-        class="select-group__select"
+        class="themed-select"
         @change="
           $emit('update:sidecars', {
             ...sidecars,

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/MovieHandlerSidecar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/MovieHandlerSidecar.vue
@@ -9,7 +9,7 @@
       <select
         :id="languageId"
         :value="sidecars.language ?? ''"
-        class="rounded-md border-outline-variant bg-surface-container text-sm focus-visible:ring-2"
+        class="select-group__select"
         @change="
           $emit('update:sidecars', {
             ...sidecars,

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/MovieHandlerSidecar.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/MovieHandlerSidecar.vue
@@ -9,7 +9,7 @@
       <select
         :id="languageId"
         :value="sidecars.language ?? ''"
-        class="select-group__select"
+        class="themed-select"
         @change="
           $emit('update:sidecars', {
             ...sidecars,

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/UploadableTextArea.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditUploadWidget/Sidecars/UploadableTextArea.vue
@@ -6,7 +6,7 @@
       :placeholder="placeholder"
       :inputClass="
         cn(
-          'border-outline-variant rounded-b-none placeholder:text-on-surface-variant px-4 py-3',
+          'border-outline-variant rounded-b-none px-4 py-3',
           inputClass
         )
       "

--- a/src/pages/DrawerViewPage/DrawerViewPage.vue
+++ b/src/pages/DrawerViewPage/DrawerViewPage.vue
@@ -57,7 +57,7 @@
             </div>
           </div>
           <div class="flex items-center gap-2">
-            <label for="location" class="sr-only">Sort</label>
+            <label for="sort" class="sr-only">Sort</label>
             <select
               id="sort"
               name="sort"

--- a/src/pages/InstanceSettingsPage/ThemeCard.vue
+++ b/src/pages/InstanceSettingsPage/ThemeCard.vue
@@ -6,7 +6,7 @@
       <input
         type="checkbox"
         :checked="isAvailable"
-        class="shrink-0 rounded border-outline text-primary focus:ring-m3-primary"
+        class="shrink-0 rounded border-outline text-primary focus:ring-primary"
         @change="$emit('toggleAvailable')" />
       <!-- The swatch scope: everything inside renders in the theme's own
            colors and display font. Controls stay outside so they keep the

--- a/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
+++ b/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
@@ -26,7 +26,7 @@
           <select
             id="add-results-to-drawer-select"
             v-model="selectedDrawer"
-            class="select-group__select"
+            class="themed-select"
             :class="{
               'text-on-surface-variant': !selectedDrawer,
             }">

--- a/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
+++ b/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
@@ -23,7 +23,7 @@
           <label class="sr-only">Add to Drawer</label>
           <select
             v-model="selectedDrawer"
-            class="border border-outline rounded w-full text-sm bg-surface text-on-surface"
+            class="select-group__select"
             :class="{
               'text-on-surface-variant': !selectedDrawer,
             }">

--- a/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
+++ b/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
@@ -55,7 +55,7 @@
         <DrawerTitleInput
           v-model="newDrawerName"
           class="flex-1 border border-outline rounded"
-          inputClass="bg-surface placeholder-on-surface-variant"
+          inputClass="bg-surface"
           :labelHidden="true" />
 
         <Button type="submit" class="text-sm" :disabled="!isDrawerNameValid">

--- a/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
+++ b/src/pages/SearchResultsPage/AddSearchResultsToDrawerButton.vue
@@ -20,8 +20,11 @@
         class="flex items-center justify-between gap-2"
         @submit.prevent="handleAddToDrawer(selectedDrawer)">
         <div class="flex-1 flex gap-4 items-center">
-          <label class="sr-only">Add to Drawer</label>
+          <label for="add-results-to-drawer-select" class="sr-only">
+            Add to Drawer
+          </label>
           <select
+            id="add-results-to-drawer-select"
             v-model="selectedDrawer"
             class="select-group__select"
             :class="{
@@ -44,7 +47,7 @@
       <p
         class="my-4 before:absolute before:top-1/2 before:-translate-y-1/2 before:block before:h-[1px] before:w-full before:left-0 before:bg-outline-variant relative leading-none text-center">
         <span
-          class="text-on-surface-variant bg- bg-surface-container-low relative z-10 px-2">
+          class="text-on-surface-variant bg-surface-container-low relative z-10 px-2">
           or
         </span>
       </p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -138,6 +138,20 @@ export default {
           DEFAULT: "var(--outline)",
           variant: "var(--outline-variant)",
         },
+        // shadcn-vue palette names aliased to the M3 tokens above, so
+        // components pasted into src/components/ui/ render themed
+        // without a rewrite
+        background: "var(--surface)",
+        foreground: "var(--on-surface)",
+        muted: {
+          DEFAULT: "var(--surface-container)",
+          foreground: "var(--on-surface-variant)",
+        },
+        accent: {
+          DEFAULT: "var(--primary-container)",
+          foreground: "var(--on-primary-container)",
+        },
+        ring: "var(--primary)",
         "inverse-surface": "var(--inverse-surface)",
         "inverse-on-surface": "var(--inverse-on-surface)",
         "inverse-on-surface-variant":

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -138,7 +138,7 @@ export default {
           DEFAULT: "var(--outline)",
           variant: "var(--outline-variant)",
         },
-        // shadcn-vue palette names aliased to the M3 tokens above, so
+        // shadcn-vue palette names aliased to the M3 theme tokens, so
         // components pasted into src/components/ui/ render themed
         // without a rewrite
         background: "var(--surface)",

--- a/tests/e2e/dark-theme-form-controls.spec.ts
+++ b/tests/e2e/dark-theme-form-controls.spec.ts
@@ -16,7 +16,7 @@ const DARK_THEMES = [
 
 // The app reads the saved theme from localStorage at boot, so write it
 // directly and reload rather than driving the settings UI.
-async function activateTheme(page: Page, theme: string) {
+async function activateTheme(page: Page, theme: string): Promise<void> {
   await page.evaluate(
     (themeName) =>
       localStorage.setItem(`theme-${window.location.hostname}`, themeName),
@@ -66,6 +66,9 @@ test.describe("Dark theme form controls", () => {
     await activateTheme(page, "dark");
 
     await page.goto("/assetManager/addAsset");
+    // the navigation reboots the app, so confirm the theme reapplied
+    // before sampling any colors
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     await page
       .getByLabel("Template")
       .selectOption({ label: "All Fields with Autocomplete" });
@@ -73,11 +76,12 @@ test.describe("Dark theme form controls", () => {
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByLabel(/title/i).first()).toBeVisible();
 
-    const checkbox = page.locator('input[type="checkbox"]').first();
-    await expect(checkbox).toBeVisible();
-    expect(await backgroundColor(checkbox), "checkbox widget input").not.toBe(
-      WHITE
-    );
+    await expect(page.locator('input[type="checkbox"]').first()).toBeVisible();
+    for (const checkbox of await page.locator('input[type="checkbox"]').all()) {
+      expect(await backgroundColor(checkbox), "checkbox widget input").not.toBe(
+        WHITE
+      );
+    }
 
     await page.getByText("Select an asset...").click();
     const comboboxInput = page.getByPlaceholder("Select Related Assets...");

--- a/tests/e2e/dark-theme-form-controls.spec.ts
+++ b/tests/e2e/dark-theme-form-controls.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
+
+const WHITE = "rgb(255, 255, 255)";
+
+// Dark-surfaced themes beyond dark.css. Each must declare `color-scheme: dark`
+// so native select popups, date pickers, and scrollbars render dark.
+const DARK_THEMES = [
+  "construction",
+  "hotrod",
+  "matrix",
+  "nord-dark",
+  "tron",
+  "vaporwave",
+];
+
+// The app reads the saved theme from localStorage at boot, so write it
+// directly and reload rather than driving the settings UI.
+async function activateTheme(page: Page, theme: string) {
+  await page.evaluate(
+    (themeName) =>
+      localStorage.setItem(`theme-${window.location.hostname}`, themeName),
+    theme
+  );
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+}
+
+function backgroundColor(locator: Locator): Promise<string> {
+  return locator.evaluate((el) => getComputedStyle(el).backgroundColor);
+}
+
+test.describe("Dark theme form controls", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const workerId = test.info().workerIndex.toString();
+    await setupWorkerHTTPHeader({ page, workerId });
+    await refreshDatabase({ request, workerId });
+  });
+
+  test("sort select on search results is reachable by its label", async ({
+    page,
+    request,
+  }) => {
+    const workerId = test.info().workerIndex.toString();
+    await loginUser({ request, page, workerId });
+
+    await page.goto("/");
+    const searchInput = page.getByRole("textbox", { name: "Search" }).first();
+    await searchInput.fill("test");
+    await searchInput.press("Enter");
+    await expect(page).toHaveURL(/\/search\//);
+
+    await expect(page.getByLabel("Sort")).toBeVisible();
+  });
+
+  test("asset form controls are not painted white on the dark theme", async ({
+    page,
+    request,
+  }) => {
+    // Three full page loads: boot, theme reload, then the add-asset form.
+    test.setTimeout(30_000);
+    const workerId = test.info().workerIndex.toString();
+    await loginUser({ request, page, workerId, username: "curator" });
+
+    await page.goto("/");
+    await activateTheme(page, "dark");
+
+    await page.goto("/assetManager/addAsset");
+    await page
+      .getByLabel("Template")
+      .selectOption({ label: "All Fields with Autocomplete" });
+    await page.getByLabel("Collection").selectOption({ index: 1 });
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByLabel(/title/i).first()).toBeVisible();
+
+    const checkbox = page.locator('input[type="checkbox"]').first();
+    await expect(checkbox).toBeVisible();
+    expect(await backgroundColor(checkbox), "checkbox widget input").not.toBe(
+      WHITE
+    );
+
+    await page.getByText("Select an asset...").click();
+    const comboboxInput = page.getByPlaceholder("Select Related Assets...");
+    await expect(comboboxInput).toBeVisible();
+    expect(
+      await backgroundColor(comboboxInput),
+      "related-asset combobox input"
+    ).not.toBe(WHITE);
+  });
+
+  test("optional SelectGroup select is not natively required", async ({
+    page,
+    request,
+  }) => {
+    const workerId = test.info().workerIndex.toString();
+    await loginUser({ request, page, workerId, username: "admin" });
+
+    await page.goto("/instances/edit/1");
+    const select = page.getByLabel("Display Custom Header/Footer");
+    await expect(select).toBeVisible();
+    await expect(select).not.toHaveAttribute("required");
+  });
+
+  test("dark themes declare a dark color scheme", async ({
+    page,
+    request,
+  }) => {
+    // Six theme activations, each a reload plus a lazy CSS fetch.
+    test.setTimeout(60_000);
+    const workerId = test.info().workerIndex.toString();
+    await loginUser({ request, page, workerId });
+    await page.goto("/");
+
+    for (const theme of DARK_THEMES) {
+      await activateTheme(page, theme);
+      const colorScheme = await page.evaluate(
+        () => getComputedStyle(document.documentElement).colorScheme
+      );
+      expect(colorScheme, `theme ${theme}`).toBe("dark");
+    }
+  });
+});


### PR DESCRIPTION
- Resolves #611 
- Selects, text inputs, textareas, and checkboxes rendered with white fills, gray borders, and blue focus rings on dark themes, sometimes leaving white-on-white text. They now follow the active theme everywhere.
- Root cause was `@tailwindcss/forms`, which hardcodes light-scheme colors on every bare control. Components had been fighting it one `!bg-white` at a time, so this overrides the plugin once in the base layer instead.
- some dark themes never declared `color-scheme: dark`, so native select popups, date pickers, and scrollbars rendered light on them.
- Also fixes the accessibility bugs found in the same lines: selects with no accessible name and labels pointing at ids that do not exist.
