### PR TITLE
Fix collection settings label and description editor sizing

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -172,6 +172,14 @@ onMounted(() => {
   border: none;
 }
 
+.ql-container .ql-editor {
+  min-height: 8rem;
+  /* resize belongs on .ql-editor, which already scrolls, rather than on
+     .ql-container: the container also holds quill's link tooltip, and a
+     non-visible overflow there would clip it. */
+  resize: vertical;
+}
+
 .ql-toolbar.ql-snow button {
   @apply text-on-surface opacity-50;
 }

--- a/src/pages/CreateOrEditAssetPage/EditWidget/EditTextAreaWidget.vue
+++ b/src/pages/CreateOrEditAssetPage/EditWidget/EditTextAreaWidget.vue
@@ -3,7 +3,6 @@
     :widgetContents="widgetContents"
     :widgetDef="widgetDef"
     :isOpen="isOpen"
-    class="edit-textarea-widget"
     @update:isOpen="$emit('update:isOpen', $event)"
     @add="
       $emit(
@@ -83,9 +82,3 @@ defineEmits<{
 
 // Note: textarea content cleaning now happens automatically before save in `toSaveableFormData()`in the asset editor.
 </script>
-<style scoped>
-/* Ensure the embedded Quill editor starts a bit taller */
-.edit-textarea-widget :deep(.ql-container .ql-editor) {
-  min-height: 6rem;
-}
-</style>

--- a/src/pages/CreateOrEditCollectionPage/CreateOrEditCollectionPage.vue
+++ b/src/pages/CreateOrEditCollectionPage/CreateOrEditCollectionPage.vue
@@ -50,8 +50,8 @@
 
         <InputGroup
           v-model="form.previewImageId"
-          label="Preview Image Asset ID"
-          placeholder="Asset ID shown on the browse page" />
+          label="Preview Image File ID"
+          placeholder="File ID shown on the browse page" />
 
         <Accordion type="single" collapsible>
           <AccordionItem value="bucket">


### PR DESCRIPTION
- Fixes #636
- The collection form's preview image field is now labeled "Preview Image File ID", which matches the value it actually takes
- Rich text editors now open taller and can be dragged to any height.


https://github.com/user-attachments/assets/036aeef2-05db-4428-9493-3c66ad5e58eb

