### PR TITLE
Fix flakey drag and drop in template editor

### DIFF
--- a/src/components/DragDropList/DragDropContainer.vue
+++ b/src/components/DragDropList/DragDropContainer.vue
@@ -33,13 +33,9 @@ const emit = defineEmits<{
 
 provide(GROUP_ID_PROVIDE_KEY, props.groupId);
 
-type CleanupFn = () => void;
-const cleanupFns = [] as CleanupFn[];
-onUnmounted(dnd.combine(...cleanupFns));
-
 const dragDropStore = useDragDropStore(props.groupId);
 
-function setupDragDropMonitor(): CleanupFn {
+function setupDragDropMonitor(): dnd.CleanupFn {
   return dnd.monitorForElements({
     onDrop: ({ source, location }) => {
       const target = location.current.dropTargets[0];
@@ -104,9 +100,14 @@ function setupDragDropMonitor(): CleanupFn {
   });
 }
 
+let stopMonitoring: dnd.CleanupFn | null = null;
+
 onMounted(() => {
-  const cleanupMonitor = setupDragDropMonitor();
-  cleanupFns.push(cleanupMonitor);
+  stopMonitoring = setupDragDropMonitor();
 });
+
+// A monitor that outlives its container still handles every drop, so a
+// remount would leave two of them reordering the same list.
+onUnmounted(() => stopMonitoring?.());
 </script>
 <style scoped></style>

--- a/src/components/DragDropList/DragDropList.test.ts
+++ b/src/components/DragDropList/DragDropList.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount, type VueWrapper } from "@vue/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, enableAutoUnmount, type VueWrapper } from "@vue/test-utils";
 import { h, nextTick } from "vue";
 import DragDropContainer from "./DragDropContainer.vue";
 import DragDropList from "./DragDropList.vue";
@@ -52,6 +52,10 @@ vi.mock("./utils/dnd", async (importOriginal) => {
 
 const GROUP_ID = "test-group";
 const LIST_ID = "test-list";
+
+// Unmounting is what releases a component's registrations, so a wrapper left
+// mounted would keep watching this group and could emit into a later test.
+enableAutoUnmount(afterEach);
 
 // Every order the list has emitted since the current test began.
 const ordersEmitted: string[][] = [];
@@ -115,7 +119,6 @@ describe("DragDropList", () => {
     dndRegistry.liveMonitors.length = 0;
     dndRegistry.liveElementRegistrations = 0;
     ordersEmitted.length = 0;
-    document.body.innerHTML = "";
   });
 
   it("releases its drag and drop registrations on unmount", () => {

--- a/src/components/DragDropList/DragDropList.test.ts
+++ b/src/components/DragDropList/DragDropList.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { h, nextTick } from "vue";
+import DragDropContainer from "./DragDropContainer.vue";
+import DragDropList from "./DragDropList.vue";
+import { makeDragData, makeDropData } from "./utils/dataHelpers";
+import type { CleanupFn } from "./utils/dnd";
+import type { HasId } from "./dndTypes";
+
+type DropPayload = {
+  source: { data: Record<string | symbol, unknown> };
+  location: {
+    current: { dropTargets: { data: Record<string | symbol, unknown> }[] };
+  };
+};
+
+type MonitorConfig = { onDrop: (payload: DropPayload) => void };
+
+// Stands in for pragmatic-drag-and-drop's registry so the test can see which
+// registrations a component released when it unmounted.
+const dndRegistry = vi.hoisted(() => ({
+  liveMonitors: [] as MonitorConfig[],
+  liveElementRegistrations: 0,
+}));
+
+vi.mock("./utils/dnd", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./utils/dnd")>();
+
+  function registerElement(): CleanupFn {
+    dndRegistry.liveElementRegistrations += 1;
+    return () => {
+      dndRegistry.liveElementRegistrations -= 1;
+    };
+  }
+
+  function registerMonitor(config: MonitorConfig): CleanupFn {
+    dndRegistry.liveMonitors.push(config);
+    return () => {
+      const position = dndRegistry.liveMonitors.indexOf(config);
+      if (position !== -1) dndRegistry.liveMonitors.splice(position, 1);
+    };
+  }
+
+  return {
+    ...actual,
+    announce: vi.fn(),
+    draggable: registerElement,
+    dropTargetForElements: registerElement,
+    monitorForElements: registerMonitor,
+  };
+});
+
+const GROUP_ID = "test-group";
+const LIST_ID = "test-list";
+
+// Every order the list has emitted since the current test began.
+const ordersEmitted: string[][] = [];
+
+function mountList(items: HasId[]): VueWrapper {
+  return mount(DragDropContainer, {
+    props: { groupId: GROUP_ID },
+    slots: {
+      default: () =>
+        h(DragDropList, {
+          listId: LIST_ID,
+          modelValue: items,
+          "onUpdate:modelValue": (reordered: HasId[]) =>
+            ordersEmitted.push(reordered.map((item) => String(item.id))),
+        }),
+    },
+    attachTo: document.body,
+  });
+}
+
+/**
+ * Notifies every monitor still registered, the way the real adapter does.
+ *
+ * No closest edge is attached, so the item lands on the target's own index.
+ */
+function dropItemOnTarget(
+  items: HasId[],
+  sourceIndex: number,
+  targetIndex: number
+): void {
+  const payload: DropPayload = {
+    source: {
+      data: makeDragData({
+        sourceId: items[sourceIndex].id,
+        sourceIndex,
+        groupId: GROUP_ID,
+        listId: LIST_ID,
+      }),
+    },
+    location: {
+      current: {
+        dropTargets: [
+          {
+            data: makeDropData({
+              targetId: items[targetIndex].id,
+              targetIndex,
+              groupId: GROUP_ID,
+              listId: LIST_ID,
+            }),
+          },
+        ],
+      },
+    },
+  };
+
+  [...dndRegistry.liveMonitors].forEach((monitor) => monitor.onDrop(payload));
+}
+
+describe("DragDropList", () => {
+  beforeEach(() => {
+    dndRegistry.liveMonitors.length = 0;
+    dndRegistry.liveElementRegistrations = 0;
+    ordersEmitted.length = 0;
+    document.body.innerHTML = "";
+  });
+
+  it("releases its drag and drop registrations on unmount", () => {
+    const wrapper = mountList([{ id: "a" }, { id: "b" }]);
+    expect(dndRegistry.liveMonitors).toHaveLength(1);
+    expect(dndRegistry.liveElementRegistrations).toBeGreaterThan(0);
+
+    wrapper.unmount();
+
+    expect(dndRegistry.liveMonitors).toHaveLength(0);
+    expect(dndRegistry.liveElementRegistrations).toBe(0);
+  });
+
+  it("moves a dropped item once after the list has been remounted", async () => {
+    const items: HasId[] = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+    mountList(items).unmount();
+    mountList(items);
+
+    dropItemOnTarget(items, 0, 1);
+    await nextTick();
+
+    expect(ordersEmitted.at(-1)).toEqual(["b", "a", "c"]);
+  });
+});

--- a/src/components/DragDropList/DragDropListItem.vue
+++ b/src/components/DragDropList/DragDropListItem.vue
@@ -71,16 +71,11 @@ const dragHandleRef = useTemplateRef<{ buttonRef: HTMLButtonElement }>(
   "dragHandleRef"
 );
 
-// cleanup
-type CleanupFn = () => void;
-const cleanupFns = [] as CleanupFn[];
-onUnmounted(dnd.combine(...cleanupFns));
-
 /**
  * Set up the draggable behavior for the list item.
- * @returns {CleanupFn} A function to clean up the draggable behavior.
+ * @returns A function to clean up the draggable behavior.
  */
-function setupDraggable() {
+function setupDraggable(): dnd.CleanupFn {
   invariant(listItemRef.value, "listItemRef is not defined");
   invariant(dragHandleRef.value, "dragHandleRef is not defined");
   invariant(groupId, "groupId is not defined");
@@ -130,9 +125,9 @@ function setupDraggable() {
 
 /**
  * Set up the droppable behavior for the list item.
- * @returns {CleanupFn} A function to clean up the droppable behavior.
+ * @returns A function to clean up the droppable behavior.
  */
-function setupDroppable() {
+function setupDroppable(): dnd.CleanupFn {
   invariant(listItemRef.value, "listItemRef is not defined");
 
   return dnd.dropTargetForElements({
@@ -314,12 +309,13 @@ function moveList(targetListId: HasId["id"]) {
   });
 }
 
-onMounted(() => {
-  const cleanupDraggable = setupDraggable();
-  const cleanupDroppable = setupDroppable();
+let stopDragAndDrop: dnd.CleanupFn | null = null;
 
-  cleanupFns.push(cleanupDraggable, cleanupDroppable);
+onMounted(() => {
+  stopDragAndDrop = dnd.combine(setupDraggable(), setupDroppable());
 });
+
+onUnmounted(() => stopDragAndDrop?.());
 </script>
 <style scoped>
 .drag-drop-list-item {

--- a/src/components/DragDropList/DragHandle.test.ts
+++ b/src/components/DragDropList/DragHandle.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, enableAutoUnmount } from "@vue/test-utils";
 import DragHandle from "./DragHandle.vue";
 
+// These tests attach to the real document, so a wrapper left mounted would
+// keep its element (and its focus) in the DOM for whatever runs next.
+enableAutoUnmount(afterEach);
+
 describe("DragHandle", () => {
-  // Neither Safari nor jsdom focuses a button on click, so focus landing on the
+  // A synthetic click focuses nothing on its own, so focus landing on the
   // handle can only have come from the component's own handler.
   it("focuses itself when clicked", async () => {
     const wrapper = mount(DragHandle, { attachTo: document.body });

--- a/src/components/DragDropList/DragHandle.test.ts
+++ b/src/components/DragDropList/DragHandle.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import DragHandle from "./DragHandle.vue";
+
+describe("DragHandle", () => {
+  // Neither Safari nor jsdom focuses a button on click, so focus landing on the
+  // handle can only have come from the component's own handler.
+  it("focuses itself when clicked", async () => {
+    const wrapper = mount(DragHandle, { attachTo: document.body });
+    const button = wrapper.get("button");
+
+    expect(document.activeElement).not.toBe(button.element);
+
+    await button.trigger("click");
+
+    expect(document.activeElement).toBe(button.element);
+  });
+});

--- a/src/components/DragDropList/DragHandle.vue
+++ b/src/components/DragDropList/DragHandle.vue
@@ -3,7 +3,7 @@
     ref="buttonRef"
     type="button"
     class="drag-handle"
-    @pointerdown="focusHandle">
+    @click="focusHandle">
     <DragHandleIcon class="drag-handle__icon" />
     <span class="sr-only">Drag Handle</span>
   </button>
@@ -14,9 +14,11 @@ import { ref } from "vue";
 
 const buttonRef = ref<HTMLButtonElement | null>(null);
 
-// Safari does not focus a button on click (webkit.org/b/22261), so clicking
-// the handle would show no focus ring and no hint that arrow keys now move
-// the item.
+// We want users to see the drag handle focussed on click,
+// so that they can use arrow keys to move an item after
+// click the drag handle and see the focus ring.
+// Safari doesn't focus a button on click, so this is a
+// is a workaround.
 function focusHandle(): void {
   buttonRef.value?.focus();
 }

--- a/src/components/DragDropList/DragHandle.vue
+++ b/src/components/DragDropList/DragHandle.vue
@@ -14,11 +14,9 @@ import { ref } from "vue";
 
 const buttonRef = ref<HTMLButtonElement | null>(null);
 
-// We want users to see the drag handle focussed on click,
-// so that they can use arrow keys to move an item after
-// click the drag handle and see the focus ring.
-// Safari doesn't focus a button on click, so this is a
-// is a workaround.
+// We want users to see the drag handle focused on click, so that they can
+// see the focus ring and use arrow keys to move an item. Safari doesn't
+// focus a button on click, so this is a workaround.
 function focusHandle(): void {
   buttonRef.value?.focus();
 }

--- a/src/components/DragDropList/DragHandle.vue
+++ b/src/components/DragDropList/DragHandle.vue
@@ -1,5 +1,9 @@
 <template>
-  <button ref="buttonRef" type="button" class="drag-handle">
+  <button
+    ref="buttonRef"
+    type="button"
+    class="drag-handle"
+    @pointerdown="focusHandle">
     <DragHandleIcon class="drag-handle__icon" />
     <span class="sr-only">Drag Handle</span>
   </button>
@@ -9,6 +13,13 @@ import DragHandleIcon from "./DragHandleIcon.vue";
 import { ref } from "vue";
 
 const buttonRef = ref<HTMLButtonElement | null>(null);
+
+// Safari does not focus a button on click (webkit.org/b/22261), so clicking
+// the handle would show no focus ring and no hint that arrow keys now move
+// the item.
+function focusHandle(): void {
+  buttonRef.value?.focus();
+}
 
 // need to expose the ref to the parent component
 defineExpose({ buttonRef });

--- a/src/components/DragDropList/DropIndicator.vue
+++ b/src/components/DragDropList/DropIndicator.vue
@@ -14,9 +14,16 @@ defineProps<{
 </script>
 <style scoped>
 .drop-indicator {
+  /* Inset the line so its terminal circles land inside the
+     list item and don't overflow the container triggering
+     scrollbars during drag. */
+  --dnd-indicator-terminalOffset: calc(
+    var(--dnd-indicator-terminalSize) + var(--dnd-indicator-strokeWidth) * 2
+  );
+
   position: absolute;
-  width: 100%;
-  left: 0;
+  left: var(--dnd-indicator-terminalOffset);
+  right: var(--dnd-indicator-terminalOffset);
   z-index: 10;
   height: var(--dnd-indicator-strokeWidth);
   background: var(--dnd-indicator-color);
@@ -45,17 +52,13 @@ defineProps<{
   height: var(--dnd-indicator-terminalSize);
   border-radius: 50%;
   border: var(--dnd-indicator-strokeWidth) solid var(--dnd-indicator-color);
-  --dnd-terminal-position: calc(
-    -1 * calc(var(--dnd-indicator-terminalSize) +
-          var(--dnd-indicator-strokeWidth) * 2)
-  );
 }
 
 .drop-indicator::before {
-  left: var(--dnd-terminal-position);
+  left: calc(-1 * var(--dnd-indicator-terminalOffset));
 }
 
 .drop-indicator::after {
-  right: var(--dnd-terminal-position);
+  right: calc(-1 * var(--dnd-indicator-terminalOffset));
 }
 </style>

--- a/src/components/DragDropList/DropIndicator.vue
+++ b/src/components/DragDropList/DropIndicator.vue
@@ -22,12 +22,17 @@ defineProps<{
   background: var(--dnd-indicator-color);
 }
 
-.drop-indicator.drop-indicator--top {
-  top: 0;
+/* Below one item and above the next are the same insertion point, so center
+   the line on the border those two items share. Either way the drop lands in
+   the same gap, and the line does not jump as the pointer crosses over. */
+.drop-indicator--top {
+  top: calc(var(--dnd-listItem-borderWidth) / -2);
+  transform: translateY(-50%);
 }
 
-.drop-indicator.drop-indicator--bottom {
-  bottom: 0;
+.drop-indicator--bottom {
+  bottom: calc(var(--dnd-listItem-borderWidth) / -2);
+  transform: translateY(50%);
 }
 
 .drop-indicator::before,

--- a/src/components/DragDropList/EmptyList.vue
+++ b/src/components/DragDropList/EmptyList.vue
@@ -17,7 +17,6 @@ import {
   computed,
   useTemplateRef,
 } from "vue";
-import type { CleanupFn } from "@atlaskit/pragmatic-drag-and-drop/dist/types/internal-types";
 import * as dnd from "./utils/dnd";
 import { useDragDropStore } from "./useDragDropStore";
 import { GROUP_ID_PROVIDE_KEY } from "./constants";
@@ -34,9 +33,6 @@ invariant(groupId, "groupId must be provided");
 const emptyListRef = useTemplateRef("emptyListRef");
 const isDraggingOver = ref(false);
 
-const cleanupFns = [] as CleanupFn[];
-onUnmounted(dnd.combine(...cleanupFns));
-
 const dragDropStore = useDragDropStore(groupId);
 
 const targetData = computed(() => {
@@ -48,7 +44,7 @@ const targetData = computed(() => {
   });
 });
 
-function setupDropZone() {
+function setupDropZone(): dnd.CleanupFn {
   invariant(emptyListRef.value, "emptyListRef is not defined");
 
   return dnd.dropTargetForElements({
@@ -86,9 +82,13 @@ function setupDropZone() {
   });
 }
 
+let stopDropZone: dnd.CleanupFn | null = null;
+
 onMounted(() => {
-  setupDropZone();
+  stopDropZone = setupDropZone();
 });
+
+onUnmounted(() => stopDropZone?.());
 </script>
 <style scoped>
 .empty-list {

--- a/src/components/DragDropList/dndStyles.css
+++ b/src/components/DragDropList/dndStyles.css
@@ -35,7 +35,8 @@
     --on-secondary-container,
     --dnd-color-blue-600
   );
-  --dnd-listItem-border: 1px solid
+  --dnd-listItem-borderWidth: 1px;
+  --dnd-listItem-border: var(--dnd-listItem-borderWidth) solid
     var(--outline-variant, --dnd-color-neutral-200);
   --dnd-emptyList-bg: var(--surface-container-lowest, --dnd-color-neutral-100);
   --dnd-emptyList-border: 1px dashed

--- a/src/components/DragDropList/utils/dnd.ts
+++ b/src/components/DragDropList/utils/dnd.ts
@@ -1,6 +1,7 @@
 // a centralized location for all the pragmatic drag and drop
 
 export type {
+  CleanupFn,
   DragLocationHistory,
   ElementDragPayload,
   DropTargetRecord,


### PR DESCRIPTION
- Fixes #613 
- Dragging a field to a new position now takes, in Chrome and Safari. It used to snap back to where it started.
- Root cause: all three drag and drop components built a list of cleanup functions but called `combine` on it at setup time, while it was still empty, so the unmount hook was a no-op. A remounted list left a second drop monitor alive, both handled the drop, and applying one reorder twice returns the item to its starting position.
- Also fixes three smaller problems in the same component: no focus ring on the drag handle in Safari, a drop line that jumped between two positions in each gap, and a scrollbar that flashed for the length of every drag.

https://github.com/user-attachments/assets/fd139280-0d7d-4daf-826e-298e9096aabf

