### PR TITLE
fix template editor select sample field data

### DIFF
--- a/mock-server/routes/templates.ts
+++ b/mock-server/routes/templates.ts
@@ -75,8 +75,7 @@ function generateFieldTitle(label: string): string {
 
 // GET /templates/getFieldTypes — mirrors Templates::getFieldTypes() JSON path.
 // sampleFieldData is a JSON string or null (the real endpoint unescapes the
-// stored text), and may be deliberately invalid JSON: the select sample shows
-// two shapes an admin edits down. hasFieldData flags types carrying config.
+// stored text), and may be deliberately invalid JSON
 const jsonSample = (value: unknown): string => JSON.stringify(value, null, 2);
 
 const SELECT_SAMPLE = `{

--- a/mock-server/routes/templates.ts
+++ b/mock-server/routes/templates.ts
@@ -73,46 +73,76 @@ function generateFieldTitle(label: string): string {
   return `${slug}_${MOCK_INSTANCE_ID}`;
 }
 
-// GET /templates/getFieldTypes — mirrors Templates::getFieldTypes() JSON path
+// GET /templates/getFieldTypes — mirrors Templates::getFieldTypes() JSON path.
+// sampleFieldData is a JSON string or null (the real endpoint unescapes the
+// stored text), and may be deliberately invalid JSON: the select sample shows
+// two shapes an admin edits down. hasFieldData flags types carrying config.
+const jsonSample = (value: unknown): string => JSON.stringify(value, null, 2);
+
+const SELECT_SAMPLE = `{
+  "multiSelect": false,
+  "selectGroup": ["option 1", "option 2", "option 3"]
+}
+
+alt:
+
+{
+  "selectGroup": { "option 1": "more text about option 1" }
+}`;
+
 app.get("/getFieldTypes", (c) => {
   const user = c.get("user");
   if (!user) return c.json({ error: "Unauthorized" }, 401);
 
   return c.json([
-    { id: 1, name: "text", modelName: "TextField", sampleFieldData: null },
+    {
+      id: 1,
+      name: "text",
+      modelName: "TextField",
+      hasFieldData: false,
+      sampleFieldData: null,
+    },
     {
       id: 2,
       name: "text area",
       modelName: "TextAreaField",
+      hasFieldData: false,
       sampleFieldData: null,
     },
     {
       id: 3,
       name: "select",
       modelName: "SelectField",
-      sampleFieldData: {
-        multiSelect: false,
-        selectGroup: ["option 1", "option 2", "option 3"],
-      },
+      hasFieldData: true,
+      sampleFieldData: SELECT_SAMPLE,
     },
     {
       id: 4,
       name: "checkbox",
       modelName: "CheckboxField",
+      hasFieldData: false,
       sampleFieldData: null,
     },
-    { id: 5, name: "date", modelName: "DateField", sampleFieldData: null },
+    {
+      id: 5,
+      name: "date",
+      modelName: "DateField",
+      hasFieldData: false,
+      sampleFieldData: null,
+    },
     {
       id: 6,
       name: "tag list",
       modelName: "TagListField",
+      hasFieldData: false,
       sampleFieldData: null,
     },
     {
       id: 7,
       name: "multiselect",
       modelName: "MultiSelectField",
-      sampleFieldData: {
+      hasFieldData: true,
+      sampleFieldData: jsonSample({
         country: {
           usa: {
             state: {
@@ -132,19 +162,21 @@ app.get("/getFieldTypes", (c) => {
             },
           },
         },
-      },
+      }),
     },
     {
       id: 8,
       name: "location",
       modelName: "LocationField",
+      hasFieldData: false,
       sampleFieldData: null,
     },
     {
       id: 9,
       name: "upload",
       modelName: "UploadField",
-      sampleFieldData: {
+      hasFieldData: true,
+      sampleFieldData: jsonSample({
         extractLocation: true,
         extractDate: true,
         enableTiling: true,
@@ -153,13 +185,14 @@ app.get("/getFieldTypes", (c) => {
         enableAnnotation: false,
         forceTiling: false,
         interactiveTranscript: false,
-      },
+      }),
     },
     {
       id: 10,
       name: "related asset",
       modelName: "RelatedAssetField",
-      sampleFieldData: {
+      hasFieldData: true,
+      sampleFieldData: jsonSample({
         nestData: true,
         showLabel: true,
         collapseNestedChildren: false,
@@ -170,7 +203,7 @@ app.get("/getFieldTypes", (c) => {
         ignoreForDigitalAsset: false,
         ignoreForLocationSearch: false,
         ignoreForDateSearch: false,
-      },
+      }),
     },
   ]);
 });

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1152,7 +1152,7 @@ function serializeTemplatePayload(
     p("clickToSearchType", String(widget.clickToSearchType));
     // Raw text, not re-stringified: the server json_decodes it on save and rejects when it doesn't parse. Trimmed so a whitespace-only
     // box normalizes to null server-side instead of failing validation.
-    p("fieldData", widget.fieldData.trim());
+    p("fieldData", widget.fieldData?.trim() ?? "");
 
     if (widget.display) p("display", "On");
     if (widget.displayInPreview) p("displayInPreview", "On");

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1115,7 +1115,7 @@ export async function fetchAdminTemplate(
  *   - indexForSearching      → indexforSearching  (lowercase 'f' — matches controller)
  *   - boolean template flags  → "On" when true, omitted when false
  *   - boolean widget flags    → any value when true, omitted when false
- *   - fieldData              → JSON string
+ *   - fieldData              → raw JSON text, trimmed ("" becomes null server-side)
  *   - fieldTypeId            → widget[n][fieldType]
  */
 function serializeTemplatePayload(
@@ -1150,10 +1150,9 @@ function serializeTemplatePayload(
     p("templateOrder", String(widget.templateOrder));
     p("viewOrder", String(widget.viewOrder));
     p("clickToSearchType", String(widget.clickToSearchType));
-    p(
-      "fieldData",
-      widget.fieldData != null ? JSON.stringify(widget.fieldData) : ""
-    );
+    // Raw text, not re-stringified: the server json_decodes it on save and rejects when it doesn't parse. Trimmed so a whitespace-only
+    // box normalizes to null server-side instead of failing validation.
+    p("fieldData", widget.fieldData.trim());
 
     if (widget.display) p("display", "On");
     if (widget.displayInPreview) p("displayInPreview", "On");

--- a/src/pages/CreateOrEditTemplatePage/EditTemplateForm/EditTemplateForm.vue
+++ b/src/pages/CreateOrEditTemplatePage/EditTemplateForm/EditTemplateForm.vue
@@ -127,7 +127,10 @@
             form="template-form"
             variant="primary"
             class="w-full justify-center"
-            :disabled="editor.isSaving.value">
+            :disabled="
+              editor.isSaving.value ||
+              editor.invalidFieldDataLabels.value.length > 0
+            ">
             <SpinnerIcon
               v-if="editor.isSaving.value"
               class="w-4 h-4 mr-2 animate-spin" />
@@ -141,6 +144,12 @@
           </Button>
         </div>
         <div class="text-xs text-right text-on-surface-variant">
+          <p
+            v-if="editor.invalidFieldDataLabels.value.length > 0"
+            class="text-error">
+            Field data is not valid JSON:
+            {{ editor.invalidFieldDataLabels.value.join(", ") }}
+          </p>
           <p v-if="editor.lastModifiedAt.value" data-testid="last-modified">
             {{ formatDate(editor.lastModifiedAt.value) }}
           </p>

--- a/src/pages/CreateOrEditTemplatePage/EditTemplateForm/WidgetEditor/WidgetEditor.vue
+++ b/src/pages/CreateOrEditTemplatePage/EditTemplateForm/WidgetEditor/WidgetEditor.vue
@@ -274,22 +274,6 @@ function handleFieldDataBlur() {
   widget.value.fieldData = formatFieldDataText(widget.value.fieldData);
 }
 
-// "Empty" means safe to overwrite with a sample: blank, or an empty
-// structure. "[]" is a legacy backend artifact on simple-type widgets, not
-// user-entered config. Text that doesn't parse is a draft, never empty.
-function isEmptyFieldDataText(text: string): boolean {
-  if (!text.trim()) return true;
-  try {
-    const parsed: unknown = JSON.parse(text);
-    if (parsed === null) return true;
-    if (Array.isArray(parsed)) return parsed.length === 0;
-    if (typeof parsed === "object") return Object.keys(parsed).length === 0;
-    return false;
-  } catch {
-    return false;
-  }
-}
-
 function handleTypeChange(newTypeId: number) {
   const newType = fieldTypes.value?.find((ft) => ft.id === newTypeId);
   if (!newType?.hasFieldData) {
@@ -297,9 +281,8 @@ function handleTypeChange(newTypeId: number) {
     widget.value.fieldData = "";
     return;
   }
-  // Pre-fill only when there's no user-entered config to overwrite.
-  if (isEmptyFieldDataText(widget.value.fieldData)) {
-    widget.value.fieldData = formatFieldDataText(newType.sampleFieldData ?? "");
-  }
+
+  // reset to sample field data
+  widget.value.fieldData = formatFieldDataText(newType.sampleFieldData ?? "");
 }
 </script>

--- a/src/pages/CreateOrEditTemplatePage/EditTemplateForm/WidgetEditor/WidgetEditor.vue
+++ b/src/pages/CreateOrEditTemplatePage/EditTemplateForm/WidgetEditor/WidgetEditor.vue
@@ -40,7 +40,7 @@
 
     <template v-if="hasFieldData">
       <TextAreaGroup
-        :modelValue="rawFieldDataString"
+        v-model="widget.fieldData"
         class="mb-4"
         label="Field data (JSON)"
         :inputClass="[
@@ -48,8 +48,6 @@
           isFieldDataInvalid ? 'border-error' : '',
         ]"
         placeholder="null"
-        @update:modelValue="handleFieldDataChange"
-        @focus="isFocused = true"
         @blur="handleFieldDataBlur" />
       <p v-if="isFieldDataInvalid" class="text-error text-xs -mt-3">
         Invalid JSON
@@ -166,10 +164,13 @@ import ConfirmModal from "@/components/ConfirmModal/ConfirmModal.vue";
 import { ChevronRightIcon, WarningIcon } from "@/icons";
 import {
   FIELD_TYPE_NAME_ICONS,
-  FIELD_TYPE_SAMPLE_DATA,
   FIELD_TYPE_DISPLAY_NAMES,
 } from "../fieldTypeConstants";
-import { TEMPLATE_EDITOR_KEY } from "../../useTemplateEditor/useTemplateEditor";
+import {
+  TEMPLATE_EDITOR_KEY,
+  isFieldDataTextInvalid,
+  formatFieldDataText,
+} from "../../useTemplateEditor/useTemplateEditor";
 import { WIDGET_EXPANSION_KEY } from "../widgetExpansionKey";
 import type { SelectOption } from "@/types";
 import { useInstanceStore } from "@/stores/instanceStore";
@@ -257,86 +258,48 @@ const clickToSearchMode = computed({
 
 const { data: fieldTypes } = useFieldTypesQuery();
 
-// Build a lookup map from fieldTypeId → effective sample field data.
-// Server's sampleFieldData takes precedence; falls back to client-side defaults
-// for types that have configurable field data but where the server returns null.
-const sampleFieldDataByTypeId = computed(() => {
-  if (!fieldTypes.value) return {} as Record<number, unknown>;
-  return Object.fromEntries(
-    fieldTypes.value.map((ft) => [
-      ft.id,
-      ft.sampleFieldData ?? FIELD_TYPE_SAMPLE_DATA[ft.name] ?? null,
-    ])
-  ) as Record<number, unknown>;
-});
+const currentFieldType = computed(() =>
+  fieldTypes.value?.find((ft) => ft.id === widget.value.fieldTypeId)
+);
 
-// Show the fieldData JSON editor only for types that carry structured config.
-// Derived from the API: types with non-null sampleFieldData have a config schema.
 const hasFieldData = computed(
-  () => sampleFieldDataByTypeId.value[widget.value.fieldTypeId] != null
+  () => currentFieldType.value?.hasFieldData ?? false
 );
 
-const isFieldDataInvalid = ref(false);
-const isFocused = ref(false);
-
-const rawFieldDataString = ref(
-  widget.value.fieldData != null
-    ? JSON.stringify(widget.value.fieldData, null, 2)
-    : ""
+const isFieldDataInvalid = computed(() =>
+  isFieldDataTextInvalid(widget.value.fieldData)
 );
-
-// Sync when fieldData is changed externally (e.g. type change auto-fills defaults)
-watch(
-  () => widget.value.fieldData,
-  (newVal) => {
-    if (!isFocused.value) {
-      rawFieldDataString.value =
-        newVal != null ? JSON.stringify(newVal, null, 2) : "";
-      isFieldDataInvalid.value = false;
-    }
-  }
-);
-
-function handleFieldDataChange(value: string) {
-  rawFieldDataString.value = value;
-  if (!value.trim()) {
-    widget.value.fieldData = null;
-    isFieldDataInvalid.value = false;
-    return;
-  }
-  try {
-    widget.value.fieldData = JSON.parse(value);
-    isFieldDataInvalid.value = false;
-  } catch {
-    isFieldDataInvalid.value = true;
-  }
-}
 
 function handleFieldDataBlur() {
-  isFocused.value = false;
-  if (!isFieldDataInvalid.value && widget.value.fieldData != null) {
-    rawFieldDataString.value = JSON.stringify(widget.value.fieldData, null, 2);
-  }
+  widget.value.fieldData = formatFieldDataText(widget.value.fieldData);
 }
 
-// [] is a legacy backend artifact on simple-type widgets, not user-entered config.
-function isEmptyFieldData(value: unknown): boolean {
-  if (value === null) return true;
-  if (Array.isArray(value)) return value.length === 0;
-  if (typeof value === "object") return Object.keys(value).length === 0;
-  return false;
+// "Empty" means safe to overwrite with a sample: blank, or an empty
+// structure. "[]" is a legacy backend artifact on simple-type widgets, not
+// user-entered config. Text that doesn't parse is a draft, never empty.
+function isEmptyFieldDataText(text: string): boolean {
+  if (!text.trim()) return true;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed === null) return true;
+    if (Array.isArray(parsed)) return parsed.length === 0;
+    if (typeof parsed === "object") return Object.keys(parsed).length === 0;
+    return false;
+  } catch {
+    return false;
+  }
 }
 
 function handleTypeChange(newTypeId: number) {
-  const sample = sampleFieldDataByTypeId.value[newTypeId] ?? null;
-  if (sample === null) {
+  const newType = fieldTypes.value?.find((ft) => ft.id === newTypeId);
+  if (!newType?.hasFieldData) {
     // New type has no configurable field data — clear any stale config.
-    widget.value.fieldData = null;
+    widget.value.fieldData = "";
     return;
   }
-  // Pre-fill with sample only when there's no real user-entered config.
-  if (isEmptyFieldData(widget.value.fieldData)) {
-    widget.value.fieldData = sample;
+  // Pre-fill only when there's no user-entered config to overwrite.
+  if (isEmptyFieldDataText(widget.value.fieldData)) {
+    widget.value.fieldData = formatFieldDataText(newType.sampleFieldData ?? "");
   }
 }
 </script>

--- a/src/pages/CreateOrEditTemplatePage/EditTemplateForm/fieldTypeConstants.ts
+++ b/src/pages/CreateOrEditTemplatePage/EditTemplateForm/fieldTypeConstants.ts
@@ -12,69 +12,6 @@ import {
   LinkIcon,
 } from "lucide-vue-next";
 
-/**
- * Client-side fallback sample field data, keyed by field type name.
- * Used when the server returns null for sampleFieldData (e.g. older API versions).
- * Only types with structured config (non-trivial fieldData) are included here —
- * types like text, checkbox, date etc. don't have configurable field data.
- */
-export const FIELD_TYPE_SAMPLE_DATA: Record<string, unknown> = {
-  select: {
-    multiSelect: false,
-    _comment:
-      "`selectGroup` can be object or array. Two examples are below. Pick one form, change its key  to `selectGroup`, and delete the other example",
-    selectGroupExampleArray: ["option 1", "option 2", "option 3"],
-    selectGroupExampleObject: {
-      "option 1 - curator view": "option 1 - visitor view",
-      "option 2 - curator view": "option 2 - visitor view",
-      "option 3 - curator view": "option 3 - visitor view",
-    },
-  },
-  multiselect: {
-    country: {
-      usa: {
-        state: {
-          wisconsin: { city: ["madison", "milwaukee"] },
-          minnesota: {
-            city: {
-              minneapolis: { neighborhood: ["uptown", "downtown"] },
-              mankato: { neighborhood: ["campus", "downtown"] },
-            },
-          },
-        },
-      },
-      canada: {
-        state: {
-          alberta: { city: ["fakeville", "faketown"] },
-          quebec: { city: ["montreal"] },
-        },
-      },
-    },
-  },
-  upload: {
-    extractLocation: true,
-    extractDate: true,
-    enableTiling: true,
-    enableDendro: false,
-    enableIframe: false,
-    enableAnnotation: false,
-    forceTiling: false,
-    interactiveTranscript: false,
-  },
-  "related asset": {
-    nestData: true,
-    showLabel: true,
-    collapseNestedChildren: false,
-    thumbnailView: false,
-    defaultTemplate: 0,
-    matchAgainst: [0],
-    displayInline: false,
-    ignoreForDigitalAsset: false,
-    ignoreForLocationSearch: false,
-    ignoreForDateSearch: false,
-  },
-};
-
 /** Display name overrides for field types whose API names are confusing or misleading. */
 export const FIELD_TYPE_DISPLAY_NAMES: Record<string, string> = {
   // Backend calls this "multiselect" but it's actually a cascading/hierarchical select.

--- a/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.test.ts
+++ b/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.test.ts
@@ -16,7 +16,13 @@ vi.mock("@/queries/useTemplateQuery", () => ({
   }),
   useFieldTypesQuery: () => ({
     data: ref([
-      { id: 1, name: "text", modelName: "TextField", sampleFieldData: null },
+      {
+        id: 1,
+        name: "text",
+        modelName: "TextField",
+        hasFieldData: false,
+        sampleFieldData: null,
+      },
     ]),
   }),
   useCreateTemplateMutation: () => ({
@@ -30,7 +36,12 @@ vi.mock("@/queries/useTemplateQuery", () => ({
 }));
 
 // Import after mock registration so the mock is in place.
-import { newWidget, useTemplateEditor } from "./useTemplateEditor";
+import {
+  newWidget,
+  useTemplateEditor,
+  isFieldDataTextInvalid,
+  formatFieldDataText,
+} from "./useTemplateEditor";
 
 const makeAdminTemplate = (
   overrides: Partial<AdminTemplate> = {}
@@ -48,6 +59,42 @@ const makeAdminTemplate = (
   recursiveIndexDepth: 1,
   widgetArray: [],
   ...overrides,
+});
+
+describe("isFieldDataTextInvalid", () => {
+  it("treats blank text as valid (no config)", () => {
+    expect(isFieldDataTextInvalid("")).toBe(false);
+    expect(isFieldDataTextInvalid("   \n  ")).toBe(false);
+  });
+
+  it("treats parseable JSON as valid", () => {
+    expect(isFieldDataTextInvalid('{ "multiSelect": false }')).toBe(false);
+    expect(isFieldDataTextInvalid("[]")).toBe(false);
+    expect(isFieldDataTextInvalid("null")).toBe(false);
+  });
+
+  it("flags text that fails to parse", () => {
+    expect(isFieldDataTextInvalid("{ oops }")).toBe(true);
+    expect(isFieldDataTextInvalid('{ "a": 1 } alt: { "b": 2 }')).toBe(true);
+  });
+});
+
+describe("formatFieldDataText", () => {
+  it("pretty-prints valid JSON with a 2-space indent", () => {
+    expect(formatFieldDataText('{"a":1,"b":[2,3]}')).toBe(
+      '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}'
+    );
+  });
+
+  it("returns invalid text verbatim so a deliberate non-JSON sample survives", () => {
+    const sample = '{ "a": 1 }\n\nalt:\n\n{ "b": 2 }';
+    expect(formatFieldDataText(sample)).toBe(sample);
+  });
+
+  it("leaves blank text untouched", () => {
+    expect(formatFieldDataText("")).toBe("");
+    expect(formatFieldDataText("   ")).toBe("   ");
+  });
 });
 
 describe("newWidget", () => {
@@ -199,6 +246,93 @@ describe("useTemplateEditor", () => {
     expect(editor.form.widgetArray).toHaveLength(1);
     expect(editor.form.widgetArray[0].fieldTitle).toBe("title_1");
     expect(editor.form.widgetArray[0].label).toBe("Title");
+  });
+
+  it("converts loaded widget fieldData objects to pretty JSON text", async () => {
+    const editor = useTemplateEditor(() => 5);
+    mockTemplateData.value = makeAdminTemplate({
+      widgetArray: [
+        {
+          widgetId: 100,
+          fieldTitle: "options_1",
+          fieldType: "select",
+          fieldTypeId: 4,
+          label: "Options",
+          tooltip: "",
+          templateOrder: 1,
+          viewOrder: 1,
+          display: true,
+          displayInPreview: false,
+          required: false,
+          searchable: false,
+          allowMultiple: false,
+          attemptAutocomplete: false,
+          directSearch: false,
+          clickToSearch: false,
+          clickToSearchType: 0,
+          fieldData: { multiSelect: false, selectGroup: ["a", "b"] },
+        },
+      ],
+    });
+
+    await nextTick();
+
+    expect(editor.form.widgetArray[0].fieldData).toBe(
+      JSON.stringify({ multiSelect: false, selectGroup: ["a", "b"] }, null, 2)
+    );
+  });
+
+  it("converts loaded null fieldData to an empty string", async () => {
+    const editor = useTemplateEditor(() => 5);
+    mockTemplateData.value = makeAdminTemplate({
+      widgetArray: [
+        {
+          widgetId: 100,
+          fieldTitle: "title_1",
+          fieldType: "text",
+          fieldTypeId: 1,
+          label: "Title",
+          tooltip: "",
+          templateOrder: 1,
+          viewOrder: 1,
+          display: true,
+          displayInPreview: false,
+          required: false,
+          searchable: false,
+          allowMultiple: false,
+          attemptAutocomplete: false,
+          directSearch: false,
+          clickToSearch: false,
+          clickToSearchType: 0,
+          fieldData: null,
+        },
+      ],
+    });
+
+    await nextTick();
+
+    expect(editor.form.widgetArray[0].fieldData).toBe("");
+  });
+
+  it("invalidFieldDataLabels names widgets whose field data text won't parse", () => {
+    const editor = useTemplateEditor(() => null);
+    editor.addWidget();
+    editor.addWidget();
+    editor.form.widgetArray[0].label = "Options";
+    editor.form.widgetArray[0].fieldData = "{ not json";
+    editor.form.widgetArray[1].fieldData = '{ "valid": true }';
+
+    expect(editor.invalidFieldDataLabels.value).toEqual(["Options"]);
+  });
+
+  it("save throws and skips the mutation when field data text is invalid", async () => {
+    const editor = useTemplateEditor(() => null);
+    editor.addWidget();
+    editor.form.widgetArray[0].label = "Options";
+    editor.form.widgetArray[0].fieldData = "{ not json";
+
+    await expect(editor.save()).rejects.toThrow("Options");
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
   });
 
   it("save calls createMutation in create mode and returns the new id", async () => {

--- a/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.test.ts
+++ b/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.test.ts
@@ -325,16 +325,6 @@ describe("useTemplateEditor", () => {
     expect(editor.invalidFieldDataLabels.value).toEqual(["Options"]);
   });
 
-  it("save throws and skips the mutation when field data text is invalid", async () => {
-    const editor = useTemplateEditor(() => null);
-    editor.addWidget();
-    editor.form.widgetArray[0].label = "Options";
-    editor.form.widgetArray[0].fieldData = "{ not json";
-
-    await expect(editor.save()).rejects.toThrow("Options");
-    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
-  });
-
   it("save calls createMutation in create mode and returns the new id", async () => {
     mockCreateMutateAsync.mockResolvedValue({ id: 42, name: "New Template" });
     const editor = useTemplateEditor(() => null);

--- a/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.ts
+++ b/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.ts
@@ -44,8 +44,32 @@ function widgetDefToPayload(w: AdminWidgetDef): AdminWidgetPayload {
     directSearch: w.directSearch,
     clickToSearch: w.clickToSearch,
     clickToSearchType: w.clickToSearchType,
-    fieldData: w.fieldData,
+    // The server returns parsed jsonb. The editor holds raw text, so convert
+    // it to pretty-printed text here, when the template loads.
+    fieldData: w.fieldData == null ? "" : JSON.stringify(w.fieldData, null, 2),
   };
+}
+
+export function isFieldDataTextInvalid(text: string): boolean {
+  if (!text.trim()) return false;
+  try {
+    JSON.parse(text);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Pretty-print JSON if valid, otherwise verbatim
+ */
+export function formatFieldDataText(text: string): string {
+  if (!text.trim()) return text;
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
 }
 
 function toFormState(t: AdminTemplate): FormState {
@@ -100,7 +124,7 @@ export function newWidget(
     directSearch: false,
     clickToSearch: false,
     clickToSearchType: 0,
-    fieldData: null,
+    fieldData: "",
   });
 }
 
@@ -144,6 +168,13 @@ export function useTemplateEditor(templateId: MaybeRefOrGetter<number | null>) {
 
   const hasUnsavedChanges = computed(
     () => JSON.stringify(form) !== savedSnapshot.value
+  );
+
+  // Labels of widgets whose field data text won't parse. Non-empty blocks save.
+  const invalidFieldDataLabels = computed(() =>
+    form.widgetArray
+      .filter((w) => isFieldDataTextInvalid(w.fieldData))
+      .map((w) => w.label || "Untitled field")
   );
 
   // ISO date string of the template's last server-side modification, if known.
@@ -197,6 +228,7 @@ export function useTemplateEditor(templateId: MaybeRefOrGetter<number | null>) {
     isSaving,
     saveStatus,
     hasUnsavedChanges,
+    invalidFieldDataLabels,
     lastModifiedAt,
     save,
     addWidget,

--- a/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.ts
+++ b/src/pages/CreateOrEditTemplatePage/useTemplateEditor/useTemplateEditor.ts
@@ -173,7 +173,7 @@ export function useTemplateEditor(templateId: MaybeRefOrGetter<number | null>) {
   // Labels of widgets whose field data text won't parse. Non-empty blocks save.
   const invalidFieldDataLabels = computed(() =>
     form.widgetArray
-      .filter((w) => isFieldDataTextInvalid(w.fieldData))
+      .filter((w) => isFieldDataTextInvalid(w.fieldData ?? ""))
       .map((w) => w.label || "Untitled field")
   );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1233,7 +1233,7 @@ export interface AdminWidgetPayload {
   clickToSearch: boolean;
   clickToSearchType: number;
   /** Raw JSON text as typed in the editor. Empty string means no config. */
-  fieldData: string;
+  fieldData: string | null;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1151,7 +1151,9 @@ export interface FieldType {
   id: number;
   name: string;
   modelName: string;
-  sampleFieldData: unknown;
+  hasFieldData: boolean;
+  // may not be parseable to JSON
+  sampleFieldData: string | null;
 }
 
 /**
@@ -1230,7 +1232,8 @@ export interface AdminWidgetPayload {
   directSearch: boolean;
   clickToSearch: boolean;
   clickToSearchType: number;
-  fieldData: unknown;
+  /** Raw JSON text as typed in the editor. Empty string means no config. */
+  fieldData: string;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1233,7 +1233,7 @@ export interface AdminWidgetPayload {
   clickToSearch: boolean;
   clickToSearchType: number;
   /** Raw JSON text as typed in the editor. Empty string means no config. */
-  fieldData: string | null;
+  fieldData: string;
 }
 
 /**

--- a/tests/e2e/template-editor.spec.ts
+++ b/tests/e2e/template-editor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { setupWorkerHTTPHeader, loginUser, refreshDatabase } from "../setup";
 
 // Seed templates available in the test database after refreshDatabase()
@@ -207,6 +207,63 @@ test.describe("Template Editor", () => {
       await expect(
         page.locator("[data-testid='last-modified']")
       ).toBeVisible();
+    });
+  });
+
+  test.describe("Field data editor", () => {
+    // Add one field in create mode and switch it to the given type.
+    async function addFieldOfType(page: Page, label: string, typeName: string) {
+      await page.goto("/templates/edit");
+      await page.getByRole("button", { name: "+ Add field" }).click();
+      await page.getByLabel("Label").fill(label);
+      await page.getByRole("button", { name: "Text" }).click();
+      await page.getByRole("option", { name: typeName, exact: true }).click();
+    }
+
+    test("pre-fills a config type's sample as formatted JSON", async ({
+      page,
+    }) => {
+      await addFieldOfType(page, "Attachment", "Upload");
+
+      const box = page.getByLabel("Field data (JSON)");
+      await expect(box).toBeVisible();
+      // Readable (not \n escape soup) and 2-space indented.
+      await expect(box).toHaveValue(/"enableTiling": true/);
+      await expect(box).toHaveValue(/\n {2}"/);
+    });
+
+    test("blocks save and names the widget when the sample is invalid JSON", async ({
+      page,
+    }) => {
+      await addFieldOfType(page, "Options", "Select");
+
+      await expect(page.getByText("Invalid JSON")).toBeVisible();
+      await expect(
+        page.getByText(/Field data is not valid JSON:\s*Options/)
+      ).toBeVisible();
+      await expect(page.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+
+    test("re-enables save once the field data parses", async ({ page }) => {
+      await addFieldOfType(page, "Options", "Select");
+      await expect(page.getByRole("button", { name: "Save" })).toBeDisabled();
+
+      await page
+        .getByLabel("Field data (JSON)")
+        .fill('{ "multiSelect": false }');
+
+      await expect(page.getByText("Invalid JSON")).not.toBeVisible();
+      await expect(page.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+
+    test("formats minified JSON on blur", async ({ page }) => {
+      await addFieldOfType(page, "Attachment", "Upload");
+
+      const box = page.getByLabel("Field data (JSON)");
+      await box.fill('{"a":1,"b":2}');
+      await box.blur();
+
+      await expect(box).toHaveValue('{\n  "a": 1,\n  "b": 2\n}');
     });
   });
 });


### PR DESCRIPTION
- Resolves #633.
- The field data box now holds raw text as the source of truth. Previously, fallback data was hard coded client-side in case of invalid json. The parsing issues are fixed in the backend. We also remove the expectation for valid json. (In some cases the sample field data includes comments or alternative config.
- Invalid JSON in any widget disables save form-wide and names the offending widgets.
- Changing field type in template editor, resets to the sample field data.
- The box's visibility comes from the server's `hasFieldData` flag.

on dev