### PR TITLE
remove formula button

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -84,7 +84,6 @@ const options = computed(() => ({
         { list: "bullet" },
         "link",
         ...(props.enableImageInsert ? ["image"] : []),
-        "formula",
         { direction: "rtl" }, // text direction
         "clean",
       ],


### PR DESCRIPTION
- Fixes #610
- Removes the formula (equation) button from the rich text editor toolbar

Why remove instead of fix?
1. Hasn't ever worked, so seems unused.
2. fixing requires katex is bit heavy at 280KB. Loading on demand is possible (scan content for class, then load), but would require a bit more logic.
3. would need to verify that quill's getSemanticHTML() parses to mathml.
