### PR TITLE
add mock backend for collections

### DIFF
--- a/mock-server/db/collections.ts
+++ b/mock-server/db/collections.ts
@@ -1,183 +1,208 @@
-import { AssetCollection, RawAssetCollection } from "../../src/types";
+import { RawAssetCollection } from "../../src/types";
+import { MockCollection } from "../types";
 import { createBaseTable } from "./baseTable";
 
-const collectionSeeds: AssetCollection[] = [
-  {
+type CollectionSeed = Pick<
+  MockCollection,
+  "id" | "title" | "parentId" | "showInBrowse" | "canView" | "canEdit"
+> &
+  Partial<MockCollection>;
+
+function makeCollectionSeed(seed: CollectionSeed): MockCollection {
+  return {
+    previewImageId: "",
+    description: "",
+    // null S3 settings mean the collection uses the instance defaults
+    bucket: null,
+    bucketRegion: null,
+    s3Key: null,
+    s3Secret: null,
+    ...seed,
+  };
+}
+
+const collectionSeeds: MockCollection[] = [
+  makeCollectionSeed({
     id: 1,
     title: "Default Collection",
-    previewImageId: "",
+    description: "<p>Everything that has no home of its own.</p>",
     parentId: null,
     showInBrowse: true,
     canView: true,
     canEdit: true,
-    children: [],
-  },
-  {
+  }),
+  makeCollectionSeed({
     id: 2,
     title: "Second Collection",
-    previewImageId: "",
     parentId: null,
     showInBrowse: true,
     canView: true,
     canEdit: false,
-    children: [],
-  },
-  {
+  }),
+  makeCollectionSeed({
     id: 3,
     title: "Parent Collection",
-    previewImageId: "",
     parentId: null,
     showInBrowse: true,
     canView: true,
     canEdit: true,
-    children: [
-      {
-        id: 30,
-        title: "Child Collection 1",
-        previewImageId: "",
-        parentId: 3,
-        showInBrowse: true,
-        canView: true,
-        canEdit: true,
-        children: [
-          {
-            id: 300,
-            title: "Grandchild Collection",
-            previewImageId: "",
-            children: [],
-            parentId: 30,
-            showInBrowse: true,
-            canView: true,
-            canEdit: true,
-          },
-        ],
-      },
-      {
-        id: 31,
-        title: "Child Collection 2",
-        previewImageId: "",
-        parentId: 3,
-        showInBrowse: true,
-        canView: true,
-        canEdit: true,
-        children: [
-          {
-            id: 310,
-            title: "Grandchild Collection 2",
-            previewImageId: "",
-            children: [],
-            parentId: 31,
-            showInBrowse: true,
-            canView: true,
-            canEdit: true,
-          },
-        ],
-      },
-      {
-        id: 32,
-        title: "Hidden Child Collection",
-        previewImageId: "",
-        parentId: 3,
-        showInBrowse: false,
-        canView: true,
-        canEdit: false,
-        children: [],
-      },
-    ],
-  },
-  {
+  }),
+  makeCollectionSeed({
+    id: 30,
+    title: "Child Collection 1",
+    parentId: 3,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+  }),
+  makeCollectionSeed({
+    id: 300,
+    title: "Grandchild Collection",
+    parentId: 30,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+  }),
+  makeCollectionSeed({
+    id: 31,
+    title: "Child Collection 2",
+    parentId: 3,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+  }),
+  makeCollectionSeed({
+    id: 310,
+    title: "Grandchild Collection 2",
+    parentId: 31,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+  }),
+  makeCollectionSeed({
+    id: 32,
+    title: "Hidden Child Collection",
+    parentId: 3,
+    showInBrowse: false,
+    canView: true,
+    canEdit: false,
+  }),
+  makeCollectionSeed({
     id: 4,
     title: "Non-Browsable Parent Collection",
-    previewImageId: "",
     parentId: null,
     showInBrowse: false, // Not browsable itself
     canView: true,
     canEdit: true,
-    children: [
-      // case 1: has a browseable child, no grandchildren
-      {
-        id: 40,
-        title: "Browsable Child Collection",
-        previewImageId: "",
-        parentId: 4,
-        showInBrowse: false,
-        canView: true,
-        canEdit: true,
-        children: [],
-      },
+  }),
 
-      // case 2: browseable child with non-browsable grandchild
-      {
-        id: 41,
-        title: "Browsable Child with Non-Browsable Grandchild",
-        previewImageId: "",
-        parentId: 4,
-        showInBrowse: true,
-        canView: true,
-        canEdit: true,
-        children: [
-          {
-            id: 410,
-            title: "Non-Browsable Grandchild",
-            previewImageId: "",
-            children: [],
-            parentId: 41,
-            showInBrowse: false,
-            canView: true,
-            canEdit: true,
-          },
-        ],
-      },
-      //case 3: non-browsable child, with a browseable grandchild
-      {
-        id: 42,
-        title: "Non-Browsable Child Collection",
-        previewImageId: "",
-        parentId: 4,
-        showInBrowse: false,
-        canView: true,
-        canEdit: true,
-        children: [
-          {
-            id: 420,
-            title: "Browsable Grandchild",
-            previewImageId: "",
-            children: [],
-            parentId: 42,
-            showInBrowse: true,
-            canView: true,
-            canEdit: true,
-          },
-        ],
-      },
-    ],
-  },
+  // case 1: has a browseable child, no grandchildren
+  makeCollectionSeed({
+    id: 40,
+    title: "Browsable Child Collection",
+    parentId: 4,
+    showInBrowse: false,
+    canView: true,
+    canEdit: true,
+  }),
+
+  // case 2: browseable child with non-browsable grandchild
+  makeCollectionSeed({
+    id: 41,
+    title: "Browsable Child with Non-Browsable Grandchild",
+    parentId: 4,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+  }),
+  makeCollectionSeed({
+    id: 410,
+    title: "Non-Browsable Grandchild",
+    parentId: 41,
+    showInBrowse: false,
+    canView: true,
+    canEdit: true,
+  }),
+
+  // case 3: non-browsable child, with a browseable grandchild
+  makeCollectionSeed({
+    id: 42,
+    title: "Non-Browsable Child Collection",
+    parentId: 4,
+    showInBrowse: false,
+    canView: true,
+    canEdit: true,
+  }),
+  makeCollectionSeed({
+    id: 420,
+    title: "Browsable Grandchild",
+    parentId: 42,
+    showInBrowse: true,
+    canView: true,
+    canEdit: true,
+  }),
 ];
 
-function toRawAssetCollection(collection: AssetCollection): RawAssetCollection {
-  return {
+const firstGeneratedId =
+  Math.max(...collectionSeeds.map((collection) => collection.id)) + 1;
+
+export function createCollectionsTable() {
+  const baseTable = createBaseTable(
+    (collection: MockCollection) => collection.id,
+    collectionSeeds
+  );
+  let nextId = firstGeneratedId;
+
+  const getChildren = (parentId: number | null): MockCollection[] =>
+    baseTable.filter((collection) => collection.parentId === parentId);
+
+  const getSubtreeIds = (collectionId: number): number[] => {
+    const descendantIds = getChildren(collectionId).flatMap((child) =>
+      getSubtreeIds(child.id)
+    );
+    return [collectionId, ...descendantIds];
+  };
+
+  const toRawAssetCollection = (
+    collection: MockCollection
+  ): RawAssetCollection => ({
     id: collection.id,
     title: collection.title,
     previewImageId: collection.previewImageId,
     showInBrowse: collection.showInBrowse,
     canView: collection.canView,
     canEdit: collection.canEdit,
-    children:
-      collection.children?.map(toRawAssetCollection) ??
-      ([] as RawAssetCollection[]),
-  };
-}
-
-export function createCollectionsTable() {
-  const baseTable = createBaseTable(
-    (collection: AssetCollection) => collection.id,
-    collectionSeeds
-  );
+    children: getChildren(collection.id).map(toRawAssetCollection),
+  });
 
   return {
     ...baseTable,
-    getAllAsRawAssetCollections: (): RawAssetCollection[] => {
-      return baseTable.getAll().map(toRawAssetCollection);
+    getChildren,
+    getSubtreeIds,
+    getAllAsRawAssetCollections: (): RawAssetCollection[] =>
+      getChildren(null).map(toRawAssetCollection),
+    create: (data: Omit<MockCollection, "id">): MockCollection => {
+      const collection: MockCollection = { id: nextId++, ...data };
+      baseTable.set(collection.id, collection);
+      return collection;
+    },
+    // replaces the row rather than mutating it, so the seed objects stay
+    // clean for the next reset
+    update: (
+      id: number,
+      data: Partial<Omit<MockCollection, "id">>
+    ): MockCollection | undefined => {
+      const collection = baseTable.get(id);
+      if (!collection) return undefined;
+
+      const updated: MockCollection = { ...collection, ...data };
+      baseTable.set(id, updated);
+      return updated;
+    },
+    reset: (): void => {
+      baseTable.reset();
+      nextId = firstGeneratedId;
+      baseTable.seed();
     },
   };
 }

--- a/mock-server/db/instances.ts
+++ b/mock-server/db/instances.ts
@@ -77,3 +77,13 @@ export function createInstancesTable() {
 }
 
 export type InstancesTable = ReturnType<typeof createInstancesTable>;
+
+// S3 settings a new collection inherits when its own are left blank.
+// These are backend-only credentials, so they have no place on
+// InstanceSettings, which is the shape the UI receives.
+export const INSTANCE_S3_DEFAULTS = {
+  bucket: "elevator-default-bucket",
+  bucketRegion: "us-east-2",
+  s3Key: "AKIAINSTANCEDEFAULT",
+  s3Secret: "instance-default-secret",
+};

--- a/mock-server/db/searches.ts
+++ b/mock-server/db/searches.ts
@@ -54,9 +54,11 @@ export function createSearchesTable({
       {
         totalResultsOverride,
         specificFieldSearch,
+        collectionIds = [],
       }: {
         totalResultsOverride?: number;
         specificFieldSearch?: SpecificFieldSearchItem[];
+        collectionIds?: number[];
       } = {}
     ): SearchResultsResponse => {
       const searchId = crypto.randomUUID();
@@ -64,19 +66,37 @@ export function createSearchesTable({
       // find any matches in the assets
       const allAssets = assets.getAll();
 
+      // a collection search sweeps that collection and everything under
+      // it. No ids means every collection.
+      const searchedCollectionIds = collectionIds.length
+        ? new Set(
+            collectionIds.flatMap((collectionId) =>
+              collections.getSubtreeIds(collectionId)
+            )
+          )
+        : null;
+
       // not a real search
       // just stringify the assets and filter by the query
-      const matchedAssets = allAssets.filter(stupidSearch(query));
-      const allSearchMatches = matchedAssets.map((asset) => {
-        const collection = collections.get(asset.collectionId);
-        const template = templates.get(asset.templateId);
-        if (!collection || !template) {
-          throw new Error(
-            `Collection or template not found for asset ${asset.assetId}`
-          );
+      const matchesQuery = stupidSearch(query);
+      const matchedAssets = allAssets.filter((asset) => {
+        if (
+          searchedCollectionIds &&
+          !searchedCollectionIds.has(asset.collectionId)
+        ) {
+          return false;
         }
+        return matchesQuery(asset);
+      });
+      const allSearchMatches = matchedAssets.flatMap((asset) => {
+        const template = templates.get(asset.templateId);
+        if (!template) return [];
 
-        return assetToSearchResultMatch({ asset, collection, template });
+        // an asset outlives the collection it was in, and keeps its
+        // place in the results with an empty hierarchy
+        const collection = collections.get(asset.collectionId);
+
+        return [assetToSearchResultMatch({ asset, collection, template })];
       });
 
       const searchEntry: SearchEntry = {
@@ -95,7 +115,7 @@ export function createSearchesTable({
       };
 
       // permit override for testing when there's a mismatch between the number of matched assets and the expected total results (e.g. when testing pagination)
-      const totalResults = totalResultsOverride ?? matchedAssets.length;
+      const totalResults = totalResultsOverride ?? allSearchMatches.length;
 
       // Store complete results for pagination
       completeSearchResults.set(searchId, {

--- a/mock-server/routes/adminCollections.ts
+++ b/mock-server/routes/adminCollections.ts
@@ -1,0 +1,264 @@
+import { Hono } from "hono";
+import { delay } from "../utils/index";
+import type { MockCollection, MockServerContext } from "../types";
+import type { CollectionsTable } from "../db/collections";
+import { INSTANCE_S3_DEFAULTS } from "../db/instances";
+import type {
+  AdminCollectionDetail,
+  AdminCollectionSummary,
+} from "../../src/types";
+
+const app = new Hono<MockServerContext>();
+
+// the validator's message, which the UI surfaces verbatim
+const TITLE_REQUIRED = "This field is required";
+
+function toAdminCollectionSummary(
+  collection: MockCollection
+): AdminCollectionSummary {
+  return {
+    id: collection.id,
+    title: collection.title,
+    parentId: collection.parentId,
+    showInBrowse: collection.showInBrowse,
+    previewImageId: collection.previewImageId,
+  };
+}
+
+function toAdminCollectionDetail(
+  collection: MockCollection
+): AdminCollectionDetail {
+  return {
+    ...toAdminCollectionSummary(collection),
+    description: collection.description,
+    bucket: collection.bucket,
+    bucketRegion: collection.bucketRegion,
+    s3Key: collection.s3Key,
+    s3Secret: collection.s3Secret,
+  };
+}
+
+interface CollectionForm {
+  title: string;
+  parentId: number | null;
+  showInBrowse: boolean;
+  description: string;
+  previewImageId: string;
+  bucket: string;
+  bucketRegion: string;
+  s3Key: string;
+  s3Secret: string;
+}
+
+// null for a path segment that is not an integer, which the API
+// rejects as a bad request rather than a missing collection.
+function toCollectionId(rawCollectionId: string): number | null {
+  const collectionId = Number(rawCollectionId);
+  if (!Number.isInteger(collectionId)) return null;
+  return collectionId;
+}
+
+// The form sends 0 for top level.
+function toParentId(rawParentId: string): number | null {
+  const parentId = Number(rawParentId);
+  if (!Number.isInteger(parentId) || parentId <= 0) return null;
+  return parentId;
+}
+
+function readCollectionForm(body: Record<string, unknown>): CollectionForm {
+  const readText = (key: string): string => {
+    const value = body[key];
+    return typeof value === "string" ? value : "";
+  };
+
+  return {
+    title: readText("title"),
+    parentId: toParentId(readText("parentId")),
+    showInBrowse: readText("showInBrowse") === "true",
+    description: readText("description"),
+    previewImageId: readText("previewImageId"),
+    bucket: readText("bucket"),
+    bucketRegion: readText("bucketRegion"),
+    s3Key: readText("s3Key"),
+    s3Secret: readText("s3Secret"),
+  };
+}
+
+// A blank S3 field means "unset": create falls back to the instance
+// defaults, update keeps whatever is already stored. Storing "" would
+// break asset storage.
+function toStoredS3Setting(
+  submitted: string,
+  fallback: string | null
+): string | null {
+  if (submitted === "") return fallback;
+  return submitted;
+}
+
+// Walking up from the proposed parent must reach the top level without
+// meeting the collection itself, or the tree gains a cycle and every
+// recursive read of it hangs.
+function wouldCreateCycle(
+  collections: CollectionsTable,
+  collectionId: number,
+  parentId: number | null
+): boolean {
+  let ancestorId = parentId;
+  while (ancestorId !== null) {
+    if (ancestorId === collectionId) return true;
+    ancestorId = collections.get(ancestorId)?.parentId ?? null;
+  }
+  return false;
+}
+
+// every route requires a signed-in instance admin
+app.use("*", async (c, next) => {
+  const user = c.get("user");
+  if (!user) {
+    return c.json({ error: "Not Authenticated" }, 401);
+  }
+  if (!user.isInstanceAdmin && !user.isSuperAdmin) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  await next();
+});
+
+app.get("/collections", async (c) => {
+  await delay(100);
+  const db = c.get("db");
+
+  const collections = db.collections
+    .getAll()
+    .sort((left, right) => left.title.localeCompare(right.title))
+    .map(toAdminCollectionSummary);
+
+  return c.json({ collections });
+});
+
+app.get("/collections/:collectionId", async (c) => {
+  await delay(100);
+  const db = c.get("db");
+
+  const collectionId = toCollectionId(c.req.param("collectionId"));
+  if (collectionId === null) {
+    return c.json({ error: "Invalid ID" }, 400);
+  }
+
+  const collection = db.collections.get(collectionId);
+  if (!collection) {
+    return c.json({ error: "Collection not found" }, 404);
+  }
+
+  return c.json({ collection: toAdminCollectionDetail(collection) });
+});
+
+app.post("/collections", async (c) => {
+  await delay(150);
+  const db = c.get("db");
+  const form = readCollectionForm(await c.req.parseBody());
+
+  if (form.title === "") {
+    return c.json({ errors: { title: [TITLE_REQUIRED] } }, 422);
+  }
+  if (form.parentId !== null && !db.collections.get(form.parentId)) {
+    return c.json({ error: "Parent collection not found" }, 422);
+  }
+
+  const collection = db.collections.create({
+    title: form.title,
+    parentId: form.parentId,
+    showInBrowse: form.showInBrowse,
+    description: form.description,
+    previewImageId: form.previewImageId,
+    bucket: toStoredS3Setting(form.bucket, INSTANCE_S3_DEFAULTS.bucket),
+    bucketRegion: toStoredS3Setting(
+      form.bucketRegion,
+      INSTANCE_S3_DEFAULTS.bucketRegion
+    ),
+    s3Key: toStoredS3Setting(form.s3Key, INSTANCE_S3_DEFAULTS.s3Key),
+    s3Secret: toStoredS3Setting(form.s3Secret, INSTANCE_S3_DEFAULTS.s3Secret),
+    canView: true,
+    canEdit: true,
+  });
+
+  return c.json({ collection: toAdminCollectionDetail(collection) }, 201);
+});
+
+app.put("/collections/:collectionId", async (c) => {
+  await delay(150);
+  const db = c.get("db");
+
+  const collectionId = toCollectionId(c.req.param("collectionId"));
+  if (collectionId === null) {
+    return c.json({ error: "Invalid ID" }, 400);
+  }
+
+  const collection = db.collections.get(collectionId);
+  if (!collection) {
+    return c.json({ error: "Collection not found" }, 404);
+  }
+
+  const form = readCollectionForm(await c.req.parseBody());
+
+  if (form.title === "") {
+    return c.json({ errors: { title: [TITLE_REQUIRED] } }, 422);
+  }
+  if (form.parentId !== null && !db.collections.get(form.parentId)) {
+    return c.json({ error: "Parent collection not found" }, 422);
+  }
+  if (wouldCreateCycle(db.collections, collectionId, form.parentId)) {
+    return c.json(
+      {
+        error:
+          "Parent cannot be the collection itself or one of its descendants",
+      },
+      422
+    );
+  }
+
+  const updated = db.collections.update(collectionId, {
+    title: form.title,
+    parentId: form.parentId,
+    showInBrowse: form.showInBrowse,
+    description: form.description,
+    previewImageId: form.previewImageId,
+    bucket: toStoredS3Setting(form.bucket, collection.bucket),
+    bucketRegion: toStoredS3Setting(form.bucketRegion, collection.bucketRegion),
+    s3Key: toStoredS3Setting(form.s3Key, collection.s3Key),
+    s3Secret: toStoredS3Setting(form.s3Secret, collection.s3Secret),
+  });
+
+  if (!updated) {
+    return c.json({ error: "Collection not found" }, 404);
+  }
+
+  return c.json({ collection: toAdminCollectionDetail(updated) });
+});
+
+app.delete("/collections/:collectionId", async (c) => {
+  await delay(150);
+  const db = c.get("db");
+
+  const collectionId = toCollectionId(c.req.param("collectionId"));
+  if (collectionId === null) {
+    return c.json({ error: "Invalid ID" }, 400);
+  }
+
+  if (!db.collections.get(collectionId)) {
+    return c.json({ error: "Collection not found" }, 404);
+  }
+
+  // children move to the top level rather than being deleted too. The
+  // collection's assets keep pointing at the gone id, since the backend
+  // stores collectionId on an asset as a plain column, not a relation.
+  db.collections
+    .getChildren(collectionId)
+    .forEach((child) => db.collections.update(child.id, { parentId: null }));
+
+  db.collections.delete(collectionId);
+
+  return c.json({ deleted: collectionId });
+});
+
+export default app;

--- a/mock-server/routes/collections.ts
+++ b/mock-server/routes/collections.ts
@@ -16,7 +16,7 @@ app.get("/collectionHeader/:collectionId/true", async (c) => {
   }
 
   return c.json({
-    collectionDescription: "",
+    collectionDescription: collection.description ?? "",
     collectionTitle: collection.title,
   });
 });

--- a/mock-server/routes/search.ts
+++ b/mock-server/routes/search.ts
@@ -86,6 +86,51 @@ function generateTagAutocompletions(searchTerm: string): string[] {
   return generateAutocompletions(searchTerm, baseTags);
 }
 
+interface SearchRequest {
+  searchText: string;
+  collectionIds: number[];
+}
+
+function toCollectionIds(
+  collection: SearchRequestOptions["collection"]
+): number[] {
+  if (!collection) return [];
+
+  // 0 is the "any collection" sentinel
+  return collection.map(Number).filter((collectionId) => collectionId > 0);
+}
+
+/**
+ * Read a search from either shape the API accepts: a JSON `searchQuery`
+ * field, or the browse page's flat `searchText` plus `collectionId`.
+ * `searchQuery` wins when both are present.
+ */
+function readSearchRequest(body: FormData): SearchRequest {
+  const readField = (name: string): string | null => {
+    const value = body.get(name);
+    return typeof value === "string" ? value : null;
+  };
+
+  const rawSearchQuery = readField("searchQuery");
+  if (rawSearchQuery) {
+    const searchQuery = JSON.parse(rawSearchQuery) as SearchRequestOptions;
+    return {
+      searchText: searchQuery.searchText ?? "",
+      collectionIds: toCollectionIds(searchQuery.collection),
+    };
+  }
+
+  const searchText = readField("searchText");
+  if (searchText === null) {
+    return { searchText: "", collectionIds: [] };
+  }
+
+  return {
+    searchText,
+    collectionIds: toCollectionIds([readField("collectionId") ?? "0"]),
+  };
+}
+
 // POST /search/searchResults
 app.post("/searchResults", async (c) => {
   await delay(300);
@@ -103,12 +148,16 @@ app.post("/searchResults", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  const storeOnly = parsed.storeOnly === "true";
-  const searchQuery = parsed.searchQuery as SearchRequestOptions;
+  // parseFormData coerces "true" to a boolean before the route sees it
+  const storeOnly = parsed.storeOnly === true;
+  const { searchText, collectionIds } = readSearchRequest(body);
 
-  console.log(`Search requested: ${searchQuery} (storeOnly: ${storeOnly})`);
+  console.log(
+    `Search requested: "${searchText}" in collections ` +
+      `[${collectionIds}] (storeOnly: ${storeOnly})`
+  );
 
-  const resultsResponse = db.searches.create(searchQuery.searchText ?? "");
+  const resultsResponse = db.searches.create(searchText, { collectionIds });
 
   // create a new search if `storeOnly`
   // and only return the searchId

--- a/mock-server/server.ts
+++ b/mock-server/server.ts
@@ -7,6 +7,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import type { MockServerContext } from "./types";
 import { db, getOrCreateWorkerDb } from "./db/index";
 
+import adminCollectionsRoutes from "./routes/adminCollections";
 import adminPermissionsRoutes from "./routes/adminPermissions";
 import assetRoutes from "./routes/assets";
 import collectionRoutes from "./routes/collections";
@@ -91,6 +92,7 @@ app.route("/defaultinstance/collections", collectionRoutes);
 app.route("/defaultinstance/search", searchRoutes);
 app.route("/defaultinstance/drawers", drawerRoutes);
 app.route("/defaultinstance/drawerPermissions", drawerPermissionsRoutes);
+app.route("/defaultinstance/adminCollections", adminCollectionsRoutes);
 app.route("/defaultinstance/adminPermissions", adminPermissionsRoutes);
 app.route("/defaultinstance/permissions", permissionsRoutes);
 app.route("/defaultinstance/loginManager", authRoutes);

--- a/mock-server/types.ts
+++ b/mock-server/types.ts
@@ -1,4 +1,7 @@
-import type { PermissionsGroupEntry } from "../src/types";
+import type {
+  AdminCollectionDetail,
+  PermissionsGroupEntry,
+} from "../src/types";
 
 export interface MockUser {
   id: number;
@@ -40,6 +43,13 @@ export interface MockInstanceGrant {
   id: number;
   groupId: number;
   permissionLevelId: number;
+}
+
+// One collection row. Rows are stored flat and linked by parentId: the
+// admin API lists them as they are, the browse API nests them.
+export interface MockCollection extends AdminCollectionDetail {
+  canView: boolean;
+  canEdit: boolean;
 }
 
 // One group's permission level on one collection

--- a/mock-server/utils/assetToSearchResultMatch.ts
+++ b/mock-server/utils/assetToSearchResultMatch.ts
@@ -142,7 +142,8 @@ export function assetToSearchResultMatch({
   template,
 }: {
   asset: Asset;
-  collection: AssetCollection;
+  // undefined once the collection is deleted out from under the asset
+  collection: Pick<AssetCollection, "id" | "title"> | undefined;
   template: Template;
 }): SearchResultMatch {
   const collectionHierarchy = collection


### PR DESCRIPTION
Adds mock `adminCollections` API that the collections admin pages call. Those pages had no mock backing at all, so they couldn't be run locally.